### PR TITLE
Update integration tests to not parse variable length data

### DIFF
--- a/network-types/tests/integration-common/src/lib.rs
+++ b/network-types/tests/integration-common/src/lib.rs
@@ -51,11 +51,11 @@ pub union HeaderUnion {
     pub esp: Esp,
     pub hop: HopOptHdr,
     pub geneve: GeneveHdr,
-    pub rpl: RplSourceRouteParsed,
+    pub rpl: RplSourceRouteHeader,
     pub type2: Type2RoutingHeader,
-    pub segment_routing: SegmentRoutingParsed,
-    pub crh16: CrhParsed,
-    pub crh32: CrhParsed,
+    pub segment_routing: SegmentRoutingHeader,
+    pub crh16: CrhHeader,
+    pub crh32: CrhHeader,
 }
 
 /// The final struct sent back to user-space. It contains the type of
@@ -65,32 +65,4 @@ pub union HeaderUnion {
 pub struct ParsedHeader {
     pub type_: PacketType,
     pub data: HeaderUnion,
-}
-
-pub const MAX_RPL_ADDR_STORAGE: usize = 128;
-pub const MAX_SRH_SEGMENTS_STORAGE: usize = 128;
-pub const MAX_CRH_SID_STORAGE: usize = 128;
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct RplSourceRouteParsed {
-    pub header: RplSourceRouteHeader,
-    pub addresses: [u8; MAX_RPL_ADDR_STORAGE],
-    pub addresses_len: u8,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct SegmentRoutingParsed {
-    pub header: SegmentRoutingHeader,
-    pub segments_and_tlvs: [u8; MAX_SRH_SEGMENTS_STORAGE],
-    pub segments_and_tlvs_len: u8,
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct CrhParsed {
-    pub header: CrhHeader,
-    pub sids: [u8; MAX_CRH_SID_STORAGE],
-    pub sids_len: u8,
 }

--- a/network-types/tests/integration/src/main.rs
+++ b/network-types/tests/integration/src/main.rs
@@ -115,7 +115,7 @@ define_header_test!(
 
 define_header_test!(
     test_parses_rpl_source_route_header,
-    RplSourceRouteParsed,
+    RplSourceRouteHeader,
     PacketType::RplSourceRoute,
     create_rpl_source_route_test_packet,
     verify_rpl_source_route_header
@@ -131,7 +131,7 @@ define_header_test!(
 
 define_header_test!(
     test_parses_segment_routing_header,
-    SegmentRoutingParsed,
+    SegmentRoutingHeader,
     PacketType::SegmentRouting,
     create_segment_routing_test_packet,
     verify_segment_routing_header
@@ -139,7 +139,7 @@ define_header_test!(
 
 define_header_test!(
     test_parses_segment_routing_with_tlvs_header,
-    SegmentRoutingParsed,
+    SegmentRoutingHeader,
     PacketType::SegmentRouting,
     create_segment_routing_with_tlvs_test_packet,
     verify_segment_routing_header
@@ -147,7 +147,7 @@ define_header_test!(
 
 define_header_test!(
     test_parses_crh16_header,
-    CrhParsed,
+    CrhHeader,
     PacketType::Crh16,
     create_crh16_test_packet,
     verify_crh16_header
@@ -155,7 +155,7 @@ define_header_test!(
 
 define_header_test!(
     test_parses_crh32_header,
-    CrhParsed,
+    CrhHeader,
     PacketType::Crh32,
     create_crh32_test_packet,
     verify_crh32_header

--- a/network-types/tests/integration/src/rpl_source_route.rs
+++ b/network-types/tests/integration/src/rpl_source_route.rs
@@ -1,42 +1,38 @@
-use integration_common::{MAX_RPL_ADDR_STORAGE, PacketType, ParsedHeader, RplSourceRouteParsed};
+use integration_common::{PacketType, ParsedHeader};
 use network_types::{
     ip::IpProto,
     route::{GenericRoute, RoutingHeaderType, RplSourceFixedHeader, RplSourceRouteHeader},
 };
 
-// Creates a test packet with two compressed addresses
-pub fn create_rpl_source_route_test_packet() -> (Vec<u8>, RplSourceRouteParsed) {
-    // With CmprI=8, CmprE=8, each address is 16-8=8 bytes (eliding 8 prefix octets)
-    // Two addresses = 2 * 8 = 16 bytes of address data
-    // Total header: GenericRoute (4) + RplSourceFixedHeader (4) + addresses (16) = 24 bytes
-    // Hdr Ext Len = (24 - 8) / 8 = 2 (excluding first 8 octets, in 8-octet units)
+// Creates a test packet including variable-length compressed addresses that should be skipped by parsing
+pub fn create_rpl_source_route_test_packet() -> (Vec<u8>, RplSourceRouteHeader) {
+    // With CmprI=8, CmprE=8, each address contributes 8 bytes
+    // Two addresses = 16 bytes of variable data
+    // Total header bytes on wire = 8 (static) + 16 (addresses) = 24
+    // Hdr Ext Len = (24 - 8) / 8 = 2
 
-    let packet_size = 1 + RplSourceRouteHeader::LEN + 16; // 1 byte discriminator + 8 byte header + 16 bytes addresses
-    let mut packet_data = vec![0u8; packet_size];
+    let mut packet_data = vec![0u8; 1 + RplSourceRouteHeader::LEN + 16];
 
     // Byte 0: Packet type discriminator for eBPF program
     packet_data[0] = PacketType::RplSourceRoute as u8;
 
     // GenericRoute (4 bytes) - starting at byte 1
     packet_data[1] = IpProto::Tcp as u8; // Next Header
-    packet_data[2] = 2; // Hdr Ext Len (2 * 8 = 16 bytes additional data)
+    packet_data[2] = 2; // Hdr Ext Len = 2 (16 bytes after first 8)
     packet_data[3] = RoutingHeaderType::RplSourceRoute.as_u8(); // Routing Type (3)
     packet_data[4] = 2; // Segments Left (2 addresses remaining)
 
     // RplSourceFixedHeader (4 bytes) - starting at byte 5
-    packet_data[5] = (8 << 4) | 8; // CmprI=8, CmprE=8 (both compress 8 octets)
+    packet_data[5] = (8 << 4) | 8; // CmprI=8, CmprE=8
     packet_data[6] = 0; // Pad=0, Reserved upper 4 bits
     packet_data[7] = 0; // Reserved middle 8 bits
     packet_data[8] = 0; // Reserved lower 8 bits
 
-    // Two compressed addresses (8 bytes each) - starting at byte 9
-    // First address (compressed): remove first 8 bytes (2001:db8:85a3:0000), keep last 8
-    packet_data[9..17].copy_from_slice(&[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]);
+    // Two compressed addresses (8 bytes each) that should be skipped by parsing
+    packet_data[9..17].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xF0, 0x11, 0x22]);
+    packet_data[17..25].copy_from_slice(&[0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0x00]);
 
-    // Second address (compressed): remove first 8 bytes (2001:db8:85a3:0000), keep last 8
-    packet_data[17..25].copy_from_slice(&[0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15]);
-
-    // Create the expected parsed structure
+    // Expected parsed structure only includes static header; dynamic addresses_len = 0
     let gen_route = GenericRoute {
         next_hdr: IpProto::Tcp,
         hdr_ext_len: 2,
@@ -48,34 +44,25 @@ pub fn create_rpl_source_route_test_packet() -> (Vec<u8>, RplSourceRouteParsed) 
         cmpr: 0,
         pad_reserved: [0; 3],
     };
-    fixed_hdr.set_cmpr(8, 8); // CmprI=8, CmprE=8
-    fixed_hdr.set_pad(0); // Pad=0
-    fixed_hdr.set_reserved(0); // Reserved=0
+    fixed_hdr.set_cmpr(8, 8);
+    fixed_hdr.set_pad(0);
+    fixed_hdr.set_reserved(0);
 
     let header = RplSourceRouteHeader {
         gen_route,
         fixed_hdr,
     };
 
-    let mut addresses = [0u8; MAX_RPL_ADDR_STORAGE];
-    // Copy the two compressed addresses (16 bytes total)
-    addresses[0..16].copy_from_slice(&packet_data[9..25]);
-
-    let expected = RplSourceRouteParsed {
-        header,
-        addresses,
-        addresses_len: 16, // 2 addresses * 8 bytes each
-    };
+    let expected = header;
 
     (packet_data, expected)
 }
 
 // Verifies the parsed RPL header and its addresses
-pub fn verify_rpl_source_route_header(received: ParsedHeader, expected: RplSourceRouteParsed) {
+pub fn verify_rpl_source_route_header(received: ParsedHeader, expected: RplSourceRouteHeader) {
     assert_eq!(received.type_, PacketType::RplSourceRoute);
-    let parsed_data = unsafe { received.data.rpl };
-    let parsed_header = parsed_data.header;
-    let expected_header = expected.header;
+    let parsed_header: RplSourceRouteHeader = unsafe { received.data.rpl };
+    let expected_header: RplSourceRouteHeader = expected;
 
     assert_eq!(
         parsed_header.gen_route.hdr_ext_len, expected_header.gen_route.hdr_ext_len,
@@ -83,13 +70,14 @@ pub fn verify_rpl_source_route_header(received: ParsedHeader, expected: RplSourc
     );
     // Add other assertions for gen_route and fixed_hdr fields...
 
+    // Verify total header length equals 24 (8 static + 16 variable)
+    let total_hdr_len_bytes = 8 + (parsed_header.gen_route.hdr_ext_len as usize) * 8;
     assert_eq!(
-        parsed_data.addresses_len, expected.addresses_len,
-        "Addresses length mismatch"
+        parsed_header.gen_route.hdr_ext_len, 2,
+        "Expected hdr_ext_len=2 for RPL SRH test"
     );
     assert_eq!(
-        &parsed_data.addresses[..parsed_data.addresses_len as usize],
-        &expected.addresses[..expected.addresses_len as usize],
-        "Addresses mismatch"
+        total_hdr_len_bytes, 24,
+        "Expected 24-byte RPL Source Route header by total_hdr_len"
     );
 }


### PR DESCRIPTION
Quick PR for refactoring the existing integration tests that dealt with parsing variable-length data: RPL, Segment, and CRH16/32. Makes it quite a bit more trim and ensures the integration tests actually reflect what we're trying in mermin-ebpf.