### PR TITLE
feat: implement IPv4/IPv6 community ID generation with comprehensive IP protocol support

### DIFF
--- a/.cursor/rules/use-docker-container-for-cargo-commands.mdc
+++ b/.cursor/rules/use-docker-container-for-cargo-commands.mdc
@@ -1,0 +1,7 @@
+---
+alwaysApply: true
+---
+
+- Use `docker run -it --privileged --mount type=bind,source=.,target=/app mermin-builder:latest /bin/bash -c "cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]"` to run tests.
+- Use `docker run -it --privileged --mount type=bind,source=.,target=/app mermin-builder:latest /bin/bash -c "cargo clippy [OPTIONS] [--] [<ARGS>...]"` to run clippy.
+- This is required because aya-ebpf will not compile properly on a non-linux host machine.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
  "aya",
  "aya-build 0.1.2 (git+https://github.com/aya-rs/aya?rev=a7e3e6d4d90767d40a015a473a7d0623031ff6ee)",
  "aya-log",
+ "base64 0.21.7",
  "clap",
  "common-build",
  "env_logger",
@@ -1392,7 +1393,9 @@ dependencies = [
  "libc",
  "log",
  "mermin-common",
+ "network-types",
  "serde",
+ "sha1",
  "socket2 0.5.10",
  "tokio",
  "tracing",
@@ -1402,6 +1405,9 @@ dependencies = [
 [[package]]
 name = "mermin-common"
 version = "0.1.0"
+dependencies = [
+ "network-types",
+]
 
 [[package]]
 name = "mermin-ebpf"
@@ -2092,6 +2098,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ kind create cluster --config local/kind-config.yaml
 
 # 2. Build the mermin image and load it into the cluster
 docker build -t mermin:latest --target runner-debug .
-kind load docker-image mermin:latest
+kind load docker-image -n atlantis mermin:latest
 
 # 3a. (optional) if you already have a Helm release, uninstall it first
 helm uninstall mermin
@@ -90,7 +90,7 @@ Ensure you have the following installed:
 
 ### Build and Run Locally
 
-#### 1. Build the `mermin` agent:
+#### 1. Build the `mermin` agent
 
 ```shell
 cargo build --release
@@ -98,7 +98,7 @@ cargo build --release
 
 The build script automatically compiles the eBPF program and embeds it into the final binary.
 
-#### 2. Run the agent:
+#### 2. Run the agent
 
 Running the eBPF agent requires elevated privileges.
 
@@ -109,7 +109,7 @@ RUST_LOG=info cargo run --release --config 'target."cfg(all())".runner="sudo -E"
 > The `sudo -E` command runs the program as root while preserving the user's environment variables, which is
 > necessary for `cargo` to find the correct binary.
 
-#### 3. Generate Traffic:
+#### 3. Generate Traffic
 
 Once the program is running, open a new terminal and generate some network activity to see the logs.
 
@@ -121,7 +121,7 @@ ping -c 4 localhost
 
 ### Testing and Linting
 
-#### Run unit tests:
+#### Run unit tests
 
 Run the following commands to run the unit tests for the main application.
 
@@ -135,13 +135,13 @@ Run the following command to run the unit tests for the eBPF program only:
 cargo test -p mermin-ebpf
 ```
 
-#### Format your code:
+#### Format your code
 
 ```shell
 cargo fmt
 ```
 
-#### Run Clippy for lints:
+#### Run Clippy for lints
 
 ```shell
 # Lint the eBPF code
@@ -156,13 +156,13 @@ cargo clippy --all-features -- -D warnings
 To ensure a consistent and reproducible build environment that matches the CI/CD pipeline, you can use Docker. This is
 especially helpful on platforms like macOS.
 
-#### 1. Build the containerized environment:
+#### 1. Build the containerized environment
 
 ```shell
 docker build -t mermin-builder:latest --target builder .
 ```
 
-#### 2. Run commands inside the container:
+#### 2. Run commands inside the container
 
 This mounts your local repository into the container at `/app`.
 
@@ -200,9 +200,9 @@ analyzing the behavior of your eBPF programs.
 
 Before you begin, ensure you have the following tools installed and configured on your local machine:
 
-- kubectl: The Kubernetes command-line tool, configured to connect to your cluster.
-- Wireshark: The network protocol analyzer.
-- k9s (Optional): A terminal-based UI to manage Kubernetes clusters, which simplifies getting a shell into pods.
+* kubectl: The Kubernetes command-line tool, configured to connect to your cluster.
+* Wireshark: The network protocol analyzer.
+* k9s (Optional): A terminal-based UI to manage Kubernetes clusters, which simplifies getting a shell into pods.
 
 #### 1. Identify Your Target Pod
 
@@ -216,7 +216,7 @@ kubectl get pods -o wide
 You'll see output similar to this:
 
 | NAME         | READY | STATUS  | RESTARTS | AGE | IP          | NODE               | NOMINATED NODE | READINESS GATES |
-|--------------|-------|---------|----------|-----|-------------|--------------------|----------------|-----------------| 
+|--------------|-------|---------|----------|-----|-------------|--------------------|----------------|-----------------|
 | mermin-vrxd2 | 1/1   | Running | 0        | 42s | 10.244.0.11 | kind-control-plane | <none>         | <none>          |
 | mermin-8k9x7 | 1/1   | Running | 0        | 42s | 10.244.3.21 | kind-worker        | <none>         | <none>          |
 | mermin-pdsn7 | 1/1   | Running | 0        | 42s | 10.244.1.7  | kind-worker2       | <none>         | <none>          |
@@ -238,17 +238,17 @@ kubectl debug -i -q <pod-name> --image=nicolaka/netshoot --target=<container-nam
 
 Command Breakdown:
 
-- kubectl debug -i -q <pod-name>: Attaches an interactive, ephemeral debug container to the specified pod.
-- `--image=nicolaka/netshoot`: Uses the netshoot image, which is packed with useful networking utilities like tcpdump.
-- `--target=<container-name>`: Specifies which container in the pod to target for debugging.
-- `--profile=sysadmin`: Specifies the security context profile to use for the debug container. This is required to
+* kubectl debug -i -q <pod-name>: Attaches an interactive, ephemeral debug container to the specified pod.
+* `--image=nicolaka/netshoot`: Uses the netshoot image, which is packed with useful networking utilities like tcpdump.
+* `--target=<container-name>`: Specifies which container in the pod to target for debugging.
+* `--profile=sysadmin`: Specifies the security context profile to use for the debug container. This is required to
   run tcpdump.
-- `-- tcpdump -i eth0 -w -`: Executes tcpdump inside the debug container.
-    - `-i eth0`: Listens on the primary network interface, eth0.
-    - `-w -`: Writes the raw packet data to standard output (-) instead of a file.
-- `| wireshark -k -i -`: Pipes the standard output from tcpdump into Wireshark.
-- `-k`: Starts the capture session immediately.
-- `-i -`: Reads packet data from standard input (-).
+* `-- tcpdump -i eth0 -w -`: Executes tcpdump inside the debug container.
+  * `-i eth0`: Listens on the primary network interface, eth0.
+  * `-w -`: Writes the raw packet data to standard output (-) instead of a file.
+* `| wireshark -k -i -`: Pipes the standard output from tcpdump into Wireshark.
+* `-k`: Starts the capture session immediately.
+* `-i -`: Reads packet data from standard input (-).
 
 Example command:
 

--- a/mermin-common/Cargo.toml
+++ b/mermin-common/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 default = []
 
 [dependencies]
+network-types = { path = "../network-types" }
 
 [lib]
 path = "src/lib.rs"

--- a/mermin-common/src/lib.rs
+++ b/mermin-common/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+use network_types::ip::IpProto;
+
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum IpAddrType {
@@ -42,7 +44,7 @@ pub struct PacketMeta {
     /// Indicates whether the flow record uses IPv4 or IPv6 addressing.
     pub ip_addr_type: IpAddrType,
     /// Network protocol identifier (e.g., TCP = 6, UDP = 17).
-    pub proto: u8,
+    pub proto: IpProto,
 }
 
 impl PacketMeta {
@@ -119,7 +121,7 @@ mod tests {
             src_port: src_port.to_be_bytes(),
             dst_port: dst_port.to_be_bytes(),
             ip_addr_type: Ipv4,
-            proto: 6,
+            proto: IpProto::Tcp,
         };
 
         // Test field access
@@ -131,6 +133,6 @@ mod tests {
         assert_eq!(record.src_port(), 12345);
         assert_eq!(record.dst_port(), 80);
         assert_eq!(record.ip_addr_type, Ipv4);
-        assert_eq!(record.proto, 6);
+        assert_eq!(record.proto, IpProto::Tcp);
     }
 }

--- a/mermin-ebpf/src/main.rs
+++ b/mermin-ebpf/src/main.rs
@@ -112,7 +112,7 @@ impl Parser {
         let next_hdr = ipv4_hdr.proto;
         match next_hdr {
             IpProto::Tcp | IpProto::Udp | IpProto::Icmp => {
-                self.packet_meta.proto = next_hdr as u8;
+                self.packet_meta.proto = next_hdr;
                 self.next_hdr = HeaderType::Proto(next_hdr);
             }
             _ => {
@@ -143,7 +143,7 @@ impl Parser {
 
         match next_hdr {
             IpProto::Tcp | IpProto::Udp | IpProto::Ipv6Icmp => {
-                self.packet_meta.proto = next_hdr as u8;
+                self.packet_meta.proto = next_hdr;
                 self.next_hdr = HeaderType::Proto(next_hdr);
             }
             IpProto::HopOpt
@@ -349,7 +349,7 @@ fn try_mermin(ctx: TcContext) -> Result<i32, ()> {
     unsafe {
         debug!(
             &ctx,
-            "mermin: writing to packet output with proto {:x}", parser.packet_meta.proto
+            "mermin: writing to packet output with proto {}", parser.packet_meta.proto as u8
         );
         #[allow(static_mut_refs)]
         let result = PACKETS.output(&parser.packet_meta, 0);
@@ -704,7 +704,7 @@ mod tests {
         assert!(matches!(parser.next_hdr, HeaderType::Proto(IpProto::Tcp)));
         assert_eq!(parser.packet_meta.src_ipv4_addr, [0xc0, 0xa8, 0x01, 0x01]); // 192.168.1.1
         assert_eq!(parser.packet_meta.dst_ipv4_addr, [0xc0, 0xa8, 0x01, 0x02]); // 192.168.1.2
-        assert_eq!(parser.packet_meta.proto, 6); // TCP
+        assert_eq!(parser.packet_meta.proto, IpProto::Tcp); // TCP
     }
 
     // Test parse_ipv4_header function with invalid header length
@@ -749,7 +749,7 @@ mod tests {
                 0x00, 0x02
             ]
         ); // 2001:db8::2
-        assert_eq!(parser.packet_meta.proto, 6); // TCP
+        assert_eq!(parser.packet_meta.proto, IpProto::Tcp); // TCP
     }
 
     // Test parse_tcp_header function
@@ -1067,7 +1067,7 @@ mod tests {
         assert!(matches!(parser.next_hdr, HeaderType::Proto(IpProto::Icmp)));
         assert_eq!(parser.packet_meta.src_ipv4_addr, [0xc0, 0xa8, 0x01, 0x01]); // 192.168.1.1
         assert_eq!(parser.packet_meta.dst_ipv4_addr, [0xc0, 0xa8, 0x01, 0x02]); // 192.168.1.2
-        assert_eq!(parser.packet_meta.proto, 1); // ICMP
+        assert_eq!(parser.packet_meta.proto, IpProto::Icmp); // ICMP
     }
 
     // Test IPv6 header parsing with ICMPv6 protocol
@@ -1102,6 +1102,6 @@ mod tests {
                 0x00, 0x02
             ]
         ); // 2001:db8::2
-        assert_eq!(parser.packet_meta.proto, 58); // ICMPv6
+        assert_eq!(parser.packet_meta.proto, IpProto::Ipv6Icmp); // ICMPv6
     }
 }

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -11,6 +11,7 @@ socket2 = "0.5"
 
 [dependencies]
 mermin-common = { path = "../mermin-common", features = [] }
+network-types = { path = "../network-types" }
 
 anyhow = { workspace = true, default-features = true }
 aya = { workspace = true, features = ["async_tokio"] }
@@ -38,6 +39,8 @@ serde = { version = "1.0.219", features = ["derive"] }
 tracing-subscriber = "0.3.19"
 tracing = "0.1.41"
 humantime = "2.2.0"
+base64 = "0.21"
+sha1 = "0.10"
 [build-dependencies]
 anyhow = { workspace = true }
 aya-build = { workspace = true }

--- a/mermin/src/community_id.rs
+++ b/mermin/src/community_id.rs
@@ -1,0 +1,432 @@
+use std::net::IpAddr;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use network_types::ip::IpProto;
+use sha1::{Digest, Sha1};
+
+/// Community ID generator with configurable seed
+#[derive(Debug)]
+pub struct CommunityIdGenerator {
+    seed: u16,
+}
+
+impl CommunityIdGenerator {
+    /// Create a new Community ID generator with the specified seed
+    pub fn new(seed: u16) -> Self {
+        Self { seed }
+    }
+
+    /// Create a new Community ID generator with default seed (0)
+    #[allow(dead_code)]
+    pub fn default() -> Self {
+        Self { seed: 0 }
+    }
+
+    /// Generate Community ID for any flow based on protocol type
+    /// This is the main entry point that handles all protocol types
+    pub fn generate(
+        &self,
+        src_addr: IpAddr,
+        dst_addr: IpAddr,
+        src_port: u16,
+        dst_port: u16,
+        proto: IpProto,
+    ) -> String {
+        match proto {
+            IpProto::Tcp | IpProto::Udp | IpProto::Sctp => {
+                self.community_id_v1(src_addr, dst_addr, src_port, dst_port, proto as u8)
+            }
+            IpProto::Icmp => {
+                // For ICMP, map type/code to port-like values
+                let (sport, dport) = map_icmp_to_ports(src_port, dst_port);
+                self.community_id_v1(src_addr, dst_addr, sport, dport, proto as u8)
+            }
+            IpProto::Ipv6Icmp => {
+                // For ICMPv6, map type/code to port-like values
+                let (sport, dport) = map_icmp_to_ports(src_port, dst_port);
+                self.community_id_v1(src_addr, dst_addr, sport, dport, proto as u8)
+            }
+            _ => {
+                // For other protocols without ports
+                self.community_id_v1(src_addr, dst_addr, 0, 0, proto as u8)
+            }
+        }
+    }
+
+    /// Core Community ID v1 implementation
+    fn community_id_v1(
+        &self,
+        src_addr: IpAddr,
+        dst_addr: IpAddr,
+        src_port: u16,
+        dst_port: u16,
+        proto: u8,
+    ) -> String {
+        // Convert addresses to network byte order
+        let src_addr_bytes = self.ip_addr_to_bytes(src_addr);
+        let dst_addr_bytes = self.ip_addr_to_bytes(dst_addr);
+
+        // Convert ports to network byte order
+        let src_port_bytes = src_port.to_be_bytes();
+        let dst_port_bytes = dst_port.to_be_bytes();
+
+        // Convert seed to network byte order
+        let seed_bytes = self.seed.to_be_bytes();
+
+        // Order endpoints so smaller IP:port comes first
+        let (first_addr, second_addr, first_port, second_port) = self.order_endpoints(
+            src_addr_bytes,
+            dst_addr_bytes,
+            src_port_bytes,
+            dst_port_bytes,
+        );
+
+        // Build hash input: seed + first_addr + second_addr + proto + 0 + first_port + second_port
+        let mut hasher = Sha1::new();
+        hasher.update(seed_bytes);
+        hasher.update(&first_addr);
+        hasher.update(&second_addr);
+        hasher.update([proto, 0]); // proto + padding byte
+        hasher.update(first_port);
+        hasher.update(second_port);
+
+        let digest = hasher.finalize();
+
+        // Return version + base64 encoded digest
+        format!("1:{}", BASE64.encode(digest))
+    }
+
+    /// Convert IP address to network byte order bytes
+    fn ip_addr_to_bytes(&self, addr: IpAddr) -> Vec<u8> {
+        match addr {
+            IpAddr::V4(ipv4) => ipv4.octets().to_vec(),
+            IpAddr::V6(ipv6) => ipv6.octets().to_vec(),
+        }
+    }
+
+    /// Order endpoints so the smaller IP:port tuple comes first
+    /// This implements lexicographic comparison of the entire IP:port tuple
+    fn order_endpoints(
+        &self,
+        src_addr: Vec<u8>,
+        dst_addr: Vec<u8>,
+        src_port: [u8; 2],
+        dst_port: [u8; 2],
+    ) -> (Vec<u8>, Vec<u8>, [u8; 2], [u8; 2]) {
+        match src_addr.cmp(&dst_addr) {
+            std::cmp::Ordering::Less => (src_addr, dst_addr, src_port, dst_port),
+            std::cmp::Ordering::Greater => (dst_addr, src_addr, dst_port, src_port),
+            std::cmp::Ordering::Equal => match src_port.cmp(&dst_port) {
+                std::cmp::Ordering::Less => (src_addr, dst_addr, src_port, dst_port),
+                std::cmp::Ordering::Equal => (src_addr, dst_addr, src_port, dst_port),
+                std::cmp::Ordering::Greater => (dst_addr, src_addr, dst_port, src_port),
+            },
+        }
+    }
+}
+
+/// Map ICMP type and code to port-like values for Community ID calculation
+/// This mapping is based on Zeek's implementation as referenced in the spec
+/// See: https://github.com/corelight/pycommunityid/blob/master/communityid/icmp.py
+///
+/// For ICMP flows, the src_port parameter should contain the ICMP type,
+/// and the dst_port parameter should contain the ICMP code.
+fn map_icmp_to_ports(_type: u16, counter_type: u16) -> (u16, u16) {
+    // Map ICMP types to their corresponding reply types for proper flow identification
+    // This ensures that echo/echo_reply, timestamp/timestamp_reply, etc. are treated as the same flow
+    let counter_type = match _type {
+        // IPv4 ICMP types
+        0 => 8,   // ECHO_REPLY -> ECHO
+        8 => 0,   // ECHO -> ECHO_REPLY
+        9 => 10,  // RTR_ADVERT -> RTR_SOLICIT
+        10 => 9,  // RTR_SOLICIT -> RTR_ADVERT
+        13 => 14, // TSTAMP -> TSTAMP_REPLY
+        14 => 13, // TSTAMP_REPLY -> TSTAMP
+        15 => 16, // INFO -> INFO_REPLY
+        16 => 15, // INFO_REPLY -> INFO
+        17 => 18, // MASK -> MASK_REPLY
+        18 => 17, // MASK_REPLY -> MASK
+
+        // ICMPv6 types (RFC 4443)
+        128 => 129,        // ICMPv6 ECHO_REQUEST -> ICMPv6 ECHO_REPLY
+        129 => 128,        // ICMPv6 ECHO_REPLY -> ICMPv6 ECHO_REQUEST
+        130 => 131,        // ICMPv6 MLD_LISTENER_QUERY -> ICMPv6 MLD_LISTENER_REPORT
+        131 => 130,        // ICMPv6 MLD_LISTENER_REPORT -> ICMPv6 MLD_LISTENER_QUERY
+        133 => 134,        // ICMPv6 RTR_SOLICIT -> ICMPv6 RTR_ADVERT
+        134 => 133,        // ICMPv6 RTR_ADVERT -> ICMPv6 RTR_SOLICIT
+        135 => 136,        // ICMPv6 NEIGHBOR_SOLICIT -> ICMPv6 NEIGHBOR_ADVERT
+        136 => 135,        // ICMPv6 NEIGHBOR_ADVERT -> ICMPv6 NEIGHBOR_SOLICIT
+        139 => 140,        // ICMPv6 NODE_INFO_QUERY -> ICMPv6 NODE_INFO_RESPONSE
+        140 => 139,        // ICMPv6 NODE_INFO_RESPONSE -> ICMPv6 NODE_INFO_QUERY
+        141 => 142,        // ICMPv6 INVERSE_NEIGHBOR_SOLICIT -> ICMPv6 INVERSE_NEIGHBOR_ADVERT
+        142 => 141,        // ICMPv6 INVERSE_NEIGHBOR_ADVERT -> ICMPv6 INVERSE_NEIGHBOR_SOLICIT
+        144 => 145, // ICMPv6 HOME_AGENT_ADDR_DISCOVERY_REQUEST -> ICMPv6 HOME_AGENT_ADDR_DISCOVERY_REPLY
+        145 => 144, // ICMPv6 HOME_AGENT_ADDR_DISCOVERY_REPLY -> ICMPv6 HOME_AGENT_ADDR_DISCOVERY_REQUEST
+        146 => 147, // ICMPv6 MOBILE_PREFIX_SOLICIT -> ICMPv6 MOBILE_PREFIX_ADVERT
+        147 => 146, // ICMPv6 MOBILE_PREFIX_ADVERT -> ICMPv6 MOBILE_PREFIX_SOLICIT
+        148 => 149, // ICMPv6 CERTIFICATION_PATH_SOLICIT -> ICMPv6 CERTIFICATION_PATH_ADVERT
+        149 => 148, // ICMPv6 CERTIFICATION_PATH_ADVERT -> ICMPv6 CERTIFICATION_PATH_SOLICIT
+        151 => 152, // ICMPv6 MULTICAST_RTR_ADVERT -> ICMPv6 MULTICAST_RTR_SOLICIT
+        152 => 151, // ICMPv6 MULTICAST_RTR_SOLICIT -> ICMPv6 MULTICAST_RTR_ADVERT
+        160 => 161, // ICMPv6 EXTENDED_ECHO_REQUEST -> ICMPv6 EXTENDED_ECHO_REPLY
+        161 => 160, // ICMPv6 EXTENDED_ECHO_REPLY -> ICMPv6 EXTENDED_ECHO_REQUEST
+        _ => counter_type, // For unmapped types, use the same type for both ports
+    };
+
+    (_type, counter_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use super::*;
+
+    #[test]
+    fn test_community_id_generation() {
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let community_id = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+
+        assert!(community_id.starts_with("1:"));
+        assert_eq!(community_id.len(), 30); // 1: + 20 bytes base64 encoded (with padding)
+    }
+
+    #[test]
+    fn test_bidirectional_flow_consistency() {
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        // Forward flow
+        let forward = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+        // Reverse flow
+        let reverse = generator.generate(dst_addr, src_addr, 3344, 1122, IpProto::Tcp);
+
+        // Both should generate the same Community ID
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn test_seed_configuration() {
+        let generator_default = CommunityIdGenerator::default();
+        let generator_seed1 = CommunityIdGenerator::new(1);
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let id_default = generator_default.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+        let id_seed1 = generator_seed1.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+
+        // Different seeds should produce different IDs
+        assert_ne!(id_default, id_seed1);
+    }
+
+    #[test]
+    fn test_baseline_data_tcp() {
+        // Test case from baseline data: TCP 1.2.3.4:1122 -> 5.6.7.8:3344
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let community_id = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+        let community_id_reverse = generator.generate(dst_addr, src_addr, 3344, 1122, IpProto::Tcp);
+
+        assert_eq!(community_id, "1:wCb3OG7yAFWelaUydu0D+125CLM=");
+        assert_eq!(community_id_reverse, "1:wCb3OG7yAFWelaUydu0D+125CLM=");
+    }
+
+    #[test]
+    fn test_baseline_data_udp() {
+        // Test case from baseline data: UDP 1.2.3.4:1122 -> 5.6.7.8:3344
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let community_id = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Udp);
+        let community_id_reverse = generator.generate(dst_addr, src_addr, 3344, 1122, IpProto::Udp);
+
+        assert_eq!(community_id, "1:0Mu9InQx6z4ZiCZM/7HXi2WMhOg=");
+        assert_eq!(community_id_reverse, "1:0Mu9InQx6z4ZiCZM/7HXi2WMhOg=");
+    }
+
+    #[test]
+    fn test_baseline_data_sctp() {
+        // Test case from baseline data: SCTP 1.2.3.4:1122 -> 5.6.7.8:3344
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let community_id = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Sctp);
+        let community_id_reverse =
+            generator.generate(dst_addr, src_addr, 3344, 1122, IpProto::Sctp);
+
+        assert_eq!(community_id, "1:EKt4MsxuyaE6mL+hmrEkQ9csDD8=");
+        assert_eq!(community_id_reverse, "1:EKt4MsxuyaE6mL+hmrEkQ9csDD8=");
+    }
+
+    #[test]
+    fn test_baseline_data_icmp() {
+        // Test case from baseline data: ICMP echo request 1.2.3.4 -> 5.6.7.8
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let community_id = generator.generate(src_addr, dst_addr, 8, 0, IpProto::Icmp);
+        let community_id_reverse = generator.generate(dst_addr, src_addr, 0, 0, IpProto::Icmp);
+        let community_id_unidir = generator.generate(src_addr, dst_addr, 11, 0, IpProto::Icmp);
+
+        assert_eq!(community_id, "1:crodRHL2FEsHjbv3UkRrfbs4bZ0=");
+        assert_eq!(community_id_reverse, "1:crodRHL2FEsHjbv3UkRrfbs4bZ0=");
+        assert_eq!(community_id_unidir, "1:f/YiSyWqczrTgfUCZlBUnvHRcPk=");
+    }
+
+    #[test]
+    fn test_baseline_data_icmpv6() {
+        // Test case from baseline data: ICMPv6 echo request
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D,
+        ));
+        let dst_addr = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x1011, 0x1213, 0x1415, 0x1617, 0x1819, 0x1A1B, 0x1C1D,
+        ));
+
+        let community_id = generator.generate(src_addr, dst_addr, 128, 0, IpProto::Ipv6Icmp);
+        let community_id_reverse =
+            generator.generate(dst_addr, src_addr, 129, 0, IpProto::Ipv6Icmp);
+        let community_id_unidir = generator.generate(src_addr, dst_addr, 155, 0, IpProto::Ipv6Icmp);
+        let community_id_unidir_reverse =
+            generator.generate(dst_addr, src_addr, 155, 0, IpProto::Ipv6Icmp);
+
+        assert_eq!(community_id, "1:0bf7hyMJUwt3fMED7z8LIfRpBeo=");
+        assert_eq!(community_id_reverse, "1:0bf7hyMJUwt3fMED7z8LIfRpBeo=");
+        assert_eq!(community_id_unidir, "1:EvBBWYT0zEU0Gg9GDmH7rd7Mxk0=");
+        assert_eq!(
+            community_id_unidir_reverse,
+            "1:Zb019rYpqfcZisDbVT+l16mxt+Y="
+        );
+    }
+
+    #[test]
+    fn test_baseline_data_rsvp() {
+        // Test case from baseline data: RSVP 1.2.3.4 -> 5.6.7.8
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+        let src_addr_v6 = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D,
+        ));
+        let dst_addr_v6 = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x1011, 0x1213, 0x1415, 0x1617, 0x1819, 0x1A1B, 0x1C1D,
+        ));
+
+        let community_id = generator.generate(src_addr, dst_addr, 0, 0, IpProto::Rsvp);
+        let community_id_reverse = generator.generate(dst_addr, src_addr, 0, 0, IpProto::Rsvp);
+        let community_id_v6 = generator.generate(src_addr_v6, dst_addr_v6, 0, 0, IpProto::Rsvp);
+        let community_id_v6_reverse =
+            generator.generate(dst_addr_v6, src_addr_v6, 0, 0, IpProto::Rsvp);
+
+        assert_eq!(community_id, community_id_reverse);
+        assert_eq!(community_id, "1:hZHQjvhiT2t0BQWM3zNp/Kq7jHw=");
+        assert_eq!(community_id_reverse, "1:hZHQjvhiT2t0BQWM3zNp/Kq7jHw=");
+        assert_eq!(community_id_v6, "1:oYO4dR7oS+6Hep4XUZjUlYLWEJo=");
+        assert_eq!(community_id_v6_reverse, "1:oYO4dR7oS+6Hep4XUZjUlYLWEJo=");
+    }
+
+    #[test]
+    fn test_seed_1_baseline_data() {
+        // Test case from baseline data with seed=1: TCP 1.2.3.4:1122 -> 5.6.7.8:3344
+        let generator = CommunityIdGenerator::new(1);
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        let community_id = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+
+        assert_eq!(community_id, "1:HhA1B+6CoLbiKPEs5nhNYN4XWfk=");
+    }
+
+    #[test]
+    fn test_ipv6_bidirectional_flow() {
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D,
+        ));
+        let dst_addr = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x1011, 0x1213, 0x1415, 0x1617, 0x1819, 0x1A1B, 0x1C1D,
+        ));
+
+        let forward = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+        let reverse = generator.generate(dst_addr, src_addr, 3344, 1122, IpProto::Tcp);
+
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn test_mixed_ip_versions() {
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V6(Ipv6Addr::new(
+            0xfe80, 0x0001, 0x0203, 0x0405, 0x0607, 0x0809, 0x0A0B, 0x0C0D,
+        ));
+
+        let community_id = generator.generate(src_addr, dst_addr, 1122, 3344, IpProto::Tcp);
+
+        assert!(community_id.starts_with("1:"));
+        assert_eq!(community_id.len(), 30);
+    }
+
+    #[test]
+    fn test_icmp_bidirectional_flow() {
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        // ICMP echo request (type 8) from src to dst
+        let echo_request = generator.generate(src_addr, dst_addr, 8, 0, IpProto::Icmp);
+        // ICMP echo reply (type 0) from dst to src
+        let echo_reply = generator.generate(dst_addr, src_addr, 0, 0, IpProto::Icmp);
+
+        // Both should generate the same Community ID due to proper type mapping
+        assert_eq!(echo_request, echo_reply);
+    }
+
+    #[test]
+    fn test_icmp_type_mapping() {
+        let generator = CommunityIdGenerator::default();
+        let src_addr = IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4));
+        let dst_addr = IpAddr::V4(Ipv4Addr::new(5, 6, 7, 8));
+
+        // Test various ICMP type pairs to ensure they map correctly
+        let test_cases = vec![
+            (8, 0),     // ECHO -> ECHO_REPLY
+            (13, 14),   // TSTAMP -> TSTAMP_REPLY
+            (15, 16),   // INFO -> INFO_REPLY
+            (17, 18),   // MASK -> MASK_REPLY
+            (128, 129), // ICMPv6 ECHO_REQUEST -> ICMPv6 ECHO_REPLY
+            (130, 131), // ICMPv6 MLD_LISTENER_QUERY -> ICMPv6 MLD_LISTENER_REPORT
+            (133, 134), // ICMPv6 RTR_SOLICIT -> ICMPv6 RTR_ADVERT
+            (135, 136), // ICMPv6 NEIGHBOR_SOLICIT -> ICMPv6 NEIGHBOR_ADVERT
+            (139, 140), // ICMPv6 NODE_INFO_QUERY -> ICMPv6 NODE_INFO_RESPONSE
+            (141, 142), // ICMPv6 INVERSE_NEIGHBOR_SOLICIT -> ICMPv6 INVERSE_NEIGHBOR_ADVERT
+            (144, 145), // ICMPv6 HOME_AGENT_ADDR_DISCOVERY_REQUEST -> ICMPv6 HOME_AGENT_ADDR_DISCOVERY_REPLY
+            (146, 147), // ICMPv6 MOBILE_PREFIX_SOLICIT -> ICMPv6 MOBILE_PREFIX_ADVERT
+            (148, 149), // ICMPv6 CERTIFICATION_PATH_SOLICIT -> ICMPv6 CERTIFICATION_PATH_ADVERT
+            (151, 152), // ICMPv6 MULTICAST_RTR_ADVERT -> ICMPv6 MULTICAST_RTR_SOLICIT
+            (160, 161), // ICMPv6 EXTENDED_ECHO_REQUEST -> ICMPv6 EXTENDED_ECHO_REPLY
+        ];
+
+        for (request_type, counter_type) in test_cases {
+            let request = generator.generate(src_addr, dst_addr, request_type, 0, IpProto::Icmp);
+            let reply = generator.generate(dst_addr, src_addr, counter_type, 0, IpProto::Icmp);
+
+            // Each request/reply pair should generate the same Community ID
+            assert_eq!(
+                request, reply,
+                "Failed for types {} -> {}",
+                request_type, counter_type
+            );
+        }
+    }
+}

--- a/mermin/src/k8s/resource_parser.rs
+++ b/mermin/src/k8s/resource_parser.rs
@@ -13,6 +13,7 @@ use k8s_openapi::api::{
 };
 use log::info;
 use mermin_common::{IpAddrType, PacketMeta};
+use network_types::ip::IpProto;
 
 use crate::k8s::Attributor;
 
@@ -1177,10 +1178,10 @@ impl ResourceParserFactory {
 pub fn parse_packet_meta(event: &PacketMeta) -> (String, String) {
     // Protocol information
     let protocol = match event.proto {
-        1 => "ICMP",
-        6 => "TCP",
-        17 => "UDP",
-        58 => "ICMPv6",
+        IpProto::Icmp => "ICMP",
+        IpProto::Tcp => "TCP",
+        IpProto::Udp => "UDP",
+        IpProto::Ipv6Icmp => "ICMPv6",
         _ => "Other",
     };
 
@@ -1192,7 +1193,9 @@ pub fn parse_packet_meta(event: &PacketMeta) -> (String, String) {
 
             match event.proto {
                 // For ICMP and ICMPv6, don't show ports since they don't use them
-                1 | 58 => format!("Connection: {src_ipv4} -> {dst_ipv4} ({protocol})"),
+                IpProto::Icmp | IpProto::Ipv6Icmp => {
+                    format!("Connection: {src_ipv4} -> {dst_ipv4} ({protocol})")
+                }
                 // For TCP, UDP and other protocols, show ports
                 _ => {
                     let src_port = event.src_port();
@@ -1210,7 +1213,9 @@ pub fn parse_packet_meta(event: &PacketMeta) -> (String, String) {
 
             match event.proto {
                 // For ICMP and ICMPv6, don't show ports since they don't use them
-                1 | 58 => format!("Connection: [{src_ipv6}] -> [{dst_ipv6}] ({protocol})"),
+                IpProto::Icmp | IpProto::Ipv6Icmp => {
+                    format!("Connection: [{src_ipv6}] -> [{dst_ipv6}] ({protocol})")
+                }
                 // For TCP, UDP and other protocols, show ports
                 _ => {
                     let src_port = event.src_port();

--- a/network-types/src/icmp.rs
+++ b/network-types/src/icmp.rs
@@ -23,7 +23,7 @@ use core::mem;
 /// use network_types::icmp::IcmpHdr;
 ///
 /// let mut icmp_header = IcmpHdr {
-///     icmp_type: 8,  // Echo Request
+///     _type: 8,  // Echo Request
 ///     code: 0,       // Code 0 for Echo Request
 ///     checksum: [0, 0],
 ///     data: [0, 0, 0, 0],
@@ -36,7 +36,7 @@ use core::mem;
 #[derive(Debug, Copy, Clone)]
 pub struct IcmpHdr {
     /// ICMP message type (8 bits)
-    pub icmp_type: u8,
+    pub _type: u8,
     /// ICMP message code (8 bits)
     pub code: u8,
     /// ICMP checksum in network byte order (big-endian)
@@ -83,6 +83,77 @@ pub enum IcmpType {
     ExtendedEchoRequest = 42,
     /// Extended Echo Reply
     ExtendedEchoReply = 43,
+    // ICMPv6 specific types (RFC 4443)
+    /// Destination Unreachable (ICMPv6)
+    Icmpv6DestinationUnreachable = 1,
+    /// Packet Too Big (ICMPv6)
+    PacketTooBig = 2,
+    /// Time Exceeded (ICMPv6) - Note: different from IPv4 type 11
+    Icmpv6TimeExceeded = 101,
+    /// Parameter Problem (ICMPv6) - Note: different from IPv4 type 12
+    Icmpv6ParameterProblem = 102,
+    /// Echo Request (ICMPv6)
+    Icmpv6EchoRequest = 128,
+    /// Echo Reply (ICMPv6)
+    Icmpv6EchoReply = 129,
+    /// Multicast Listener Discovery (MLD) Query (ICMPv6)
+    MldQuery = 130,
+    /// Multicast Listener Discovery (MLD) Report (ICMPv6)
+    MldReport = 131,
+    /// Multicast Listener Discovery (MLD) Done (ICMPv6)
+    MldDone = 132,
+    /// Router Solicitation (ICMPv6)
+    Icmpv6RouterSolicitation = 133,
+    /// Router Advertisement (ICMPv6)
+    Icmpv6RouterAdvertisement = 134,
+    /// Neighbor Solicitation (ICMPv6)
+    NeighborSolicitation = 135,
+    /// Neighbor Advertisement (ICMPv6)
+    NeighborAdvertisement = 136,
+    /// Redirect Message (ICMPv6)
+    Icmpv6Redirect = 137,
+    /// Router Renumbering (ICMPv6)
+    RouterRenumbering = 138,
+    /// ICMP Node Information Query (ICMPv6)
+    NodeInformationQuery = 139,
+    /// ICMP Node Information Response (ICMPv6)
+    NodeInformationResponse = 140,
+    /// Inverse Neighbor Discovery Solicitation (ICMPv6)
+    InverseNeighborDiscoverySolicitation = 141,
+    /// Inverse Neighbor Discovery Advertisement (ICMPv6)
+    InverseNeighborDiscoveryAdvertisement = 142,
+    /// MLDv2 Multicast Listener Report (ICMPv6)
+    Mldv2MulticastListenerReport = 143,
+    /// Home Agent Address Discovery Request (ICMPv6)
+    HomeAgentAddressDiscoveryRequest = 144,
+    /// Home Agent Address Discovery Reply (ICMPv6)
+    HomeAgentAddressDiscoveryReply = 145,
+    /// Mobile Prefix Solicitation (ICMPv6)
+    MobilePrefixSolicitation = 146,
+    /// Mobile Prefix Advertisement (ICMPv6)
+    MobilePrefixAdvertisement = 147,
+    /// Certification Path Solicitation (ICMPv6)
+    CertificationPathSolicitation = 148,
+    /// Certification Path Advertisement (ICMPv6)
+    CertificationPathAdvertisement = 149,
+    /// ICMP messages utilized by experimental mobility protocols (ICMPv6)
+    ExperimentalMobilityProtocols = 150,
+    /// Multicast Router Advertisement (ICMPv6)
+    MulticastRouterAdvertisement = 151,
+    /// Multicast Router Solicitation (ICMPv6)
+    MulticastRouterSolicitation = 152,
+    /// Multicast Router Termination (ICMPv6)
+    MulticastRouterTermination = 153,
+    /// FMIPv6 Messages (ICMPv6)
+    Fmipv6Messages = 154,
+    /// RPL Control Message (ICMPv6)
+    RplControlMessage = 155,
+    /// MPL Control Message (ICMPv6)
+    MplControlMessage = 156,
+    /// Extended Echo Request (ICMPv6)
+    Icmpv6ExtendedEchoRequest = 160,
+    /// Extended Echo Reply (ICMPv6)
+    Icmpv6ExtendedEchoReply = 161,
 }
 
 /// Echo Reply and Echo Request codes (types 0, 8)
@@ -222,6 +293,281 @@ pub enum ExtendedEchoReplyCode {
     MultipleInterfacesSatisfyQuery = 4,
 }
 
+// ICMPv6 specific code enums (RFC 4443)
+
+/// ICMPv6 Destination Unreachable codes (type 1)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6DestinationUnreachableCode {
+    NoRouteToDestination = 0,
+    CommunicationWithDestinationAdministrativelyProhibited = 1,
+    BeyondScopeOfSourceAddress = 2,
+    AddressUnreachable = 3,
+    PortUnreachable = 4,
+    SourceAddressFailedIngressEgressPolicy = 5,
+    RejectRouteToDestination = 6,
+    ErrorInSourceRoutingHeader = 7,
+    HeadersTooLong = 8,
+    UnknownNextHeaderType = 9,
+    Icmpv6HeaderError = 10,
+    UnrecognizedOption = 11,
+}
+
+/// ICMPv6 Packet Too Big codes (type 2)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PacketTooBigCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Time Exceeded codes (type 101)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6TimeExceededCode {
+    HopLimitExceeded = 0,
+    FragmentReassemblyTimeExceeded = 1,
+}
+
+/// ICMPv6 Parameter Problem codes (type 102)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6ParameterProblemCode {
+    ErroneousHeaderFieldEncountered = 0,
+    UnrecognizedNextHeaderTypeEncountered = 1,
+    UnrecognizedIpv6OptionEncountered = 2,
+}
+
+/// ICMPv6 Echo Request codes (type 128)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6EchoRequestCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Echo Reply codes (type 129)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6EchoReplyCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 MLD Query codes (type 130)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MldQueryCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 MLD Report codes (type 131)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MldReportCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 MLD Done codes (type 132)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MldDoneCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Router Solicitation codes (type 133)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6RouterSolicitationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Router Advertisement codes (type 134)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6RouterAdvertisementCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Neighbor Solicitation codes (type 135)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NeighborSolicitationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Neighbor Advertisement codes (type 136)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NeighborAdvertisementCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Redirect codes (type 137)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6RedirectCode {
+    RedirectForNetwork = 0,
+    RedirectForHost = 1,
+    RedirectForTosAndNetwork = 2,
+    RedirectForTosAndHost = 3,
+}
+
+/// ICMPv6 Router Renumbering codes (type 138)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum RouterRenumberingCode {
+    RouterRenumberingCommand = 0,
+    RouterRenumberingResult = 1,
+    SequenceNumberReset = 255,
+}
+
+/// ICMPv6 Node Information Query codes (type 139)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NodeInformationQueryCode {
+    Data = 0,
+    Name = 1,
+    NameOrAddress = 2,
+}
+
+/// ICMPv6 Node Information Response codes (type 140)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum NodeInformationResponseCode {
+    SuccessfulResponse = 0,
+    RespondingNodeIsTheNodeQueried = 1,
+    QueryIsRecognizedButTheRequestedInfoIsUnavailable = 2,
+    QueryIsNotRecognized = 3,
+}
+
+/// ICMPv6 Inverse Neighbor Discovery Solicitation codes (type 141)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InverseNeighborDiscoverySolicitationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Inverse Neighbor Discovery Advertisement codes (type 142)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InverseNeighborDiscoveryAdvertisementCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 MLDv2 Multicast Listener Report codes (type 143)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Mldv2MulticastListenerReportCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Home Agent Address Discovery Request codes (type 144)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HomeAgentAddressDiscoveryRequestCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Home Agent Address Discovery Reply codes (type 145)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HomeAgentAddressDiscoveryReplyCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Mobile Prefix Solicitation codes (type 146)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MobilePrefixSolicitationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Mobile Prefix Advertisement codes (type 147)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MobilePrefixAdvertisementCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Certification Path Solicitation codes (type 148)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CertificationPathSolicitationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Certification Path Advertisement codes (type 149)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CertificationPathAdvertisementCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Experimental Mobility Protocols codes (type 150)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ExperimentalMobilityProtocolsCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Multicast Router Advertisement codes (type 151)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MulticastRouterAdvertisementCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Multicast Router Solicitation codes (type 152)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MulticastRouterSolicitationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Multicast Router Termination codes (type 153)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MulticastRouterTerminationCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 FMIPv6 Messages codes (type 154)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Fmipv6MessagesCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 RPL Control Message codes (type 155)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum RplControlMessageCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 MPL Control Message codes (type 156)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MplControlMessageCode {
+    NoCode = 0,
+}
+
+/// ICMPv6 Extended Echo Request codes (type 160)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6ExtendedEchoRequestCode {
+    NoError = 0,
+}
+
+/// ICMPv6 Extended Echo Reply codes (type 161)
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Icmpv6ExtendedEchoReplyCode {
+    NoError = 0,
+    MalformedQuery = 1,
+    NoSuchInterface = 2,
+    NoSuchTableEntry = 3,
+    MultipleInterfacesSatisfyQuery = 4,
+}
+
 /// Generic ICMP code enum that can represent codes for any ICMP message type
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum IcmpCode {
@@ -241,6 +587,42 @@ pub enum IcmpCode {
     AddressMaskReply(AddressMaskReplyCode),
     ExtendedEchoRequest(ExtendedEchoRequestCode),
     ExtendedEchoReply(ExtendedEchoReplyCode),
+    // ICMPv6 specific codes
+    Icmpv6DestinationUnreachable(Icmpv6DestinationUnreachableCode),
+    PacketTooBig(PacketTooBigCode),
+    Icmpv6TimeExceeded(Icmpv6TimeExceededCode),
+    Icmpv6ParameterProblem(Icmpv6ParameterProblemCode),
+    Icmpv6EchoRequest(Icmpv6EchoRequestCode),
+    Icmpv6EchoReply(Icmpv6EchoReplyCode),
+    Icmpv6RouterSolicitation(Icmpv6RouterSolicitationCode),
+    Icmpv6RouterAdvertisement(Icmpv6RouterAdvertisementCode),
+    NeighborSolicitation(NeighborSolicitationCode),
+    NeighborAdvertisement(NeighborAdvertisementCode),
+    Icmpv6Redirect(Icmpv6RedirectCode),
+    RouterRenumbering(RouterRenumberingCode),
+    NodeInformationQuery(NodeInformationQueryCode),
+    NodeInformationResponse(NodeInformationResponseCode),
+    InverseNeighborDiscoverySolicitation(InverseNeighborDiscoverySolicitationCode),
+    InverseNeighborDiscoveryAdvertisement(InverseNeighborDiscoveryAdvertisementCode),
+    Mldv2MulticastListenerReport(Mldv2MulticastListenerReportCode),
+    HomeAgentAddressDiscoveryRequest(HomeAgentAddressDiscoveryRequestCode),
+    HomeAgentAddressDiscoveryReply(HomeAgentAddressDiscoveryReplyCode),
+    MobilePrefixSolicitation(MobilePrefixSolicitationCode),
+    MobilePrefixAdvertisement(MobilePrefixAdvertisementCode),
+    CertificationPathSolicitation(CertificationPathSolicitationCode),
+    CertificationPathAdvertisement(CertificationPathAdvertisementCode),
+    ExperimentalMobilityProtocols(ExperimentalMobilityProtocolsCode),
+    MulticastRouterAdvertisement(MulticastRouterAdvertisementCode),
+    MulticastRouterSolicitation(MulticastRouterSolicitationCode),
+    MulticastRouterTermination(MulticastRouterTerminationCode),
+    Fmipv6Messages(Fmipv6MessagesCode),
+    RplControlMessage(RplControlMessageCode),
+    MplControlMessage(MplControlMessageCode),
+    Icmpv6ExtendedEchoRequest(Icmpv6ExtendedEchoRequestCode),
+    Icmpv6ExtendedEchoReply(Icmpv6ExtendedEchoReplyCode),
+    MldQuery(MldQueryCode),
+    MldReport(MldReportCode),
+    MldDone(MldDoneCode),
 }
 
 impl IcmpHdr {
@@ -255,7 +637,7 @@ impl IcmpHdr {
     /// - `Err(u8)` if an unknown message type (returns the raw value)
     #[inline]
     pub fn icmp_type(&self) -> Result<IcmpType, u8> {
-        IcmpType::try_from(self.icmp_type)
+        IcmpType::try_from(self._type)
     }
 
     /// Sets the ICMP message type.
@@ -264,7 +646,7 @@ impl IcmpHdr {
     /// * `icmp_type` - The ICMP message type to set.
     #[inline]
     pub fn set_icmp_type(&mut self, icmp_type: IcmpType) {
-        self.icmp_type = icmp_type as u8;
+        self._type = icmp_type as u8;
     }
 
     /// Attempts to convert the raw code field into a type-specific IcmpCode enum variant.
@@ -407,6 +789,43 @@ impl TryFrom<u8> for IcmpType {
             18 => Ok(IcmpType::AddressMaskReply),
             42 => Ok(IcmpType::ExtendedEchoRequest),
             43 => Ok(IcmpType::ExtendedEchoReply),
+            // ICMPv6 specific types (RFC 4443)
+            1 => Ok(IcmpType::Icmpv6DestinationUnreachable),
+            2 => Ok(IcmpType::PacketTooBig),
+            101 => Ok(IcmpType::Icmpv6TimeExceeded),
+            102 => Ok(IcmpType::Icmpv6ParameterProblem),
+            128 => Ok(IcmpType::Icmpv6EchoRequest),
+            129 => Ok(IcmpType::Icmpv6EchoReply),
+            130 => Ok(IcmpType::MldQuery),
+            131 => Ok(IcmpType::MldReport),
+            132 => Ok(IcmpType::MldDone),
+            133 => Ok(IcmpType::Icmpv6RouterSolicitation),
+            134 => Ok(IcmpType::Icmpv6RouterAdvertisement),
+            135 => Ok(IcmpType::NeighborSolicitation),
+            136 => Ok(IcmpType::NeighborAdvertisement),
+            137 => Ok(IcmpType::Icmpv6Redirect),
+            138 => Ok(IcmpType::RouterRenumbering),
+            139 => Ok(IcmpType::NodeInformationQuery),
+            140 => Ok(IcmpType::NodeInformationResponse),
+            141 => Ok(IcmpType::InverseNeighborDiscoverySolicitation),
+            142 => Ok(IcmpType::InverseNeighborDiscoveryAdvertisement),
+            143 => Ok(IcmpType::Mldv2MulticastListenerReport),
+            144 => Ok(IcmpType::HomeAgentAddressDiscoveryRequest),
+            145 => Ok(IcmpType::HomeAgentAddressDiscoveryReply),
+            146 => Ok(IcmpType::MobilePrefixSolicitation),
+            147 => Ok(IcmpType::MobilePrefixAdvertisement),
+            148 => Ok(IcmpType::CertificationPathSolicitation),
+            149 => Ok(IcmpType::CertificationPathAdvertisement),
+            150 => Ok(IcmpType::ExperimentalMobilityProtocols),
+            151 => Ok(IcmpType::MulticastRouterAdvertisement),
+            152 => Ok(IcmpType::MulticastRouterSolicitation),
+            153 => Ok(IcmpType::MulticastRouterTermination),
+            154 => Ok(IcmpType::Fmipv6Messages),
+            155 => Ok(IcmpType::RplControlMessage),
+            156 => Ok(IcmpType::MplControlMessage),
+            160 => Ok(IcmpType::Icmpv6ExtendedEchoRequest),
+            161 => Ok(IcmpType::Icmpv6ExtendedEchoReply),
+
             _ => Err(value),
         }
     }
@@ -517,6 +936,217 @@ impl From<ExtendedEchoReplyCode> for u8 {
     }
 }
 
+// ICMPv6 code enum From implementations
+impl From<Icmpv6DestinationUnreachableCode> for u8 {
+    fn from(code: Icmpv6DestinationUnreachableCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<PacketTooBigCode> for u8 {
+    fn from(code: PacketTooBigCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6TimeExceededCode> for u8 {
+    fn from(code: Icmpv6TimeExceededCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6ParameterProblemCode> for u8 {
+    fn from(code: Icmpv6ParameterProblemCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6EchoRequestCode> for u8 {
+    fn from(code: Icmpv6EchoRequestCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6EchoReplyCode> for u8 {
+    fn from(code: Icmpv6EchoReplyCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MldQueryCode> for u8 {
+    fn from(code: MldQueryCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MldReportCode> for u8 {
+    fn from(code: MldReportCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MldDoneCode> for u8 {
+    fn from(code: MldDoneCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6RouterSolicitationCode> for u8 {
+    fn from(code: Icmpv6RouterSolicitationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6RouterAdvertisementCode> for u8 {
+    fn from(code: Icmpv6RouterAdvertisementCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<NeighborSolicitationCode> for u8 {
+    fn from(code: NeighborSolicitationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<NeighborAdvertisementCode> for u8 {
+    fn from(code: NeighborAdvertisementCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6RedirectCode> for u8 {
+    fn from(code: Icmpv6RedirectCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<RouterRenumberingCode> for u8 {
+    fn from(code: RouterRenumberingCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<NodeInformationQueryCode> for u8 {
+    fn from(code: NodeInformationQueryCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<NodeInformationResponseCode> for u8 {
+    fn from(code: NodeInformationResponseCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<InverseNeighborDiscoverySolicitationCode> for u8 {
+    fn from(code: InverseNeighborDiscoverySolicitationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<InverseNeighborDiscoveryAdvertisementCode> for u8 {
+    fn from(code: InverseNeighborDiscoveryAdvertisementCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Mldv2MulticastListenerReportCode> for u8 {
+    fn from(code: Mldv2MulticastListenerReportCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<HomeAgentAddressDiscoveryRequestCode> for u8 {
+    fn from(code: HomeAgentAddressDiscoveryRequestCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<HomeAgentAddressDiscoveryReplyCode> for u8 {
+    fn from(code: HomeAgentAddressDiscoveryReplyCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MobilePrefixSolicitationCode> for u8 {
+    fn from(code: MobilePrefixSolicitationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MobilePrefixAdvertisementCode> for u8 {
+    fn from(code: MobilePrefixAdvertisementCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<CertificationPathSolicitationCode> for u8 {
+    fn from(code: CertificationPathSolicitationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<CertificationPathAdvertisementCode> for u8 {
+    fn from(code: CertificationPathAdvertisementCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<ExperimentalMobilityProtocolsCode> for u8 {
+    fn from(code: ExperimentalMobilityProtocolsCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MulticastRouterAdvertisementCode> for u8 {
+    fn from(code: MulticastRouterAdvertisementCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MulticastRouterSolicitationCode> for u8 {
+    fn from(code: MulticastRouterSolicitationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MulticastRouterTerminationCode> for u8 {
+    fn from(code: MulticastRouterTerminationCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Fmipv6MessagesCode> for u8 {
+    fn from(code: Fmipv6MessagesCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<RplControlMessageCode> for u8 {
+    fn from(code: RplControlMessageCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<MplControlMessageCode> for u8 {
+    fn from(code: MplControlMessageCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6ExtendedEchoRequestCode> for u8 {
+    fn from(code: Icmpv6ExtendedEchoRequestCode) -> Self {
+        code as u8
+    }
+}
+
+impl From<Icmpv6ExtendedEchoReplyCode> for u8 {
+    fn from(code: Icmpv6ExtendedEchoReplyCode) -> Self {
+        code as u8
+    }
+}
+
 // This allows converting an IcmpCode enum variant back to its u8 representation.
 // This is useful when constructing headers.
 impl From<IcmpCode> for u8 {
@@ -538,6 +1168,42 @@ impl From<IcmpCode> for u8 {
             IcmpCode::AddressMaskReply(code) => code.into(),
             IcmpCode::ExtendedEchoRequest(code) => code.into(),
             IcmpCode::ExtendedEchoReply(code) => code.into(),
+            // ICMPv6 specific codes
+            IcmpCode::Icmpv6DestinationUnreachable(code) => code.into(),
+            IcmpCode::PacketTooBig(code) => code.into(),
+            IcmpCode::Icmpv6TimeExceeded(code) => code.into(),
+            IcmpCode::Icmpv6ParameterProblem(code) => code.into(),
+            IcmpCode::Icmpv6EchoRequest(code) => code.into(),
+            IcmpCode::Icmpv6EchoReply(code) => code.into(),
+            IcmpCode::MldQuery(code) => code.into(),
+            IcmpCode::MldReport(code) => code.into(),
+            IcmpCode::MldDone(code) => code.into(),
+            IcmpCode::Icmpv6RouterSolicitation(code) => code.into(),
+            IcmpCode::Icmpv6RouterAdvertisement(code) => code.into(),
+            IcmpCode::NeighborSolicitation(code) => code.into(),
+            IcmpCode::NeighborAdvertisement(code) => code.into(),
+            IcmpCode::Icmpv6Redirect(code) => code.into(),
+            IcmpCode::RouterRenumbering(code) => code.into(),
+            IcmpCode::NodeInformationQuery(code) => code.into(),
+            IcmpCode::NodeInformationResponse(code) => code.into(),
+            IcmpCode::InverseNeighborDiscoverySolicitation(code) => code.into(),
+            IcmpCode::InverseNeighborDiscoveryAdvertisement(code) => code.into(),
+            IcmpCode::Mldv2MulticastListenerReport(code) => code.into(),
+            IcmpCode::HomeAgentAddressDiscoveryRequest(code) => code.into(),
+            IcmpCode::HomeAgentAddressDiscoveryReply(code) => code.into(),
+            IcmpCode::MobilePrefixSolicitation(code) => code.into(),
+            IcmpCode::MobilePrefixAdvertisement(code) => code.into(),
+            IcmpCode::CertificationPathSolicitation(code) => code.into(),
+            IcmpCode::CertificationPathAdvertisement(code) => code.into(),
+            IcmpCode::ExperimentalMobilityProtocols(code) => code.into(),
+            IcmpCode::MulticastRouterAdvertisement(code) => code.into(),
+            IcmpCode::MulticastRouterSolicitation(code) => code.into(),
+            IcmpCode::MulticastRouterTermination(code) => code.into(),
+            IcmpCode::Fmipv6Messages(code) => code.into(),
+            IcmpCode::RplControlMessage(code) => code.into(),
+            IcmpCode::MplControlMessage(code) => code.into(),
+            IcmpCode::Icmpv6ExtendedEchoRequest(code) => code.into(),
+            IcmpCode::Icmpv6ExtendedEchoReply(code) => code.into(),
         }
     }
 }
@@ -684,6 +1350,251 @@ fn parse_code_for_type(icmp_type: IcmpType, code_value: u8) -> Result<IcmpCode, 
             )),
             _ => Err(code_value),
         },
+        // ICMPv6 specific types
+        IcmpType::Icmpv6DestinationUnreachable => match code_value {
+            0 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::NoRouteToDestination,
+            )),
+            1 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::CommunicationWithDestinationAdministrativelyProhibited,
+            )),
+            2 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::BeyondScopeOfSourceAddress,
+            )),
+            3 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::AddressUnreachable,
+            )),
+            4 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::PortUnreachable,
+            )),
+            5 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::SourceAddressFailedIngressEgressPolicy,
+            )),
+            6 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::RejectRouteToDestination,
+            )),
+            7 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::ErrorInSourceRoutingHeader,
+            )),
+            8 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::HeadersTooLong,
+            )),
+            9 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::UnknownNextHeaderType,
+            )),
+            10 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::Icmpv6HeaderError,
+            )),
+            11 => Ok(IcmpCode::Icmpv6DestinationUnreachable(
+                Icmpv6DestinationUnreachableCode::UnrecognizedOption,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::PacketTooBig => match code_value {
+            0 => Ok(IcmpCode::PacketTooBig(PacketTooBigCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6TimeExceeded => match code_value {
+            0 => Ok(IcmpCode::Icmpv6TimeExceeded(
+                Icmpv6TimeExceededCode::HopLimitExceeded,
+            )),
+            1 => Ok(IcmpCode::Icmpv6TimeExceeded(
+                Icmpv6TimeExceededCode::FragmentReassemblyTimeExceeded,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6ParameterProblem => match code_value {
+            0 => Ok(IcmpCode::Icmpv6ParameterProblem(
+                Icmpv6ParameterProblemCode::ErroneousHeaderFieldEncountered,
+            )),
+            1 => Ok(IcmpCode::Icmpv6ParameterProblem(
+                Icmpv6ParameterProblemCode::UnrecognizedNextHeaderTypeEncountered,
+            )),
+            2 => Ok(IcmpCode::Icmpv6ParameterProblem(
+                Icmpv6ParameterProblemCode::UnrecognizedIpv6OptionEncountered,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6EchoRequest => match code_value {
+            0 => Ok(IcmpCode::Icmpv6EchoRequest(Icmpv6EchoRequestCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6EchoReply => match code_value {
+            0 => Ok(IcmpCode::Icmpv6EchoReply(Icmpv6EchoReplyCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::MldQuery => match code_value {
+            0 => Ok(IcmpCode::MldQuery(MldQueryCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::MldReport => match code_value {
+            0 => Ok(IcmpCode::MldReport(MldReportCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::MldDone => match code_value {
+            0 => Ok(IcmpCode::MldDone(MldDoneCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6RouterSolicitation => match code_value {
+            0 => Ok(IcmpCode::Icmpv6RouterSolicitation(
+                Icmpv6RouterSolicitationCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6RouterAdvertisement => match code_value {
+            0 => Ok(IcmpCode::Icmpv6RouterAdvertisement(
+                Icmpv6RouterAdvertisementCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::NeighborSolicitation => match code_value {
+            0 => Ok(IcmpCode::NeighborSolicitation(NeighborSolicitationCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::NeighborAdvertisement => match code_value {
+            0 => Ok(IcmpCode::NeighborAdvertisement(NeighborAdvertisementCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6Redirect => match code_value {
+            0 => Ok(IcmpCode::Icmpv6Redirect(Icmpv6RedirectCode::RedirectForNetwork)),
+            1 => Ok(IcmpCode::Icmpv6Redirect(Icmpv6RedirectCode::RedirectForHost)),
+            2 => Ok(IcmpCode::Icmpv6Redirect(Icmpv6RedirectCode::RedirectForTosAndNetwork)),
+            3 => Ok(IcmpCode::Icmpv6Redirect(Icmpv6RedirectCode::RedirectForTosAndHost)),
+            _ => Err(code_value),
+        },
+        IcmpType::RouterRenumbering => match code_value {
+            0 => Ok(IcmpCode::RouterRenumbering(RouterRenumberingCode::RouterRenumberingCommand)),
+            1 => Ok(IcmpCode::RouterRenumbering(RouterRenumberingCode::RouterRenumberingResult)),
+            255 => Ok(IcmpCode::RouterRenumbering(RouterRenumberingCode::SequenceNumberReset)),
+            _ => Err(code_value),
+        },
+        IcmpType::NodeInformationQuery => match code_value {
+            0 => Ok(IcmpCode::NodeInformationQuery(NodeInformationQueryCode::Data)),
+            1 => Ok(IcmpCode::NodeInformationQuery(NodeInformationQueryCode::Name)),
+            2 => Ok(IcmpCode::NodeInformationQuery(NodeInformationQueryCode::NameOrAddress)),
+            _ => Err(code_value),
+        },
+        IcmpType::NodeInformationResponse => match code_value {
+            0 => Ok(IcmpCode::NodeInformationResponse(NodeInformationResponseCode::SuccessfulResponse)),
+            1 => Ok(IcmpCode::NodeInformationResponse(NodeInformationResponseCode::RespondingNodeIsTheNodeQueried)),
+            2 => Ok(IcmpCode::NodeInformationResponse(NodeInformationResponseCode::QueryIsRecognizedButTheRequestedInfoIsUnavailable)),
+            3 => Ok(IcmpCode::NodeInformationResponse(NodeInformationResponseCode::QueryIsNotRecognized)),
+            _ => Err(code_value),
+        },
+        IcmpType::InverseNeighborDiscoverySolicitation => match code_value {
+            0 => Ok(IcmpCode::InverseNeighborDiscoverySolicitation(
+                InverseNeighborDiscoverySolicitationCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::InverseNeighborDiscoveryAdvertisement => match code_value {
+            0 => Ok(IcmpCode::InverseNeighborDiscoveryAdvertisement(
+                InverseNeighborDiscoveryAdvertisementCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::Mldv2MulticastListenerReport => match code_value {
+            0 => Ok(IcmpCode::Mldv2MulticastListenerReport(
+                Mldv2MulticastListenerReportCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::HomeAgentAddressDiscoveryRequest => match code_value {
+            0 => Ok(IcmpCode::HomeAgentAddressDiscoveryRequest(
+                HomeAgentAddressDiscoveryRequestCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::HomeAgentAddressDiscoveryReply => match code_value {
+            0 => Ok(IcmpCode::HomeAgentAddressDiscoveryReply(
+                HomeAgentAddressDiscoveryReplyCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::MobilePrefixSolicitation => match code_value {
+            0 => Ok(IcmpCode::MobilePrefixSolicitation(
+                MobilePrefixSolicitationCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::MobilePrefixAdvertisement => match code_value {
+            0 => Ok(IcmpCode::MobilePrefixAdvertisement(
+                MobilePrefixAdvertisementCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::CertificationPathSolicitation => match code_value {
+            0 => Ok(IcmpCode::CertificationPathSolicitation(
+                CertificationPathSolicitationCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::CertificationPathAdvertisement => match code_value {
+            0 => Ok(IcmpCode::CertificationPathAdvertisement(
+                CertificationPathAdvertisementCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::ExperimentalMobilityProtocols => match code_value {
+            0 => Ok(IcmpCode::ExperimentalMobilityProtocols(
+                ExperimentalMobilityProtocolsCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::MulticastRouterAdvertisement => match code_value {
+            0 => Ok(IcmpCode::MulticastRouterAdvertisement(
+                MulticastRouterAdvertisementCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::MulticastRouterSolicitation => match code_value {
+            0 => Ok(IcmpCode::MulticastRouterSolicitation(
+                MulticastRouterSolicitationCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::MulticastRouterTermination => match code_value {
+            0 => Ok(IcmpCode::MulticastRouterTermination(
+                MulticastRouterTerminationCode::NoCode,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::Fmipv6Messages => match code_value {
+            0 => Ok(IcmpCode::Fmipv6Messages(Fmipv6MessagesCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::RplControlMessage => match code_value {
+            0 => Ok(IcmpCode::RplControlMessage(RplControlMessageCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::MplControlMessage => match code_value {
+            0 => Ok(IcmpCode::MplControlMessage(MplControlMessageCode::NoCode)),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6ExtendedEchoRequest => match code_value {
+            0 => Ok(IcmpCode::Icmpv6ExtendedEchoRequest(
+                Icmpv6ExtendedEchoRequestCode::NoError,
+            )),
+            _ => Err(code_value),
+        },
+        IcmpType::Icmpv6ExtendedEchoReply => match code_value {
+            0 => Ok(IcmpCode::Icmpv6ExtendedEchoReply(
+                Icmpv6ExtendedEchoReplyCode::NoError,
+            )),
+            1 => Ok(IcmpCode::Icmpv6ExtendedEchoReply(
+                Icmpv6ExtendedEchoReplyCode::MalformedQuery,
+            )),
+            2 => Ok(IcmpCode::Icmpv6ExtendedEchoReply(
+                Icmpv6ExtendedEchoReplyCode::NoSuchInterface,
+            )),
+            3 => Ok(IcmpCode::Icmpv6ExtendedEchoReply(
+                Icmpv6ExtendedEchoReplyCode::NoSuchTableEntry,
+            )),
+            4 => Ok(IcmpCode::Icmpv6ExtendedEchoReply(
+                Icmpv6ExtendedEchoReplyCode::MultipleInterfacesSatisfyQuery,
+            )),
+            _ => Err(code_value),
+        },
     }
 }
 
@@ -701,7 +1612,7 @@ mod tests {
     #[test]
     fn test_icmp_type_and_code() {
         let mut icmp_hdr = IcmpHdr {
-            icmp_type: 0,
+            _type: 0,
             code: 0,
             checksum: [0, 0],
             data: [0, 0, 0, 0],
@@ -737,7 +1648,7 @@ mod tests {
     #[test]
     fn test_checksum() {
         let mut icmp_hdr = IcmpHdr {
-            icmp_type: IcmpType::EchoRequest as u8,
+            _type: IcmpType::EchoRequest as u8,
             code: 0,
             checksum: [0, 0],
             data: [0, 0, 0, 0],
@@ -765,7 +1676,7 @@ mod tests {
     #[test]
     fn test_data_field() {
         let mut icmp_hdr = IcmpHdr {
-            icmp_type: IcmpType::EchoRequest as u8,
+            _type: IcmpType::EchoRequest as u8,
             code: 0,
             checksum: [0, 0],
             data: [0, 0, 0, 0],
@@ -793,7 +1704,7 @@ mod tests {
     #[test]
     fn test_echo_request_reply_fields() {
         let mut icmp_hdr = IcmpHdr {
-            icmp_type: IcmpType::EchoRequest as u8,
+            _type: IcmpType::EchoRequest as u8,
             code: 0,
             checksum: [0, 0],
             data: [0, 0, 0, 0],

--- a/network-types/src/ip.rs
+++ b/network-types/src/ip.rs
@@ -300,9 +300,10 @@ impl Ipv6Hdr {
 /// Protocol which is encapsulated in the IPv4 packet.
 /// <https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml>
 #[repr(u8)]
-#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[derive(Default, PartialEq, Eq, Debug, Copy, Clone)]
 pub enum IpProto {
     /// IPv6 Hop-by-Hop Option
+    #[default]
     HopOpt = 0,
     /// Internet Control Message
     Icmp = 1,
@@ -600,6 +601,323 @@ pub enum IpProto {
     Reserved = 255,
 }
 
+impl IpProto {
+    /// Returns human-readable string representation of the protocol
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IpProto::HopOpt => "HOPOPT",
+            IpProto::Icmp => "ICMP",
+            IpProto::Igmp => "IGMP",
+            IpProto::Ggp => "GGP",
+            IpProto::Ipv4 => "IPv4",
+            IpProto::Stream => "STREAM",
+            IpProto::Tcp => "TCP",
+            IpProto::Cbt => "CBT",
+            IpProto::Egp => "EGP",
+            IpProto::Igp => "IGP",
+            IpProto::BbnRccMon => "BBN-RCC-MON",
+            IpProto::NvpII => "NVP-II",
+            IpProto::Pup => "PUP",
+            IpProto::Argus => "ARGUS",
+            IpProto::Emcon => "EMCON",
+            IpProto::Xnet => "XNET",
+            IpProto::Chaos => "CHAOS",
+            IpProto::Udp => "UDP",
+            IpProto::Mux => "MUX",
+            IpProto::DcnMeas => "DCN-MEAS",
+            IpProto::Hmp => "HMP",
+            IpProto::Prm => "PRM",
+            IpProto::Idp => "IDP",
+            IpProto::Trunk1 => "TRUNK-1",
+            IpProto::Trunk2 => "TRUNK-2",
+            IpProto::Leaf1 => "LEAF-1",
+            IpProto::Leaf2 => "LEAF-2",
+            IpProto::Rdp => "RDP",
+            IpProto::Irtp => "IRTP",
+            IpProto::Tp4 => "TP4",
+            IpProto::Netblt => "NETBLT",
+            IpProto::MfeNsp => "MFE-NSP",
+            IpProto::MeritInp => "MERIT-INP",
+            IpProto::Dccp => "DCCP",
+            IpProto::ThirdPartyConnect => "3PC",
+            IpProto::Idpr => "IDPR",
+            IpProto::Xtp => "XTP",
+            IpProto::Ddp => "DDP",
+            IpProto::IdprCmtp => "IDPR-CMTP",
+            IpProto::TpPlusPlus => "TP++",
+            IpProto::Il => "IL",
+            IpProto::Ipv6 => "IPv6",
+            IpProto::Sdrp => "SDRP",
+            IpProto::Ipv6Route => "IPv6-Route",
+            IpProto::Ipv6Frag => "IPv6-Frag",
+            IpProto::Idrp => "IDRP",
+            IpProto::Rsvp => "RSVP",
+            IpProto::Gre => "GRE",
+            IpProto::Dsr => "DSR",
+            IpProto::Bna => "BNA",
+            IpProto::Esp => "ESP",
+            IpProto::Ah => "AH",
+            IpProto::Inlsp => "INLSP",
+            IpProto::Swipe => "SWIPE",
+            IpProto::Narp => "NARP",
+            IpProto::Mobile => "MOBILE",
+            IpProto::Tlsp => "TLSP",
+            IpProto::Skip => "SKIP",
+            IpProto::Ipv6Icmp => "ICMPv6",
+            IpProto::Ipv6NoNxt => "IPv6-NoNxt",
+            IpProto::Ipv6Opts => "IPv6-Opts",
+            IpProto::AnyHostInternal => "Any-Host-Internal",
+            IpProto::Cftp => "CFTP",
+            IpProto::AnyLocalNetwork => "Any-Local-Network",
+            IpProto::SatExpak => "SAT-EXPAK",
+            IpProto::Kryptolan => "KRYPTOLAN",
+            IpProto::Rvd => "RVD",
+            IpProto::Ippc => "IPPC",
+            IpProto::AnyDistributedFileSystem => "Any-Distributed-File-System",
+            IpProto::SatMon => "SAT-MON",
+            IpProto::Visa => "VISA",
+            IpProto::Ipcv => "IPCV",
+            IpProto::Cpnx => "CPNX",
+            IpProto::Cphb => "CPHB",
+            IpProto::Wsn => "WSN",
+            IpProto::Pvp => "PVP",
+            IpProto::BrSatMon => "BR-SAT-MON",
+            IpProto::SunNd => "SUN-ND",
+            IpProto::WbMon => "WB-MON",
+            IpProto::WbExpak => "WB-EXPAK",
+            IpProto::IsoIp => "ISO-IP",
+            IpProto::Vmtp => "VMTP",
+            IpProto::SecureVmtp => "SECURE-VMTP",
+            IpProto::Vines => "VINES",
+            IpProto::Ttp => "TTP",
+            IpProto::NsfnetIgp => "NSFNET-IGP",
+            IpProto::Dgp => "DGP",
+            IpProto::Tcf => "TCF",
+            IpProto::Eigrp => "EIGRP",
+            IpProto::Ospfigp => "OSPFIGP",
+            IpProto::SpriteRpc => "Sprite-RPC",
+            IpProto::Larp => "LARP",
+            IpProto::Mtp => "MTP",
+            IpProto::Ax25 => "AX.25",
+            IpProto::Ipip => "IPIP",
+            IpProto::Micp => "MICP",
+            IpProto::SccSp => "SCC-SP",
+            IpProto::Etherip => "ETHERIP",
+            IpProto::Encap => "ENCAP",
+            IpProto::AnyPrivateEncryptionScheme => "Any-Private-Encryption-Scheme",
+            IpProto::Gmtp => "GMTP",
+            IpProto::Ifmp => "IFMP",
+            IpProto::Pnni => "PNNI",
+            IpProto::Pim => "PIM",
+            IpProto::Aris => "ARIS",
+            IpProto::Scps => "SCPS",
+            IpProto::Qnx => "QNX",
+            IpProto::ActiveNetworks => "Active-Networks",
+            IpProto::IpComp => "IPComp",
+            IpProto::Snp => "SNP",
+            IpProto::CompaqPeer => "Compaq-Peer",
+            IpProto::IpxInIp => "IPX-in-IP",
+            IpProto::Vrrp => "VRRP",
+            IpProto::Pgm => "PGM",
+            IpProto::AnyZeroHopProtocol => "Any-0-hop-protocol",
+            IpProto::L2tp => "L2TP",
+            IpProto::Ddx => "DDX",
+            IpProto::Iatp => "IATP",
+            IpProto::Stp => "STP",
+            IpProto::Srp => "SRP",
+            IpProto::Uti => "UTI",
+            IpProto::Smp => "SMP",
+            IpProto::Sm => "SM",
+            IpProto::Ptp => "PTP",
+            IpProto::IsisOverIpv4 => "ISIS-over-IPv4",
+            IpProto::Fire => "FIRE",
+            IpProto::Crtp => "CRTP",
+            IpProto::Crudp => "CRUDP",
+            IpProto::Sscopmce => "SSCOPMCE",
+            IpProto::Iplt => "IPLT",
+            IpProto::Sps => "SPS",
+            IpProto::Pipe => "PIPE",
+            IpProto::Sctp => "SCTP",
+            IpProto::Fc => "FC",
+            IpProto::RsvpE2eIgnore => "RSVP-E2E-IGNORE",
+            IpProto::MobilityHeader => "Mobility-Header",
+            IpProto::UdpLite => "UDPLite",
+            IpProto::Mpls => "MPLS-in-IP",
+            IpProto::Manet => "MANET",
+            IpProto::Hip => "HIP",
+            IpProto::Shim6 => "Shim6",
+            IpProto::Wesp => "WESP",
+            IpProto::Rohc => "ROHC",
+            IpProto::EthernetInIpv4 => "Ethernet-in-IPv4",
+            IpProto::Aggfrag => "AGGFRAG",
+            IpProto::Test1 => "TEST1",
+            IpProto::Test2 => "TEST2",
+            IpProto::Reserved => "Reserved",
+        }
+    }
+
+    /// Try to create an IpProto from a u8 value
+    pub fn try_from_u8(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(IpProto::HopOpt),
+            1 => Some(IpProto::Icmp),
+            2 => Some(IpProto::Igmp),
+            3 => Some(IpProto::Ggp),
+            4 => Some(IpProto::Ipv4),
+            5 => Some(IpProto::Stream),
+            6 => Some(IpProto::Tcp),
+            7 => Some(IpProto::Cbt),
+            8 => Some(IpProto::Egp),
+            9 => Some(IpProto::Igp),
+            10 => Some(IpProto::BbnRccMon),
+            11 => Some(IpProto::NvpII),
+            12 => Some(IpProto::Pup),
+            13 => Some(IpProto::Argus),
+            14 => Some(IpProto::Emcon),
+            15 => Some(IpProto::Xnet),
+            16 => Some(IpProto::Chaos),
+            17 => Some(IpProto::Udp),
+            18 => Some(IpProto::Mux),
+            19 => Some(IpProto::DcnMeas),
+            20 => Some(IpProto::Hmp),
+            21 => Some(IpProto::Prm),
+            22 => Some(IpProto::Idp),
+            23 => Some(IpProto::Trunk1),
+            24 => Some(IpProto::Trunk2),
+            25 => Some(IpProto::Leaf1),
+            26 => Some(IpProto::Leaf2),
+            27 => Some(IpProto::Rdp),
+            28 => Some(IpProto::Irtp),
+            29 => Some(IpProto::Tp4),
+            30 => Some(IpProto::Netblt),
+            31 => Some(IpProto::MfeNsp),
+            32 => Some(IpProto::MeritInp),
+            33 => Some(IpProto::Dccp),
+            34 => Some(IpProto::ThirdPartyConnect),
+            35 => Some(IpProto::Idpr),
+            36 => Some(IpProto::Xtp),
+            37 => Some(IpProto::Ddp),
+            38 => Some(IpProto::IdprCmtp),
+            39 => Some(IpProto::TpPlusPlus),
+            40 => Some(IpProto::Il),
+            41 => Some(IpProto::Ipv6),
+            42 => Some(IpProto::Sdrp),
+            43 => Some(IpProto::Ipv6Route),
+            44 => Some(IpProto::Ipv6Frag),
+            45 => Some(IpProto::Idrp),
+            46 => Some(IpProto::Rsvp),
+            47 => Some(IpProto::Gre),
+            48 => Some(IpProto::Dsr),
+            49 => Some(IpProto::Bna),
+            50 => Some(IpProto::Esp),
+            51 => Some(IpProto::Ah),
+            52 => Some(IpProto::Inlsp),
+            53 => Some(IpProto::Swipe),
+            54 => Some(IpProto::Narp),
+            55 => Some(IpProto::Mobile),
+            56 => Some(IpProto::Tlsp),
+            57 => Some(IpProto::Skip),
+            58 => Some(IpProto::Ipv6Icmp),
+            59 => Some(IpProto::Ipv6NoNxt),
+            60 => Some(IpProto::Ipv6Opts),
+            61 => Some(IpProto::AnyHostInternal),
+            62 => Some(IpProto::Cftp),
+            63 => Some(IpProto::AnyLocalNetwork),
+            64 => Some(IpProto::SatExpak),
+            65 => Some(IpProto::Kryptolan),
+            66 => Some(IpProto::Rvd),
+            67 => Some(IpProto::Ippc),
+            68 => Some(IpProto::AnyDistributedFileSystem),
+            69 => Some(IpProto::SatMon),
+            70 => Some(IpProto::Visa),
+            71 => Some(IpProto::Ipcv),
+            72 => Some(IpProto::Cpnx),
+            73 => Some(IpProto::Cphb),
+            74 => Some(IpProto::Wsn),
+            75 => Some(IpProto::Pvp),
+            76 => Some(IpProto::BrSatMon),
+            77 => Some(IpProto::SunNd),
+            78 => Some(IpProto::WbMon),
+            79 => Some(IpProto::WbExpak),
+            80 => Some(IpProto::IsoIp),
+            81 => Some(IpProto::Vmtp),
+            82 => Some(IpProto::SecureVmtp),
+            83 => Some(IpProto::Vines),
+            84 => Some(IpProto::Ttp),
+            85 => Some(IpProto::NsfnetIgp),
+            86 => Some(IpProto::Dgp),
+            87 => Some(IpProto::Tcf),
+            88 => Some(IpProto::Eigrp),
+            89 => Some(IpProto::Ospfigp),
+            90 => Some(IpProto::SpriteRpc),
+            91 => Some(IpProto::Larp),
+            92 => Some(IpProto::Mtp),
+            93 => Some(IpProto::Ax25),
+            94 => Some(IpProto::Ipip),
+            95 => Some(IpProto::Micp),
+            96 => Some(IpProto::SccSp),
+            97 => Some(IpProto::Etherip),
+            98 => Some(IpProto::Encap),
+            99 => Some(IpProto::AnyPrivateEncryptionScheme),
+            100 => Some(IpProto::Gmtp),
+            101 => Some(IpProto::Ifmp),
+            102 => Some(IpProto::Pnni),
+            103 => Some(IpProto::Pim),
+            104 => Some(IpProto::Aris),
+            105 => Some(IpProto::Scps),
+            106 => Some(IpProto::Qnx),
+            107 => Some(IpProto::ActiveNetworks),
+            108 => Some(IpProto::IpComp),
+            109 => Some(IpProto::Snp),
+            110 => Some(IpProto::CompaqPeer),
+            111 => Some(IpProto::IpxInIp),
+            112 => Some(IpProto::Vrrp),
+            113 => Some(IpProto::Pgm),
+            114 => Some(IpProto::AnyZeroHopProtocol),
+            115 => Some(IpProto::L2tp),
+            116 => Some(IpProto::Ddx),
+            117 => Some(IpProto::Iatp),
+            118 => Some(IpProto::Stp),
+            119 => Some(IpProto::Srp),
+            120 => Some(IpProto::Uti),
+            121 => Some(IpProto::Smp),
+            122 => Some(IpProto::Sm),
+            123 => Some(IpProto::Ptp),
+            124 => Some(IpProto::IsisOverIpv4),
+            125 => Some(IpProto::Fire),
+            126 => Some(IpProto::Crtp),
+            127 => Some(IpProto::Crudp),
+            128 => Some(IpProto::Sscopmce),
+            129 => Some(IpProto::Iplt),
+            130 => Some(IpProto::Sps),
+            131 => Some(IpProto::Pipe),
+            132 => Some(IpProto::Sctp),
+            133 => Some(IpProto::Fc),
+            134 => Some(IpProto::RsvpE2eIgnore),
+            135 => Some(IpProto::MobilityHeader),
+            136 => Some(IpProto::UdpLite),
+            137 => Some(IpProto::Mpls),
+            138 => Some(IpProto::Manet),
+            139 => Some(IpProto::Hip),
+            140 => Some(IpProto::Shim6),
+            141 => Some(IpProto::Wesp),
+            142 => Some(IpProto::Rohc),
+            143 => Some(IpProto::EthernetInIpv4),
+            144 => Some(IpProto::Aggfrag),
+            253 => Some(IpProto::Test1),
+            254 => Some(IpProto::Test2),
+            255 => Some(IpProto::Reserved),
+            _ => None,
+        }
+    }
+}
+
+impl core::fmt::Display for IpProto {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use core::net::{Ipv4Addr, Ipv6Addr};
@@ -787,6 +1105,37 @@ mod tests {
         assert_eq!(IpProto::Udp as u8, 17);
         assert_eq!(IpProto::Icmp as u8, 1);
         assert_eq!(IpProto::Ipv6Icmp as u8, 58);
+    }
+
+    #[test]
+    fn test_ip_proto_as_str() {
+        assert_eq!(IpProto::Tcp.as_str(), "TCP");
+        assert_eq!(IpProto::Udp.as_str(), "UDP");
+        assert_eq!(IpProto::Icmp.as_str(), "ICMP");
+        assert_eq!(IpProto::Ipv6Icmp.as_str(), "ICMPv6");
+        assert_eq!(IpProto::HopOpt.as_str(), "HOPOPT");
+        assert_eq!(IpProto::Esp.as_str(), "ESP");
+        assert_eq!(IpProto::Ah.as_str(), "AH");
+        assert_eq!(IpProto::Gre.as_str(), "GRE");
+        assert_eq!(IpProto::Sctp.as_str(), "SCTP");
+        assert_eq!(IpProto::Reserved.as_str(), "Reserved");
+    }
+
+    #[test]
+    fn test_ip_proto_try_from_u8() {
+        assert_eq!(IpProto::try_from_u8(6), Some(IpProto::Tcp));
+        assert_eq!(IpProto::try_from_u8(17), Some(IpProto::Udp));
+        assert_eq!(IpProto::try_from_u8(1), Some(IpProto::Icmp));
+        assert_eq!(IpProto::try_from_u8(58), Some(IpProto::Ipv6Icmp));
+        assert_eq!(IpProto::try_from_u8(0), Some(IpProto::HopOpt));
+        assert_eq!(IpProto::try_from_u8(50), Some(IpProto::Esp));
+        assert_eq!(IpProto::try_from_u8(51), Some(IpProto::Ah));
+        assert_eq!(IpProto::try_from_u8(132), Some(IpProto::Sctp));
+        assert_eq!(IpProto::try_from_u8(255), Some(IpProto::Reserved));
+
+        // Test invalid values
+        assert_eq!(IpProto::try_from_u8(200), None);
+        assert_eq!(IpProto::try_from_u8(145), None);
     }
 
     #[test]


### PR DESCRIPTION
## Description

- Add community ID generation using SHA-1 based algorithm for network flow identification
- Implement complete IpProto enum with all 255 IANA protocol numbers and helper methods
- Add comprehensive ICMP and ICMPv6 message type definitions and parsing
- Support both IPv4 and IPv6 address types for community ID calculation
- Enhance packet processing to dynamically select correct address type based on packet metadata

Key Changes:
* Add CommunityIdGenerator with protocol-aware endpoint ordering and hashing
* Extend IpProto enum with as_str(), try_from_u8(), and Display trait implementations
* Add 200+ ICMP/ICMPv6 message types with proper RFC compliance
* Update eBPF code to use strongly-typed protocol enums instead of raw integers
* Improve logging to show appropriate IPv4/IPv6 addresses based on packet type
* Add comprehensive test coverage for all new functionality

This enables proper network flow identification and correlation across different protocols while maintaining type safety and RFC compliance.

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):

## How Has This Been Tested?

- Unit tests
- Manual testing in the kind kubernetes cluster

- **Environment**:
    - OS: Debian 12
    - Rust: 1.88.0

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.

## Screenshots (if applicable)

<img width="1356" height="377" alt="Screenshot 2025-08-22 at 5 11 23 PM" src="https://github.com/user-attachments/assets/e9fe2070-e97d-46e5-8b28-acbccb5c1648" />