### PR TITLE
Implement IPv6 Ext Destination Options Header Support

### DIFF
--- a/network-types/src/destopts.rs
+++ b/network-types/src/destopts.rs
@@ -1,0 +1,124 @@
+use core::mem;
+
+use crate::ip::IpProto;
+
+/// Destination Options Header - RFC 8200
+///
+///  0                   1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |  Next Header  |  Hdr Ext Len  |                               |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               +
+/// |                                                               |
+/// .                                                               .
+/// .                            Options                            .
+/// .                                                               .
+/// |                                                               |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+/// Fields
+///
+/// * **Next Header (8 bits)**: 8-bit selector. Identifies the type of header
+///   immediately following the Destination Options header. Uses the same
+///   values as the IPv4 Protocol field [IANA-PN].
+///
+/// * **Hdr Ext Len (8 bits)**: 8-bit unsigned integer. Length of the
+///   Destination Options header in 8-octet units, not including the first 8
+///   octets.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct DestOptsHdr {
+    pub next_hdr: IpProto,
+    pub hdr_ext_len: u8,
+    pub opt_data: [u8; 6], // Minimum needed for 8 bytes of padding if options is empty
+}
+
+impl DestOptsHdr {
+    /// The size of the fixed part of the Destination Options Header, in bytes.
+    pub const LEN: usize = mem::size_of::<DestOptsHdr>();
+
+    /// Gets the Next Header value.
+    #[inline]
+    pub fn next_hdr(&self) -> IpProto {
+        self.next_hdr
+    }
+
+    /// Sets the Next Header value.
+    #[inline]
+    pub fn set_next_hdr(&mut self, next_hdr: IpProto) {
+        self.next_hdr = next_hdr;
+    }
+
+    /// Gets the Hdr Ext Len value.
+    #[inline]
+    pub fn hdr_ext_len(&self) -> u8 {
+        self.hdr_ext_len
+    }
+
+    /// Sets the Hdr Ext Len value.
+    #[inline]
+    pub fn set_hdr_ext_len(&mut self, hdr_ext_len: u8) {
+        self.hdr_ext_len = hdr_ext_len;
+    }
+
+    /// Calculates the total length of the Destination Options Header in bytes.
+    /// The Hdr Ext Len is in 8-octet units, not including the first 8 octets.
+    /// So, total length = (hdr_ext_len + 1) * 8.
+    #[inline]
+    pub fn total_hdr_len(&self) -> usize {
+        (self.hdr_ext_len as usize + 1) << 3
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_hdr() -> DestOptsHdr {
+        DestOptsHdr {
+            next_hdr: IpProto::Tcp,
+            hdr_ext_len: 0,
+            opt_data: [0; 6],
+        }
+    }
+
+    #[test]
+    fn test_getters_setters() {
+        let mut hdr = default_hdr();
+        assert_eq!(hdr.next_hdr(), IpProto::Tcp);
+        hdr.set_next_hdr(IpProto::Udp);
+        assert_eq!(hdr.next_hdr(), IpProto::Udp);
+
+        assert_eq!(hdr.hdr_ext_len(), 0);
+        hdr.set_hdr_ext_len(3);
+        assert_eq!(hdr.hdr_ext_len(), 3);
+    }
+
+    #[test]
+    fn test_total_hdr_len_various() {
+        let mut hdr = default_hdr();
+        // hdr_ext_len = 0 -> (0+1)*8 = 8
+        hdr.set_hdr_ext_len(0);
+        assert_eq!(hdr.total_hdr_len(), 8);
+        // 1 -> 16
+        hdr.set_hdr_ext_len(1);
+        assert_eq!(hdr.total_hdr_len(), 16);
+        // 2 -> 24
+        hdr.set_hdr_ext_len(2);
+        assert_eq!(hdr.total_hdr_len(), 24);
+        // 7 -> 64
+        hdr.set_hdr_ext_len(7);
+        assert_eq!(hdr.total_hdr_len(), 64);
+        // 255 -> 2048
+        hdr.set_hdr_ext_len(255);
+        assert_eq!(hdr.total_hdr_len(), (255usize + 1) * 8);
+    }
+
+    #[test]
+    fn test_len_constant() {
+        // Ensure LEN equals size_of::<DestOptsHdr>()
+        assert_eq!(DestOptsHdr::LEN, core::mem::size_of::<DestOptsHdr>());
+        // And is at least 8 bytes (minimum header size)
+        assert!(DestOptsHdr::LEN >= 8);
+    }
+}

--- a/network-types/src/lib.rs
+++ b/network-types/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod ah;
+pub mod destopts;
 pub mod esp;
 pub mod eth;
 pub mod fragment;

--- a/network-types/tests/integration-common/src/lib.rs
+++ b/network-types/tests/integration-common/src/lib.rs
@@ -4,6 +4,7 @@
 use aya::Pod;
 use network_types::{
     ah::AuthHdr,
+    destopts::DestOptsHdr,
     esp::Esp,
     eth::EthHdr,
     fragment::Fragment,
@@ -37,6 +38,7 @@ pub enum PacketType {
     Crh16 = 13,
     Crh32 = 14,
     Fragment = 15,
+    DestOpts = 16,
 }
 
 /// A union to hold any of the possible parsed network headers.
@@ -59,6 +61,7 @@ pub union HeaderUnion {
     pub crh16: CrhHeader,
     pub crh32: CrhHeader,
     pub fragment: Fragment,
+    pub destopts: DestOptsHdr,
 }
 
 /// The final struct sent back to user-space. It contains the type of

--- a/network-types/tests/integration-ebpf/src/main.rs
+++ b/network-types/tests/integration-ebpf/src/main.rs
@@ -11,6 +11,7 @@ use aya_log_ebpf::{Level, log};
 use integration_common::{HeaderUnion, PacketType, ParsedHeader};
 use network_types::{
     ah::AuthHdr,
+    destopts::DestOptsHdr,
     esp::Esp,
     eth::EthHdr,
     fragment::Fragment,
@@ -50,6 +51,7 @@ fn u8_to_packet_type(val: u8) -> Option<PacketType> {
         13 => Some(PacketType::Crh16),
         14 => Some(PacketType::Crh32),
         15 => Some(PacketType::Fragment),
+        16 => Some(PacketType::DestOpts),
         _ => None,
     }
 }
@@ -154,6 +156,13 @@ fn try_integration_test(ctx: TcContext) -> Result<i32, i32> {
             ParsedHeader {
                 type_: PacketType::Fragment,
                 data: HeaderUnion { fragment: header },
+            }
+        }
+        PacketType::DestOpts => {
+            let header: DestOptsHdr = ctx.load(data_offset).map_err(|_| TC_ACT_SHOT)?;
+            ParsedHeader {
+                type_: PacketType::DestOpts,
+                data: HeaderUnion { destopts: header },
             }
         }
         PacketType::Type2 => {

--- a/network-types/tests/integration/src/destopts.rs
+++ b/network-types/tests/integration/src/destopts.rs
@@ -1,0 +1,52 @@
+use integration_common::{PacketType, ParsedHeader};
+use network_types::{destopts::DestOptsHdr, ip::IpProto};
+
+// Helper for constructing Destination Options Header test packets
+pub fn create_destopts_test_packet() -> ([u8; DestOptsHdr::LEN + 1], DestOptsHdr) {
+    let mut request_data = [0u8; DestOptsHdr::LEN + 1];
+
+    // Discriminator for eBPF match statement
+    request_data[0] = PacketType::DestOpts as u8;
+
+    // Build expected header
+    let mut expected = DestOptsHdr {
+        next_hdr: IpProto::Tcp,
+        hdr_ext_len: 0, // minimal header size (only 8 bytes total)
+        opt_data: [0u8; 6],
+    };
+
+    expected.set_next_hdr(IpProto::Tcp);
+    expected.set_hdr_ext_len(0);
+    // Fill some option padding bytes (for deterministic comparison)
+    expected
+        .opt_data
+        .copy_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+
+    // Serialize into buffer, following repr(C, packed) layout
+    request_data[1] = expected.next_hdr as u8; // Next Header
+    request_data[2] = expected.hdr_ext_len; // Hdr Ext Len
+    request_data[3..9].copy_from_slice(&expected.opt_data); // 6 bytes of option/pad
+
+    (request_data, expected)
+}
+
+// Helper for verifying Destination Options Header test results
+pub fn verify_destopts_header(received: ParsedHeader, expected: DestOptsHdr) {
+    assert_eq!(received.type_, PacketType::DestOpts);
+    let parsed = unsafe { received.data.destopts };
+
+    assert_eq!(
+        parsed.next_hdr(),
+        expected.next_hdr(),
+        "Next Header mismatch"
+    );
+    assert_eq!(
+        parsed.hdr_ext_len(),
+        expected.hdr_ext_len(),
+        "Hdr Ext Len mismatch"
+    );
+    assert_eq!(parsed.opt_data, expected.opt_data, "Option data mismatch");
+
+    // Also validate total length calculation for hdr_ext_len = 0
+    assert_eq!(parsed.total_hdr_len(), 8, "Total header length mismatch");
+}

--- a/network-types/tests/integration/src/main.rs
+++ b/network-types/tests/integration/src/main.rs
@@ -1,5 +1,6 @@
 mod ah;
 mod crh;
+mod destopts;
 mod esp;
 mod eth;
 mod fragment;
@@ -21,6 +22,7 @@ use crate::{
         create_crh16_test_packet, create_crh32_test_packet, verify_crh16_header,
         verify_crh32_header,
     },
+    destopts::{create_destopts_test_packet, verify_destopts_header},
     esp::{create_esp_test_packet, verify_esp_header},
     eth::{create_eth_test_packet, verify_eth_header},
     fragment::{create_fragment_test_packet, verify_fragment_header},
@@ -169,4 +171,12 @@ define_header_test!(
     PacketType::Fragment,
     create_fragment_test_packet,
     verify_fragment_header
+);
+
+define_header_test!(
+    test_parses_destopts_header,
+    DestOptsHdr,
+    PacketType::DestOpts,
+    create_destopts_test_packet,
+    verify_destopts_header
 );


### PR DESCRIPTION
This PR introduces parsing support for the IPv6 Destination Options header across the workspace:
- Adds a new DestOptsHdr type in network-types and exports it from the crate.
- Extends the mermin-ebpf parser to recognize IpProto::Ipv6Opts and advance parsing state accordingly.

### Changes
- network-types
  - New module: src/destopts.rs with DestOptsHdr (repr(C, packed)) and helpers (next_hdr, hdr_ext_len, total_hdr_len).
  - Added unit tests for getters/setters and length calculations.
- mermin-ebpf
  - Added Parser::parse_destopts_header and dispatch for IpProto::Ipv6Opts.
  - Added test helpers and eBPF-side unit tests for DestOptsHdr paths (happy cases and bounds check).
- Integration testing
  - integration-common: introduced PacketType::DestOpts and HeaderUnion::destopts.
  - integration-ebpf: mapped PacketType::DestOpts to DestOptsHdr loading.
  - integration (user-space): added destopts test module and end-to-end test using the shared macro.
