### PR TITLE
Implement vxlan encapsulation support

### DIFF
--- a/network-types/src/lib.rs
+++ b/network-types/src/lib.rs
@@ -7,3 +7,4 @@ pub mod geneve;
 pub mod ip;
 pub mod tcp;
 pub mod udp;
+pub mod vxlan;

--- a/network-types/src/vxlan.rs
+++ b/network-types/src/vxlan.rs
@@ -1,0 +1,44 @@
+/// # VXLAN (Virtual Extensible LAN) Header Frame:
+///   0               1               2               3
+///   0 1 2 3 4 5 6 7 8 9 ...
+///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///   |R|R|R|R|I|R|R|R|            Reserved                           |
+///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///   |                VXLAN Network Identifier (VNI) |   Reserved    |
+///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+/// ## Fields
+/// * **I Flag (1 bit)**: When set to 1, indicates that the VNI field is valid.
+/// * **VNI (24 bits)**: VXLAN Network Identifier.
+///
+/// The header is always 8 bytes long and is immediately followed by the inner
+/// Ethernet frame.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct VxlanHdr {
+    /// Flags byte – only bit 3 (I flag) is currently defined.
+    pub flags: u8,
+    /// Reserved field – MUST be zero on transmit and ignored on receipt.
+    pub reserved1: [u8; 3],
+    /// VXLAN Network Identifier (VNI) – 24 bits, network byte order.
+    pub vni: [u8; 3],
+    /// Reserved field – MUST be zero on transmit and ignored on receipt.
+    pub reserved2: u8,
+}
+
+impl VxlanHdr {
+    /// The fixed length of a VXLAN header, in bytes.
+    pub const LEN: usize = core::mem::size_of::<VxlanHdr>();
+
+    /// Returns true if the "I" flag is set, which indicates that the VNI is valid.
+    #[inline]
+    pub fn valid_vni(&self) -> bool {
+        (self.flags & 0x08) == 0x08
+    }
+
+    /// Returns the VXLAN Network Identifier (VNI) as a 24-bit value.
+    #[inline]
+    pub fn vni(&self) -> u32 {
+        u32::from_be_bytes([0, self.vni[0], self.vni[1], self.vni[2]])
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds support for VXLAN (Virtual Extensible LAN) encapsulation to the Mermin eBPF parser, addressing the need to correctly identify and analyze inner packets within VXLAN tunnels used by CNIs like Flannel, Calico, and Cilium.

Key changes include:
-   **VXLAN Header Definition:** Introduced `VxlanHdr` in the `network-types` crate, including methods to validate the 'I' flag and extract the VNI.
-   **eBPF Parser Integration:**
    -   The parser now identifies UDP packets on port 4789 as VXLAN.
    -   A new `parse_vxlan_header` function decodes the 8-byte VXLAN header, validates the 'I' flag, and advances the offset to the inner Ethernet frame.
    -   The main parsing loop is updated to invoke the VXLAN parser.
-   **Flow Analysis:** Ensures that the source and destination IP addresses from the inner encapsulated packet are correctly extracted for flow analysis, while preserving the outer tunnel IP and port information.
-   **IPv4/IPv6 Compatibility:** The logic correctly handles both IPv4 and IPv6 outer transport packets.

Fixes ENG-46

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):

## How Has This Been Tested?

-   **Unit Tests:**
    -   Added `test_parse_vxlan_header` to verify correct parsing of a valid VXLAN header.
    -   Added `test_parse_vxlan_header_invalid` to ensure proper handling when the VXLAN 'I' flag is not set.
-   **Environment**:
    -   OS: Debian 12
    -   Rust: 1.88.0

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.

## Screenshots (if applicable)

<!-- If your changes involve UI updates, please include screenshots or GIFs to demonstrate the changes. -->

## Additional Notes

-   A `TODO` remains to capture the VXLAN Network Identifier (VNI) into the `packet_meta` struct once a suitable field exists.
-   The VXLAN and Geneve ports (4789 and 6081 respectively) are currently hardcoded; a `TODO` indicates that these should eventually be configurable.

---
Linear Issue: [ENG-46](https://linear.app/elastiflow/issue/ENG-46/add-support-for-vxlan-encapsulation)

<a href="https://cursor.com/background-agent?bcId=bc-fd5bf0c8-ab75-40c6-b3e4-eee27e63eae6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd5bf0c8-ab75-40c6-b3e4-eee27e63eae6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



[ENG-46]: https://elastiflow.atlassian.net/browse/ENG-46?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ