### PR TITLE
chore: general project cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,12 +600,9 @@ dependencies = [
  "common-build",
  "env_logger",
  "integration-common",
- "libc",
  "log",
  "network-types",
- "once_cell",
  "tokio",
- "toml 0.9.5",
 ]
 
 [[package]]
@@ -707,9 +704,6 @@ dependencies = [
 [[package]]
 name = "mermin-common"
 version = "0.1.0"
-dependencies = [
- "aya",
-]
 
 [[package]]
 name = "mermin-ebpf"

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ command sequence:
 kind create cluster --config local/kind-config.yaml
 
 # 2. Build the mermin image and load it into the cluster
-docker build -t mermin:latest --target runner-slim .
+docker build -t mermin:latest --target runner-debug .
 kind load docker-image mermin:latest
 
-# 3. Deploy mermin using Helm
+# 3a. (optional) if you already have a Helm release, uninstall it first
+helm uninstall mermin
+
+# 3b. Deploy mermin using Helm
 helm upgrade -i mermin charts/mermin --values local/values.yaml
 ```
 
@@ -111,7 +114,7 @@ RUST_LOG=info cargo run --release --config 'target."cfg(all())".runner="sudo -E"
 Once the program is running, open a new terminal and generate some network activity to see the logs.
 
 ```shell
-ping -c 5 localhost
+ping -c 4 localhost
 ```
 
 > If you experience unexpected results, try to run `cargo clean` before each build to avoid stale artifacts.
@@ -184,6 +187,105 @@ CC=${ARCH}-linux-musl-gcc cargo build -p mermin --release \
 
 The final binary will be located at `target/${ARCH}-unknown-linux-musl/release/mermin` and can be copied to a Linux
 server to be executed.
+
+-----
+
+### Debugging with Wireshark
+
+This section outlines how to perform live network packet captures from a running pod in your Kubernetes cluster and
+inspect the traffic using Wireshark. This is incredibly useful for debugging network policies, service connectivity, and
+analyzing the behavior of your eBPF programs.
+
+#### Prerequisites
+
+Before you begin, ensure you have the following tools installed and configured on your local machine:
+
+- kubectl: The Kubernetes command-line tool, configured to connect to your cluster.
+- Wireshark: The network protocol analyzer.
+- k9s (Optional): A terminal-based UI to manage Kubernetes clusters, which simplifies getting a shell into pods.
+
+#### 1. Identify Your Target Pod
+
+First, list the running pods to identify the one you want to inspect. Pay attention to the pod's name, its IP address,
+and the node it's running on.
+
+```shell
+kubectl get pods -o wide
+```
+
+You'll see output similar to this:
+
+| NAME         | READY | STATUS  | RESTARTS | AGE | IP          | NODE               | NOMINATED NODE | READINESS GATES |
+|--------------|-------|---------|----------|-----|-------------|--------------------|----------------|-----------------| 
+| mermin-vrxd2 | 1/1   | Running | 0        | 42s | 10.244.0.11 | kind-control-plane | <none>         | <none>          |
+| mermin-8k9x7 | 1/1   | Running | 0        | 42s | 10.244.3.21 | kind-worker        | <none>         | <none>          |
+| mermin-pdsn7 | 1/1   | Running | 0        | 42s | 10.244.1.7  | kind-worker2       | <none>         | <none>          |
+
+For this example, we will capture traffic from mermin-vrxd2.
+
+#### 2. Start the Live Capture
+
+To start the capture, we will use kubectl debug to attach a temporary container with networking tools (netshoot) to
+our target pod. We'll then pipe the output of tcpdump from that container directly into Wireshark on your local
+machine.
+
+Run the following command in your terminal. Replace <pod-name> with your target pod's name (e.g., mermin-vrxd2)
+and <container-name> with the name of the container (e.g., mermin) inside the pod (if it's not the default one).
+
+```shell
+kubectl debug -i -q <pod-name> --image=nicolaka/netshoot --target=<container-name> --profile=sysadmin -- tcpdump -i eth0 -w - | wireshark -k -i -
+```
+
+Command Breakdown:
+
+- kubectl debug -i -q <pod-name>: Attaches an interactive, ephemeral debug container to the specified pod.
+- `--image=nicolaka/netshoot`: Uses the netshoot image, which is packed with useful networking utilities like tcpdump.
+- `--target=<container-name>`: Specifies which container in the pod to target for debugging.
+- `--profile=sysadmin`: Specifies the security context profile to use for the debug container. This is required to
+  run tcpdump.
+- `-- tcpdump -i eth0 -w -`: Executes tcpdump inside the debug container.
+    - `-i eth0`: Listens on the primary network interface, eth0.
+    - `-w -`: Writes the raw packet data to standard output (-) instead of a file.
+- `| wireshark -k -i -`: Pipes the standard output from tcpdump into Wireshark.
+- `-k`: Starts the capture session immediately.
+- `-i -`: Reads packet data from standard input (-).
+
+Example command:
+
+```shell
+kubectl debug -i -q mermin-vrxd2 --image=nicolaka/netshoot --target=mermin --profile=sysadmin -- tcpdump -i eth0 -w - | wireshark -k -i -
+```
+
+Wireshark will launch automatically and begin capturing packets from the pod's network interface.
+
+#### 3. Generate Network Traffic
+
+To see packets in Wireshark, you need to generate some network activity. Open a second terminal window and get a
+shell into another pod. You can do this with kubectl exec or more easily with a tool like k9s.
+
+From your pod list, pick a different pod to be the source of the traffic (e.g., mermin-8k9x7).
+
+Get a shell into that pod.
+
+Ping the IP address of your target pod (10.244.0.11 in our example).
+
+Get a shell into the source pod
+
+```shell
+kubectl exec -it mermin-8k9x7 -- sh
+```
+
+From inside the pod's shell, ping the target pod
+
+```shell
+ping -c 4 10.244.0.11
+```
+
+#### 4. Inspect the Packets
+
+Switch back to Wireshark. You will see the ICMP (ping) request and reply packets appearing in real-time. You can now
+use Wireshark's powerful filtering and inspection tools to analyze the traffic in detail, verifying that your eBPF
+programs are functioning as expected.
 
 -----
 

--- a/local/kind-config.yaml
+++ b/local/kind-config.yaml
@@ -1,5 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: atlantis
 nodes:
   - role: control-plane
   - role: worker

--- a/mermin-common/Cargo.toml
+++ b/mermin-common/Cargo.toml
@@ -7,10 +7,8 @@ license.workspace = true
 
 [features]
 default = []
-user = ["aya"]
 
 [dependencies]
-aya = { workspace = true, optional = true }
 
 [lib]
 path = "src/lib.rs"

--- a/network-types/README.md
+++ b/network-types/README.md
@@ -1,20 +1,34 @@
-# Network Types
+# Network Types ⚙️
 
-A lightweight, `no_std` compatible library that defines network protocol data structures for parsing and generating network packets. This crate is designed to work in both userspace and eBPF environments.
+A lightweight, no_std compatible Rust crate that provides network protocol data structures for parsing, manipulating,
+and generating network packets. This crate is designed for high-performance, low-level networking in both userspace and
+eBPF environments.
 
-## Overview
+### 🎯 Core Purpose
 
-The `network-types` crate provides memory-compatible structures for common network protocol headers. These structures are designed to be binary-compatible with their network protocol specifications, making them suitable for direct parsing of network packets.
+The primary goal of network-types is to provide a set of pure Rust, no_std-compatible data structures for working with
+network packets.
 
-## Features
+By offering structs with a guaranteed memory layout (#[repr(C, packed)]), this crate enables safe, efficient, and direct
+interaction with raw network data. It removes the need for manual byte manipulation and provides type-safe abstractions,
+which are essential in performance-critical applications and restrictive environments like eBPF.
 
-- `#![no_std]` compatible for use in environments without the standard library
-- Memory-compatible structures with `#[repr(C, packed)]` for binary compatibility
-- Comprehensive enums for protocol types (e.g., EtherType)
-- Helper methods for parsing and constructing headers
-- Thoroughly tested with both unit tests and integration tests
+## ✨ Key Features
 
-## Usage
+#![no_std] Compatible: Use it in any environment, from bare-metal to kernel space, without the standard library.
+
+- Guaranteed Binary Compatibility: Structures are defined with #[repr(C, packed)] to ensure their memory layout is
+  identical to the on-the-wire network protocol specifications.
+- Ergonomic Helpers: Provides safe and convenient methods for parsing and accessing header fields, like ether_type()
+  which safely handles endianness.
+- Comprehensive Protocol Enums: Includes thorough enums for common protocol identifiers (e.g., EtherType), making your
+  code more readable and robust.
+- Rigorously Tested: Validated by a comprehensive integration test suite that simulates a real-world eBPF scenario to
+  guarantee correctness.
+
+## 🚀 Usage
+
+First, add the crate to your `Cargo.toml`:
 
 Add the crate to your `Cargo.toml`:
 
@@ -23,100 +37,134 @@ Add the crate to your `Cargo.toml`:
 network-types = { path = "path/to/network-types" }
 ```
 
-Example usage for parsing an Ethernet header:
+Here's a basic example of parsing an Ethernet header from a raw byte slice:
 
-```
+```rust
 use network_types::eth::{EthHdr, EtherType};
 
-// Parse an Ethernet header from raw bytes
-let eth_header: EthHdr = unsafe { *(raw_bytes.as_ptr() as *const EthHdr) };
+fn parse_ethernet_frame(raw_bytes: &[u8]) {
+    // This is safe as long as raw_bytes contains at least sizeof(EthHdr).
+    // Direct memory casting is common for performance-critical packet parsing.
+    let eth_header: &EthHdr = unsafe { &*(raw_bytes.as_ptr() as *const EthHdr) };
 
-// Access header fields
-let dst_mac = eth_header.dst_addr;
-let src_mac = eth_header.src_addr;
+    // Access header fields directly
+    let dst_mac = eth_header.dst_addr;
+    let src_mac = eth_header.src_addr;
+    println!("Source MAC: {}, Destination MAC: {}", src_mac, dst_mac);
 
-// Parse the EtherType
-match eth_header.ether_type() {
-    Ok(EtherType::Ipv4) => {
-        // Handle IPv4 packet
-    },
-    Ok(EtherType::Ipv6) => {
-        // Handle IPv6 packet
-    },
-    Ok(other_type) => {
-        // Handle other known protocol
-    },
-    Err(unknown_value) => {
-        // Handle unknown protocol
+    // Use helper methods to safely parse protocol types
+    match eth_header.ether_type() {
+        Ok(EtherType::Ipv4) => {
+            println!("Payload is an IPv4 packet.");
+            // Handle IPv4 packet
+        }
+        Ok(EtherType::Ipv6) => {
+            println!("Payload is an IPv6 packet.");
+            // Handle IPv6 packet
+        }
+        // ... and so on
+        _ => println!("Payload is another protocol."),
     }
 }
 ```
 
-## Integration Tests
+-----
 
-The `network-types` crate includes comprehensive integration tests that verify the structures work correctly in both userspace and eBPF environments.
+## 🧪 Rigorous Integration Testing
 
-### Test Structure
+### Why a Complex Test Suite?
 
-The integration tests are organized into three main components:
+While the crate's purpose is simple, proving its correctness—especially for eBPF—is not. A primary challenge in eBPF
+development is ensuring that data structures are memory-compatible across different compilation targets (userspace vs.
+kernel). We previously encountered subtle bugs where:
 
-1. **integration**: Userspace tests that send test packets and verify the results
-2. **integration-ebpf**: eBPF program that parses packets and sends the results back to userspace
-3. **integration-common**: Common types used by both the userspace and eBPF components
+1. Code passing local tests would fail to compile for the eBPF target.
+2. Code that successfully compiled would later cause a runtime panic when loaded into the kernel.
 
-### Prerequisites
+To prevent this, we built an extensive integration test suite that validates our structures in a real-world eBPF
+workflow, guaranteeing they are correct and reliable.
 
-To run the integration tests, you need:
+### Test Workflow
 
-- Rust toolchain with the nightly channel (for eBPF support)
-- `bpf-linker` installed (`cargo install bpf-linker`)
-- Root privileges (for loading eBPF programs)
-- Linux kernel with eBPF support (4.9+)
+The tests follow a full-circle workflow:
 
-#### Easy Button Environment for Running Tests
+1. The userspace test constructs a network packet and sends it.
+2. An eBPF program, using these same network-types structs, is attached to a network interface to capture the packet.
+3. The eBPF program parses the packet headers and sends the parsed data back to userspace via an eBPF map.
+4. The userspace test verifies that the data received from the eBPF program matches the original values sent.
 
-Launch the project as a dev container within VSCode or RustRover. You can find the dev container Dockerfile and configuration in the workspace's root under the `.devcontainer` directory.
+#### Running the Tests
+
+The test suite is located in the network-types/tests/ directory and is managed via a Makefile.
+
+#### Prerequisites
+
+- A Linux environment with eBPF capabilities.
+- A correctly configured Rust toolchain (the workspace toolchain file will be respected).
+- sudo privileges for loading the eBPF program into the kernel.
+
+#### The Easy Way: Dev Container
+
+The simplest way to get a working test environment is to launch this project in a Dev Container using `docker run`. All
+dependencies are pre-installed in the container defined in the builder image within the `Dockerfile`.
+
+See the [workspace README](https://github.com/elastiflow/mermin?tab=readme-ov-file#using-a-dockerized-build-environment)
+for more information.
 
 ### Running the Tests
 
-The integration tests are managed through a Makefile with several targets:
+All commands should be run from the network-types/tests/ directory.
 
-1. **setup**: Sets up the environment variables
-2. **build**: Builds the eBPF program
-3. **test**: Runs the integration tests
-4. **clean**: Cleans up build artifacts
+```shell
+# Navigate to the tests directory first
+cd network-types/tests
+```
 
-To run the tests:
-```
-cd tests
-make test
-```
+1. `make build`: Compiles the eBPF program (integration-ebpf) required by the test suite. You must run this before make
+   test.
+2. `make test`: Runs the userspace integration tests. This will fail if the eBPF program hasn't been built first.
+3. `make test-ci`: (Recommended) This is the command our CI uses. It conveniently runs build and then test in the
+   correct
+   order, avoiding common test failures.
+4. `make clean`: Cleans up all build artifacts.
+
+> Important: The Makefile commands use sudo because loading eBPF programs requires elevated privileges. The script
+> correctly preserves your user's environment variables (PATH, CARGO_HOME, etc.) to ensure the right Rust toolchain is
+> used.
 
 The tests will:
+
 1. Load and attach an eBPF program to the loopback interface
 2. Send test packets with known header values
 3. The eBPF program will parse these headers and send the parsed values back to userspace
 4. The tests will verify that the parsed values match the expected values
 
-### Adding New Tests
+### Extending the Test Suite 🧑‍💻
 
-To add a new test for a different header type:
+Adding a new test for another header type is a streamlined process, thanks to a helper macro. The workflow involves two
+main steps:
 
-1. Create helper functions for constructing test packets and verifying results
-2. Use the `define_header_test!` macro to generate the test function
+1. **Create helper functions**: You'll need one function that constructs the test packet with known values and another
+   that verifies the data returned from the eBPF program.
+2. **Use the macro**: Call the define_header_test! macro to generate the full, end-to-end test case boilerplate for you.
 
-Example:
+Here is an example of how to use the macro. The comments explain each parameter:
 
-```
+```rust
 define_header_test!(
+    // 1. The name for your new test function.
     test_parses_new_header,
+    // 2. The header struct from `network-types` that you are testing.
     NewHdr,
+    // 3. A unique enum variant from `PacketType` to identify this test.
     PacketType::New,
+    // 4. The name of your function that builds the test packet.
     create_new_test_packet,
+    // 5. The name of your function that verifies the results.
     verify_new_header
 );
 ```
 
-## License
+## 📜 License
 
-This project is licensed under the terms specified in the workspace configuration.
+This project is licensed under the terms specified in the Cargo.toml file at the root of the workspace.

--- a/network-types/tests/integration/Cargo.toml
+++ b/network-types/tests/integration/Cargo.toml
@@ -11,9 +11,7 @@ env_logger = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "net", "signal", "sync", "time"] }
 anyhow = { workspace = true, default-features = true }
 log = { workspace = true }
-libc = "0.2"
 bytes = "1"
-once_cell = "1.17"
 integration-common = { path = "../integration-common", features = ["user"] }
 network-types = { path = "../.." }
 
@@ -21,7 +19,6 @@ network-types = { path = "../.." }
 anyhow = { workspace = true }
 aya-build = { workspace = true }
 common-build = { path = "../../../common-build" }
-toml = { workspace = true }
 
 [[bin]]
 name = "integration"


### PR DESCRIPTION
This pull request focuses on two main areas: significantly improving documentation and cleaning up project dependencies.
The documentation has been overhauled to provide better guidance for developers and users. Key additions include a detailed guide on debugging with Wireshark and a complete rewrite of the README to clarify its purpose and testing strategy. `network-types`

Additionally, unused dependencies such as `aya`, `libc`, and `once_cell` have been removed from several crates, simplifying the dependency graph and streamlining the build process.

### Key Changes:
- **Documentation:**
    - `README.md`: Added a "Debugging with Wireshark" section to the main to guide developers on live packet capture.
    - `README.md`: Adjusted the `docker build` command in the to use the `runner-debug` target for easier debugging. 
    - `network-types/README.md`: Completely rewrote the for clarity, with improved usage examples and a detailed explanation of the integration test suite.

- **Dependency Cleanup:**
    - Removed the `aya` dependency from to make it more generic. `mermin-common`
    - Removed unused dependencies like `libc` and `once_cell` from the integration test crate.

- **Configuration:**
    - Updated with a cluster name. `kind-config.yaml`