### PR TITLE
Implement ipv6 Mobility header parsing and testing

### DIFF
--- a/network-types/src/lib.rs
+++ b/network-types/src/lib.rs
@@ -9,6 +9,7 @@ pub mod geneve;
 pub mod hop;
 pub mod icmp;
 pub mod ip;
+pub mod mobility;
 pub mod route;
 pub mod tcp;
 pub mod udp;

--- a/network-types/src/mobility.rs
+++ b/network-types/src/mobility.rs
@@ -1,0 +1,222 @@
+use crate::ip::IpProto;
+
+/// # Mobility Header Format Section 6.1.1 - https://datatracker.ietf.org/doc/html/rfc3775
+///
+///  0                   1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// | Payload Proto |  Hdr Ext Len  |   MH Type     |   Reserved    |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |           Checksum            |    Reserved Message Data      |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |                                                               |
+/// .                                                               .
+/// .                       Message Data                            .
+/// .                                                               .
+/// |                                                               |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+/// ## Fields
+///
+/// * **Payload Proto (8 bits)**: An 8-bit selector identifying the type of header immediately following the Mobility Header.
+///
+/// * **Hdr Ext Len (8 bits)**: An 8-bit unsigned integer representing the length of the Mobility Header in units of 8 octets, **excluding the first 8 octets**.
+///
+/// * **MH Type (8 bits)**: An 8-bit selector that identifies the specific mobility message.
+///
+/// * **Reserved (8 bits)**: Reserved for future use. Should be 0
+///
+/// * **Checksum (16 bits)**: A 16-bit unsigned integer containing the checksum of the Mobility Header.
+///
+/// * **Message Data (variable length)**: A variable-length field containing data specific to the `MH Type` indicated.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct MobilityHdr {
+    pub nxt_hdr: IpProto,
+    pub hdr_ext_len: u8,
+    pub mh_type: u8,
+    pub reserved: u8,
+    pub checksum: [u8; 2],
+    pub reserved_data: [u8; 2], // Captures last two bytes of standard mobility header length, typically reserved and set to 0
+}
+
+impl MobilityHdr {
+    /// The total size in bytes of the fixed part of the Mobility Header
+    pub const LEN: usize = 8; // Fixed size of the Mobility Header (first 8 bytes)
+
+    /// Gets the Payload Proto value.
+    #[inline]
+    pub fn nxt_hdr(&self) -> IpProto {
+        self.nxt_hdr
+    }
+
+    /// Sets the Payload Proto value.
+    #[inline]
+    pub fn set_nxt_hdr(&mut self, payload_proto: IpProto) {
+        self.nxt_hdr = payload_proto;
+    }
+
+    /// Gets the Header Len value.
+    /// This value is the length of the Mobility Header in units of 8 octets, excluding the first 8 octets.
+    #[inline]
+    pub fn hdr_ext_len(&self) -> u8 {
+        self.hdr_ext_len
+    }
+
+    /// Sets the Header Len value.
+    #[inline]
+    pub fn set_hdr_ext_len(&mut self, header_len: u8) {
+        self.hdr_ext_len = header_len;
+    }
+
+    /// Gets the MH Type value.
+    #[inline]
+    pub fn mh_type(&self) -> u8 {
+        self.mh_type
+    }
+
+    /// Sets the MH Type value.
+    #[inline]
+    pub fn set_mh_type(&mut self, mh_type: u8) {
+        self.mh_type = mh_type;
+    }
+
+    /// Gets the Reserved field.
+    #[inline]
+    pub fn reserved(&self) -> u8 {
+        self.reserved
+    }
+
+    /// Sets the Reserved field.
+    #[inline]
+    pub fn set_reserved(&mut self, reserved: u8) {
+        self.reserved = reserved;
+    }
+
+    /// Gets the Checksum as a 16-bit value.
+    #[inline]
+    pub fn checksum(&self) -> u16 {
+        u16::from_be_bytes(self.checksum)
+    }
+
+    /// Sets the Checksum from a 16-bit value.
+    #[inline]
+    pub fn set_checksum(&mut self, checksum: u16) {
+        self.checksum = checksum.to_be_bytes();
+    }
+
+    /// Gets the Message Data Start as a 16-bit value.
+    #[inline]
+    pub fn reserved_data(&self) -> u16 {
+        u16::from_be_bytes(self.reserved_data)
+    }
+
+    /// Sets the Message Data Start from a 16-bit value.
+    #[inline]
+    pub fn set_reserved_data(&mut self, reserved_data: u16) {
+        self.reserved_data = reserved_data.to_be_bytes();
+    }
+
+    /// Calculates the total length of the Hop-by-Hop header in bytes.
+    /// The Hdr Ext Len is in 8-octet units, *excluding* the first 8 octets.
+    /// So, total length = (hdr_ext_len + 1) * 8.
+    #[inline]
+    pub fn total_hdr_len(&self) -> usize {
+        (self.hdr_ext_len as usize + 1) << 3
+    }
+
+    /// Calculates the length of the Message Data in bytes.
+    /// Message Data length = Total Header Length - Fixed Header Length.
+    #[inline]
+    pub fn message_data_len(&self) -> usize {
+        self.total_hdr_len().saturating_sub(MobilityHdr::LEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mobilityhdr_size() {
+        assert_eq!(MobilityHdr::LEN, 8);
+        assert_eq!(MobilityHdr::LEN, core::mem::size_of::<MobilityHdr>());
+    }
+
+    #[test]
+    fn test_mobilityhdr_getters_and_setters() {
+        let mut mobility_hdr = MobilityHdr {
+            nxt_hdr: IpProto::Stream,
+            hdr_ext_len: 0,
+            mh_type: 0,
+            reserved: 0,
+            checksum: [0, 0],
+            reserved_data: [0, 0],
+        };
+
+        // Test payload_proto
+        mobility_hdr.set_nxt_hdr(IpProto::Stream); // Example: TCP
+        assert_eq!(mobility_hdr.nxt_hdr(), IpProto::Stream);
+        assert_eq!(mobility_hdr.nxt_hdr, IpProto::Stream);
+
+        // Test header_len
+        mobility_hdr.set_hdr_ext_len(2); // Example: 2 * 8 = 16 bytes of additional data
+        assert_eq!(mobility_hdr.hdr_ext_len(), 2);
+        assert_eq!(mobility_hdr.hdr_ext_len, 2);
+
+        // Test mh_type
+        mobility_hdr.set_mh_type(5);
+        assert_eq!(mobility_hdr.mh_type(), 5);
+        assert_eq!(mobility_hdr.mh_type, 5);
+
+        // Test reserved
+        mobility_hdr.set_reserved(0);
+        assert_eq!(mobility_hdr.reserved(), 0);
+        assert_eq!(mobility_hdr.reserved, 0);
+
+        // Test checksum
+        mobility_hdr.set_checksum(0x1234);
+        assert_eq!(mobility_hdr.checksum(), 0x1234);
+        assert_eq!(mobility_hdr.checksum, [0x12, 0x34]);
+
+        // Test msg_data_start
+        mobility_hdr.set_reserved_data(0x5678);
+        assert_eq!(mobility_hdr.reserved_data(), 0x5678);
+        assert_eq!(mobility_hdr.reserved_data, [0x56, 0x78]);
+    }
+
+    #[test]
+    fn test_mobilityhdr_length_calculation_methods() {
+        let mut mobility_hdr = MobilityHdr {
+            nxt_hdr: IpProto::Stream,
+            hdr_ext_len: 0,
+            mh_type: 0,
+            reserved: 0,
+            checksum: [0, 0],
+            reserved_data: [0, 0],
+        };
+
+        // Test with header_len = 0
+        mobility_hdr.set_hdr_ext_len(0);
+        assert_eq!(mobility_hdr.total_hdr_len(), 8);
+        assert_eq!(mobility_hdr.message_data_len(), 0);
+
+        // Test with header_len = 1
+        mobility_hdr.set_hdr_ext_len(1);
+        assert_eq!(mobility_hdr.total_hdr_len(), 16);
+        assert_eq!(mobility_hdr.message_data_len(), 8);
+
+        // Test with header_len = 3
+        mobility_hdr.set_hdr_ext_len(3);
+        assert_eq!(mobility_hdr.total_hdr_len(), 32);
+        assert_eq!(mobility_hdr.message_data_len(), 24);
+
+        // Test with header_len = 255 (max value)
+        mobility_hdr.set_hdr_ext_len(255);
+        assert_eq!(mobility_hdr.total_hdr_len(), 8 + (255 * 8));
+        assert_eq!(
+            mobility_hdr.message_data_len(),
+            8 + (255 * 8) - MobilityHdr::LEN
+        );
+    }
+}

--- a/network-types/tests/integration-common/src/lib.rs
+++ b/network-types/tests/integration-common/src/lib.rs
@@ -11,6 +11,7 @@ use network_types::{
     geneve::GeneveHdr,
     hop::HopOptHdr,
     ip::{Ipv4Hdr, Ipv6Hdr},
+    mobility::MobilityHdr,
     route::{CrhHeader, RplSourceRouteHeader, SegmentRoutingHeader, Type2RoutingHeader},
     tcp::TcpHdr,
     udp::UdpHdr,
@@ -41,6 +42,7 @@ pub enum PacketType {
     Fragment = 15,
     DestOpts = 16,
     Vxlan = 17,
+    Mobility = 18,
 }
 
 /// A union to hold any of the possible parsed network headers.
@@ -65,6 +67,7 @@ pub union HeaderUnion {
     pub fragment: Fragment,
     pub destopts: DestOptsHdr,
     pub vxlan: VxlanHdr,
+    pub mobility: MobilityHdr,
 }
 
 /// The final struct sent back to user-space. It contains the type of

--- a/network-types/tests/integration-ebpf/src/main.rs
+++ b/network-types/tests/integration-ebpf/src/main.rs
@@ -18,6 +18,7 @@ use network_types::{
     geneve::GeneveHdr,
     hop::HopOptHdr,
     ip::{Ipv4Hdr, Ipv6Hdr},
+    mobility::MobilityHdr,
     route::{
         CrhHeader, RoutingHeaderType, RplSourceRouteHeader, SegmentRoutingHeader,
         Type2RoutingHeader,
@@ -54,6 +55,7 @@ fn u8_to_packet_type(val: u8) -> Option<PacketType> {
         15 => Some(PacketType::Fragment),
         16 => Some(PacketType::DestOpts),
         17 => Some(PacketType::Vxlan),
+        18 => Some(PacketType::Mobility),
         _ => None,
     }
 }
@@ -165,6 +167,13 @@ fn try_integration_test(ctx: TcContext) -> Result<i32, i32> {
             ParsedHeader {
                 type_: PacketType::DestOpts,
                 data: HeaderUnion { destopts: header },
+            }
+        }
+        PacketType::Mobility => {
+            let header: MobilityHdr = ctx.load(data_offset).map_err(|_| TC_ACT_SHOT)?;
+            ParsedHeader {
+                type_: PacketType::Mobility,
+                data: HeaderUnion { mobility: header },
             }
         }
         PacketType::Type2 => {

--- a/network-types/tests/integration/src/main.rs
+++ b/network-types/tests/integration/src/main.rs
@@ -8,6 +8,7 @@ mod geneve;
 mod hop;
 mod ipv4;
 mod ipv6;
+mod mobility;
 mod rpl_source_route;
 mod segment_routing;
 mod tcp;
@@ -31,6 +32,7 @@ use crate::{
     hop::{create_hop_test_packet, verify_hop_header},
     ipv4::{create_ipv4_test_packet, verify_ipv4_header},
     ipv6::{create_ipv6_test_packet, verify_ipv6_header},
+    mobility::{create_mobility_test_packet, verify_mobility_header},
     rpl_source_route::{create_rpl_source_route_test_packet, verify_rpl_source_route_header},
     segment_routing::{
         create_segment_routing_test_packet, create_segment_routing_with_tlvs_test_packet,
@@ -181,6 +183,14 @@ define_header_test!(
     PacketType::DestOpts,
     create_destopts_test_packet,
     verify_destopts_header
+);
+
+define_header_test!(
+    test_parses_mobility_header,
+    MobilityHdr,
+    PacketType::Mobility,
+    create_mobility_test_packet,
+    verify_mobility_header
 );
 
 define_header_test!(

--- a/network-types/tests/integration/src/mobility.rs
+++ b/network-types/tests/integration/src/mobility.rs
@@ -1,0 +1,63 @@
+use integration_common::{PacketType, ParsedHeader};
+use network_types::{ip::IpProto, mobility::MobilityHdr};
+
+// Helper for constructing Mobility Header test packets
+pub fn create_mobility_test_packet() -> ([u8; MobilityHdr::LEN + 1], MobilityHdr) {
+    let mut request_data = [0u8; MobilityHdr::LEN + 1];
+
+    // Discriminator for eBPF match statement
+    request_data[0] = PacketType::Mobility as u8;
+
+    // Build expected header
+    let mut expected = MobilityHdr {
+        nxt_hdr: IpProto::Tcp,
+        hdr_ext_len: 0, // minimal fixed 8 bytes (no additional 8-octet blocks)
+        mh_type: 5,     // arbitrary MH type
+        reserved: 0,
+        checksum: [0x12, 0x34],
+        reserved_data: [0, 0],
+    };
+
+    // Use setters as available
+    expected.set_nxt_hdr(IpProto::Tcp);
+    expected.set_hdr_ext_len(0);
+    expected.set_mh_type(5);
+    expected.set_reserved(0);
+    expected.set_checksum(0x1234);
+    expected.set_reserved_data(0);
+
+    // Serialize into buffer according to repr(C, packed) layout
+    request_data[1] = expected.nxt_hdr as u8;
+    request_data[2] = expected.hdr_ext_len;
+    request_data[3] = expected.mh_type;
+    request_data[4] = expected.reserved;
+    request_data[5] = expected.checksum[0];
+    request_data[6] = expected.checksum[1];
+    request_data[7] = expected.reserved_data[0];
+    request_data[8] = expected.reserved_data[1];
+
+    (request_data, expected)
+}
+
+// Helper for verifying Mobility Header test results
+pub fn verify_mobility_header(received: ParsedHeader, expected: MobilityHdr) {
+    assert_eq!(received.type_, PacketType::Mobility);
+    let parsed = unsafe { received.data.mobility };
+
+    assert_eq!(parsed.nxt_hdr(), expected.nxt_hdr(), "Next Header mismatch");
+    assert_eq!(
+        parsed.hdr_ext_len(),
+        expected.hdr_ext_len(),
+        "Hdr Ext Len mismatch"
+    );
+    assert_eq!(parsed.mh_type(), expected.mh_type(), "MH Type mismatch");
+    assert_eq!(parsed.reserved(), expected.reserved(), "Reserved mismatch");
+    assert_eq!(parsed.checksum(), expected.checksum(), "Checksum mismatch");
+    assert_eq!(
+        parsed.reserved_data(),
+        expected.reserved_data(),
+        "Reserved data mismatch"
+    );
+    // Also sanity check total length for hdr_ext_len = 0
+    assert_eq!(parsed.total_hdr_len(), 8, "Total header length mismatch");
+}


### PR DESCRIPTION
This PR implements initial support for IPv6 Mobility header parsing with unit and integration tests.

### Changes
- network-types
  - Added mobility::MobilityHdr modeling RFC 3775 §6.1.1 fields:
    - nxt_hdr (Payload Proto), hdr_ext_len, mh_type, reserved, checksum, reserved_data
  - Added getters/setters and helpers:
  - Included unit tests validating layout, getters/setters, and length math

- mermin-ebpf (agent)
  - Parser: added parse_mobility_header() to load MobilityHdr, advance offset by total_hdr_len(), and set next header from nxt_hdr

- Integration test scaffolding (tests/integration-common and eBPF test program)
  - PacketType: added Mobility variant (17)
  - HeaderUnion: added mobility: MobilityHdr

- Integration tests (tests/integration)
  - Added mobility test helpers (create_mobility_test_packet, verify_mobility_header)
  - Registered test via define_header_test!(... MobilityHdr ...)
