### PR TITLE
Parser and Dynamic Parsing Refactor

### DIFF
--- a/network-types/src/route.rs
+++ b/network-types/src/route.rs
@@ -376,6 +376,14 @@ impl RplSourceRouteHeader {
     /// The total size in bytes of the RPL Source Route Header struct
     pub const LEN: usize = mem::size_of::<RplSourceRouteHeader>();
 
+    /// Calculates the total length of the Segment Routing Header in bytes.
+    /// The Hdr Ext Len is in 8-octet units, *excluding* the first 8 octets.
+    /// So, total length = (hdr_ext_len + 1) * 8.
+    #[inline]
+    pub fn total_hdr_len(&self) -> usize {
+        self.gen_route.total_hdr_len()
+    }
+
     /// Calculates the size of each address in the Addresses field based on CmprI.
     #[inline]
     pub fn address_size(&self) -> usize {
@@ -682,7 +690,7 @@ impl SegmentRoutingHeader {
 #[repr(C, packed)]
 #[derive(Debug, Copy, Clone)]
 pub struct CrhHeader {
-    pub generic_route: GenericRoute,
+    pub gen_route: GenericRoute,
 }
 
 impl CrhHeader {
@@ -695,50 +703,50 @@ impl CrhHeader {
     /// Gets the Next Header value.
     #[inline]
     pub fn next_hdr(&self) -> IpProto {
-        self.generic_route.next_hdr
+        self.gen_route.next_hdr
     }
 
     /// Sets the Next Header value.
     #[inline]
     pub fn set_next_hdr(&mut self, next_hdr: IpProto) {
-        self.generic_route.next_hdr = next_hdr
+        self.gen_route.next_hdr = next_hdr
     }
 
     /// Gets the Header Extension Length value.
     #[inline]
     pub fn hdr_ext_len(&self) -> u8 {
-        self.generic_route.hdr_ext_len
+        self.gen_route.hdr_ext_len
     }
 
     /// Sets the Header Extension Length value.
     #[inline]
     pub fn set_hdr_ext_len(&mut self, hdr_ext_len: u8) {
-        self.generic_route.hdr_ext_len = hdr_ext_len
+        self.gen_route.hdr_ext_len = hdr_ext_len
     }
 
     /// Gets the Routing Type value.
     #[inline]
     pub fn type_(&self) -> RoutingHeaderType {
-        RoutingHeaderType::from_u8(self.generic_route.type_)
+        RoutingHeaderType::from_u8(self.gen_route.type_)
     }
 
     /// Sets the Routing Type value.
     /// For CRH-16 Header, this should always be 5.
     #[inline]
     pub fn set_type(&mut self, type_: RoutingHeaderType) {
-        self.generic_route.type_ = type_.as_u8()
+        self.gen_route.type_ = type_.as_u8()
     }
 
     /// Gets the Segments Left value.
     #[inline]
     pub fn sgmt_left(&self) -> u8 {
-        self.generic_route.sgmt_left
+        self.gen_route.sgmt_left
     }
 
     /// Sets the Segments Left value.
     #[inline]
     pub fn set_sgmt_left(&mut self, sgmt_left: u8) {
-        self.generic_route.sgmt_left = sgmt_left
+        self.gen_route.sgmt_left = sgmt_left
     }
 
     /// Calculates the total length of the CRH-16 Header in bytes.
@@ -746,7 +754,7 @@ impl CrhHeader {
     /// So, total length = (hdr_ext_len + 1) * 8.
     #[inline]
     pub fn total_hdr_len(&self) -> usize {
-        self.generic_route.total_hdr_len()
+        self.gen_route.total_hdr_len()
     }
 
     /// Calculates the total length available for the SID List in bytes.
@@ -1175,7 +1183,9 @@ mod tests {
             sgmt_left: 0,
         };
 
-        let mut header = CrhHeader { generic_route };
+        let mut header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test next_hdr
         header.set_next_hdr(IpProto::Udp);
@@ -1204,7 +1214,9 @@ mod tests {
             sgmt_left: 2,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test total header length
         assert_eq!(header.total_hdr_len(), 16); // (1 + 1) * 8 = 16
@@ -1226,7 +1238,9 @@ mod tests {
             sgmt_left: 1,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test total header length
         assert_eq!(header.total_hdr_len(), 16); // (1 + 1) * 8 = 16
@@ -1248,7 +1262,9 @@ mod tests {
             sgmt_left: 15,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test total header length
         assert_eq!(header.total_hdr_len(), 40); // (4 + 1) * 8 = 40
@@ -1270,7 +1286,9 @@ mod tests {
             sgmt_left: 10,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test total header length
         assert_eq!(header.total_hdr_len(), 64); // (7 + 1) * 8 = 64
@@ -1292,7 +1310,9 @@ mod tests {
             sgmt_left: 0,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test with zero hdr_ext_len
         assert_eq!(header.total_hdr_len(), 8); // (0 + 1) * 8 = 8
@@ -1310,7 +1330,9 @@ mod tests {
             sgmt_left: 0,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         // Test with invalid type
         assert_eq!(header.num_sids(), 0); // Invalid type should return 0
@@ -1326,7 +1348,9 @@ mod tests {
             sgmt_left: 0,
         };
 
-        let header = CrhHeader { generic_route };
+        let header = CrhHeader {
+            gen_route: generic_route,
+        };
 
         assert_eq!(header.total_hdr_len(), 256); // (31 + 1) * 8 = 256
         assert_eq!(header.sid_list_len(), 252); // 256 - 4 = 252
@@ -1341,7 +1365,7 @@ mod tests {
         };
 
         let header_32 = CrhHeader {
-            generic_route: generic_route_32,
+            gen_route: generic_route_32,
         };
 
         assert_eq!(header_32.total_hdr_len(), 256); // (31 + 1) * 8 = 256

--- a/network-types/tests/integration-ebpf/src/main.rs
+++ b/network-types/tests/integration-ebpf/src/main.rs
@@ -395,7 +395,7 @@ fn try_integration_test(ctx: TcContext) -> Result<i32, i32> {
                 _ => return Err(TC_ACT_SHOT),
             };
 
-            if crh_header.generic_route.type_ != expected_type {
+            if crh_header.gen_route.type_ != expected_type {
                 return Err(TC_ACT_SHOT);
             }
 

--- a/network-types/tests/integration/src/crh.rs
+++ b/network-types/tests/integration/src/crh.rs
@@ -47,7 +47,9 @@ pub fn create_crh16_test_packet() -> (Vec<u8>, CrhParsed) {
         sgmt_left: 2,
     };
 
-    let header = CrhHeader { generic_route };
+    let header = CrhHeader {
+        gen_route: generic_route,
+    };
 
     let mut sids = [0u8; MAX_CRH_SID_STORAGE];
     // Copy the three SIDs (6 bytes total)
@@ -106,7 +108,9 @@ pub fn create_crh32_test_packet() -> (Vec<u8>, CrhParsed) {
         sgmt_left: 1,
     };
 
-    let header = CrhHeader { generic_route };
+    let header = CrhHeader {
+        gen_route: generic_route,
+    };
 
     let mut sids = [0u8; MAX_CRH_SID_STORAGE];
     // Copy the two SIDs (8 bytes total)
@@ -130,19 +134,19 @@ pub fn verify_crh16_header(received: ParsedHeader, expected: CrhParsed) {
 
     // Verify GenericRoute fields
     assert_eq!(
-        parsed_header.generic_route.next_hdr, expected_header.generic_route.next_hdr,
+        parsed_header.gen_route.next_hdr, expected_header.gen_route.next_hdr,
         "Next Header mismatch"
     );
     assert_eq!(
-        parsed_header.generic_route.hdr_ext_len, expected_header.generic_route.hdr_ext_len,
+        parsed_header.gen_route.hdr_ext_len, expected_header.gen_route.hdr_ext_len,
         "Header Extension Length mismatch"
     );
     assert_eq!(
-        parsed_header.generic_route.type_, expected_header.generic_route.type_,
+        parsed_header.gen_route.type_, expected_header.gen_route.type_,
         "Routing Type mismatch"
     );
     assert_eq!(
-        parsed_header.generic_route.sgmt_left, expected_header.generic_route.sgmt_left,
+        parsed_header.gen_route.sgmt_left, expected_header.gen_route.sgmt_left,
         "Segments Left mismatch"
     );
 
@@ -174,19 +178,19 @@ pub fn verify_crh32_header(received: ParsedHeader, expected: CrhParsed) {
 
     // Verify GenericRoute fields
     assert_eq!(
-        parsed_header.generic_route.next_hdr, expected_header.generic_route.next_hdr,
+        parsed_header.gen_route.next_hdr, expected_header.gen_route.next_hdr,
         "Next Header mismatch"
     );
     assert_eq!(
-        parsed_header.generic_route.hdr_ext_len, expected_header.generic_route.hdr_ext_len,
+        parsed_header.gen_route.hdr_ext_len, expected_header.gen_route.hdr_ext_len,
         "Header Extension Length mismatch"
     );
     assert_eq!(
-        parsed_header.generic_route.type_, expected_header.generic_route.type_,
+        parsed_header.gen_route.type_, expected_header.gen_route.type_,
         "Routing Type mismatch"
     );
     assert_eq!(
-        parsed_header.generic_route.sgmt_left, expected_header.generic_route.sgmt_left,
+        parsed_header.gen_route.sgmt_left, expected_header.gen_route.sgmt_left,
         "Segments Left mismatch"
     );
 


### PR DESCRIPTION
### Summary
This refactor simplifies parser state management in the eBPF program, standardizes naming across routing header types, and fixes/centralizes total header length calculations. It removes read_var_buf (:cry:) and simply advances past dynamic portions of packet headers.

### Key changes
- Parser state
  - Moved the read offset from ParserOptions into Parser (Parser::offset). The parser now directly advances the offset during header parsing.
  - Removed Parser::with_options and simplified default initialization.
  - udp parsing now accepts a geneve_port parameter rather than storing it in options for lookups.
- Header length handling
  - Use total_hdr_len() consistently to advance offsets for IPv6 extension headers (Hop-by-Hop, Geneve, RPL Source Route, SRH, CRH-16/32, and generic routing headers). This corrects earlier ad-hoc advances and consolidates logic.
- CRH renaming and API cleanup (network-types)
  - CrhHeader.generic_route renamed to gen_route for parity with other types and to avoid overly verbose names.
  - All getters/setters forward to gen_route fields; tests and integration code updated accordingly.
- RIP read_var_buf
  - Removed variable-length buffer read helper(s) in the eBPF test context and associated tests, reducing stack usage and avoiding verifier concerns.

### Behavioral/functional impact
- No intended change to parsing outcomes for supported headers. The main functional difference is correctness/clarity in how offset advances for routing/extension headers are computed, which reduces the chance of off-by-N errors.
- eBPF verifier friendliness improved by avoiding dynamic, large buffer reads.

### Testing
- Unit and integration tests updated and passing locally for default workspace members.
  - network-types integration tests updated for gen_route.
  - eBPF integration test updated to check crh_header.gen_route.type_.
