### PR TITLE
Implement ipv6 Shim6 header parsing and testing

### DIFF
--- a/network-types/src/lib.rs
+++ b/network-types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod icmp;
 pub mod ip;
 pub mod mobility;
 pub mod route;
+pub mod shim6;
 pub mod tcp;
 pub mod udp;
 pub mod vxlan;

--- a/network-types/src/shim6.rs
+++ b/network-types/src/shim6.rs
@@ -1,0 +1,263 @@
+use core::mem;
+
+use crate::ip::IpProto;
+
+/// The Shim6 Control Header is a common header format used for various control messages within the Shim6 protocol.
+/// All Shim6 headers are designed to be a multiple of 8 octets in length, with a minimum size of 8 octets.
+///
+/// Shim6 Control Message Header Format
+///
+///  0                   1                   2                   3
+///  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// | Next Header   | Hdr Ext Len   |P|      Type     |Type-specific|S|
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/// |           Checksum            |                               |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+/// |                                                               |
+/// .                     Type-specific format                      .
+/// .                                                               .
+/// |                                                               |
+/// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+///
+///
+/// Fields
+///
+/// # Fields
+///
+/// * **Next Header (8 bits)**: Identifies the type of header immediately following this one.
+/// * **Hdr Ext Len (8 bits)**: The length of this header in 8-octet units, not including the first 8 octets.
+/// * **P (Payload Flag) (1 bit)**: Distinguishes between Shim6 Control and Payload Extension headers. Always 0.
+/// * **Type (7 bits)**: Identifies the specific Shim6 control message type.
+/// * **Type-specific (7 bits)**: A field whose interpretation depends on the message `Type`.
+/// * **S (Shim6/HIP Distinction) (1 bit)**: Distinguishes between Shim6 and HIP messages. Always 0.
+/// * **Checksum (16 bits)**: A checksum computed over the entire Shim6 message.
+/// * **Type-specific format (variable length)**: A variable-length portion whose structure depends on the message `Type`.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct Shim6Hdr {
+    /// Next Header field (8 bits)
+    pub next_hdr: IpProto,
+    /// Header Length field (8 bits). This is the length of the Shim6 header
+    /// in 8-octet units, not including the first 8 octets.
+    pub hdr_ext_len: u8,
+    /// P bit (1) + Message Type (7)
+    pub p_and_type: u8,
+    /// Type-specific (7) + S bit (1)
+    pub type_specific_and_s: u8,
+    /// Checksum field (16 bits)
+    pub checksum: [u8; 2],
+    /// The first 2 bytes of the Type-Specific data, part of the 8-octet base header.
+    pub type_specific_data: [u8; 2],
+}
+
+impl Shim6Hdr {
+    /// The size of the fixed part of the Shim6 Header in bytes.
+    pub const LEN: usize = mem::size_of::<Shim6Hdr>();
+
+    /// Gets the Next Header value.
+    #[inline]
+    pub fn next_hdr(&self) -> IpProto {
+        self.next_hdr
+    }
+
+    /// Sets the Next Header value.
+    #[inline]
+    pub fn set_next_hdr(&mut self, next_hdr: IpProto) {
+        self.next_hdr = next_hdr;
+    }
+
+    /// Gets the Hdr Ext Len value.
+    #[inline]
+    pub fn hdr_ext_len(&self) -> u8 {
+        self.hdr_ext_len
+    }
+
+    /// Sets the Hdr Ext Len value.
+    #[inline]
+    pub fn set_hdr_ext_len(&mut self, hdr_ext_len: u8) {
+        self.hdr_ext_len = hdr_ext_len;
+    }
+
+    /// Gets the P (Payload Flag) bit.
+    #[inline]
+    pub fn p(&self) -> bool {
+        (self.p_and_type >> 7) & 1 != 0
+    }
+
+    /// Sets the P (Payload Flag) bit.
+    #[inline]
+    pub fn set_p(&mut self, p: bool) {
+        self.p_and_type = (self.p_and_type & 0x7F) | ((p as u8) << 7);
+    }
+
+    /// Gets the message Type value (7 bits).
+    #[inline]
+    pub fn msg_type(&self) -> u8 {
+        self.p_and_type & 0x7F
+    }
+
+    /// Sets the message Type value (7 bits).
+    #[inline]
+    pub fn set_msg_type(&mut self, msg_type: u8) {
+        self.p_and_type = (self.p_and_type & 0x80) | (msg_type & 0x7F);
+    }
+
+    /// Gets the Type-specific bits (7 bits).
+    #[inline]
+    pub fn type_specific_bits(&self) -> u8 {
+        self.type_specific_and_s >> 1
+    }
+
+    /// Sets the Type-specific bits (7 bits).
+    #[inline]
+    pub fn set_type_specific_bits(&mut self, bits: u8) {
+        self.type_specific_and_s = (self.type_specific_and_s & 0x01) | (bits << 1);
+    }
+
+    /// Gets the S (Shim6/HIP Distinction) bit.
+    #[inline]
+    pub fn s(&self) -> bool {
+        (self.type_specific_and_s & 1) != 0
+    }
+
+    /// Sets the S (Shim6/HIP Distinction) bit.
+    #[inline]
+    pub fn set_s(&mut self, s: bool) {
+        self.type_specific_and_s = (self.type_specific_and_s & 0xFE) | (s as u8);
+    }
+
+    /// Gets the Checksum as a 16-bit value.
+    #[inline]
+    pub fn checksum(&self) -> u16 {
+        u16::from_be_bytes(self.checksum)
+    }
+
+    /// Sets the Checksum from a 16-bit value.
+    #[inline]
+    pub fn set_checksum(&mut self, checksum: u16) {
+        self.checksum = checksum.to_be_bytes();
+    }
+
+    /// Gets the Type-specific data as a 16-bit value.
+    #[inline]
+    pub fn type_specific_data(&self) -> u16 {
+        u16::from_be_bytes(self.type_specific_data)
+    }
+
+    /// Sets the Type-specific data from a 16-bit value.
+    #[inline]
+    pub fn set_type_specific_data(&mut self, data: u16) {
+        self.type_specific_data = data.to_be_bytes();
+    }
+
+    /// Calculates the total length of the Shim6 header in bytes.
+    /// Total length = (hdr_ext_len + 1) * 8.
+    #[inline]
+    pub fn total_hdr_len(&self) -> usize {
+        (self.hdr_ext_len as usize + 1) << 3
+    }
+
+    /// Calculates the length of the variable-length part of the header in bytes.
+    #[inline]
+    pub fn variable_len(&self) -> usize {
+        self.total_hdr_len().saturating_sub(Self::LEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shim6hdr_size() {
+        assert_eq!(Shim6Hdr::LEN, 8);
+        assert_eq!(Shim6Hdr::LEN, mem::size_of::<Shim6Hdr>());
+    }
+
+    #[test]
+    fn test_shim6hdr_getters_and_setters() {
+        let mut shim_hdr = Shim6Hdr {
+            next_hdr: IpProto::Ipv6NoNxt,
+            hdr_ext_len: 0,
+            p_and_type: 0,
+            type_specific_and_s: 0,
+            checksum: [0; 2],
+            type_specific_data: [0; 2],
+        };
+
+        // Test next_hdr
+        shim_hdr.set_next_hdr(IpProto::Tcp);
+        assert_eq!(shim_hdr.next_hdr(), IpProto::Tcp);
+
+        // Test hdr_ext_len
+        shim_hdr.set_hdr_ext_len(4);
+        assert_eq!(shim_hdr.hdr_ext_len(), 4);
+
+        // Test P and Type fields
+        shim_hdr.set_p(true);
+        assert!(shim_hdr.p());
+        assert_eq!(shim_hdr.p_and_type, 0x80);
+        shim_hdr.set_msg_type(0x4A); // 74
+        assert_eq!(shim_hdr.msg_type(), 0x4A);
+        assert_eq!(shim_hdr.p_and_type, 0xCA); // 11001010
+        shim_hdr.set_p(false);
+        assert!(!shim_hdr.p());
+        assert_eq!(shim_hdr.msg_type(), 0x4A);
+        assert_eq!(shim_hdr.p_and_type, 0x4A);
+
+        // Test Type-specific and S fields
+        shim_hdr.set_s(true);
+        assert!(shim_hdr.s());
+        assert_eq!(shim_hdr.type_specific_and_s, 0x01);
+        shim_hdr.set_type_specific_bits(0x75); // 1110101
+        assert_eq!(shim_hdr.type_specific_bits(), 0x75);
+        assert_eq!(shim_hdr.type_specific_and_s, 0xEB); // 11101011
+        shim_hdr.set_s(false);
+        assert!(!shim_hdr.s());
+        assert_eq!(shim_hdr.type_specific_bits(), 0x75);
+        assert_eq!(shim_hdr.type_specific_and_s, 0xEA); // 11101010
+
+        // Test checksum
+        shim_hdr.set_checksum(0x1234);
+        assert_eq!(shim_hdr.checksum(), 0x1234);
+        assert_eq!(shim_hdr.checksum, [0x12, 0x34]);
+
+        // Test type_specific_data
+        shim_hdr.set_type_specific_data(0x5678);
+        assert_eq!(shim_hdr.type_specific_data(), 0x5678);
+        assert_eq!(shim_hdr.type_specific_data, [0x56, 0x78]);
+    }
+
+    #[test]
+    fn test_shim6hdr_length_calculation() {
+        let mut shim_hdr = Shim6Hdr {
+            next_hdr: IpProto::Ipv6NoNxt,
+            hdr_ext_len: 0,
+            p_and_type: 0,
+            type_specific_and_s: 0,
+            checksum: [0; 2],
+            type_specific_data: [0; 2],
+        };
+
+        // Test with hdr_ext_len = 0
+        shim_hdr.set_hdr_ext_len(0);
+        assert_eq!(shim_hdr.total_hdr_len(), 8);
+        assert_eq!(shim_hdr.variable_len(), 0);
+
+        // Test with hdr_ext_len = 1
+        shim_hdr.set_hdr_ext_len(1);
+        assert_eq!(shim_hdr.total_hdr_len(), 16);
+        assert_eq!(shim_hdr.variable_len(), 8);
+
+        // Test with hdr_ext_len = 3
+        shim_hdr.set_hdr_ext_len(3);
+        assert_eq!(shim_hdr.total_hdr_len(), 32);
+        assert_eq!(shim_hdr.variable_len(), 24);
+
+        // Test with hdr_ext_len = 255 (max value)
+        shim_hdr.set_hdr_ext_len(255);
+        assert_eq!(shim_hdr.total_hdr_len(), (255 + 1) * 8);
+        assert_eq!(shim_hdr.variable_len(), 255 * 8);
+    }
+}

--- a/network-types/tests/integration-common/src/lib.rs
+++ b/network-types/tests/integration-common/src/lib.rs
@@ -13,6 +13,7 @@ use network_types::{
     ip::{Ipv4Hdr, Ipv6Hdr},
     mobility::MobilityHdr,
     route::{CrhHeader, RplSourceRouteHeader, SegmentRoutingHeader, Type2RoutingHeader},
+    shim6::Shim6Hdr,
     tcp::TcpHdr,
     udp::UdpHdr,
     vxlan::VxlanHdr,
@@ -43,6 +44,7 @@ pub enum PacketType {
     DestOpts = 16,
     Vxlan = 17,
     Mobility = 18,
+    Shim6 = 19,
 }
 
 /// A union to hold any of the possible parsed network headers.
@@ -68,6 +70,7 @@ pub union HeaderUnion {
     pub destopts: DestOptsHdr,
     pub vxlan: VxlanHdr,
     pub mobility: MobilityHdr,
+    pub shim6: Shim6Hdr,
 }
 
 /// The final struct sent back to user-space. It contains the type of

--- a/network-types/tests/integration-ebpf/src/main.rs
+++ b/network-types/tests/integration-ebpf/src/main.rs
@@ -23,6 +23,7 @@ use network_types::{
         CrhHeader, RoutingHeaderType, RplSourceRouteHeader, SegmentRoutingHeader,
         Type2RoutingHeader,
     },
+    shim6::Shim6Hdr,
     tcp::TcpHdr,
     udp::UdpHdr,
     vxlan::VxlanHdr,
@@ -56,6 +57,7 @@ fn u8_to_packet_type(val: u8) -> Option<PacketType> {
         16 => Some(PacketType::DestOpts),
         17 => Some(PacketType::Vxlan),
         18 => Some(PacketType::Mobility),
+        19 => Some(PacketType::Shim6),
         _ => None,
     }
 }
@@ -210,6 +212,13 @@ fn try_integration_test(ctx: TcContext) -> Result<i32, i32> {
                 data: HeaderUnion {
                     segment_routing: segment_hdr,
                 },
+            }
+        }
+        PacketType::Shim6 => {
+            let header: Shim6Hdr = ctx.load(data_offset).map_err(|_| TC_ACT_SHOT)?;
+            ParsedHeader {
+                type_: PacketType::Shim6,
+                data: HeaderUnion { shim6: header },
             }
         }
         PacketType::Crh16 | PacketType::Crh32 => {

--- a/network-types/tests/integration/src/main.rs
+++ b/network-types/tests/integration/src/main.rs
@@ -11,6 +11,7 @@ mod ipv6;
 mod mobility;
 mod rpl_source_route;
 mod segment_routing;
+mod shim6;
 mod tcp;
 mod type2;
 mod udp;
@@ -37,6 +38,9 @@ use crate::{
     segment_routing::{
         create_segment_routing_test_packet, create_segment_routing_with_tlvs_test_packet,
         verify_segment_routing_header,
+    },
+    shim6::{
+        create_shim6_test_packet, create_shim6_with_extension_test_packet, verify_shim6_header,
     },
     tcp::{create_tcp_test_packet, verify_tcp_header},
     type2::{create_type2_test_packet, verify_type2_header},
@@ -199,4 +203,20 @@ define_header_test!(
     PacketType::Vxlan,
     create_vxlan_test_packet,
     verify_vxlan_header
+);
+
+define_header_test!(
+    test_parses_shim6_header,
+    Shim6Hdr,
+    PacketType::Shim6,
+    create_shim6_test_packet,
+    verify_shim6_header
+);
+
+define_header_test!(
+    test_parses_shim6_with_extension_header,
+    Shim6Hdr,
+    PacketType::Shim6,
+    create_shim6_with_extension_test_packet,
+    verify_shim6_header
 );

--- a/network-types/tests/integration/src/shim6.rs
+++ b/network-types/tests/integration/src/shim6.rs
@@ -1,0 +1,126 @@
+use integration_common::{PacketType, ParsedHeader};
+use network_types::{ip::IpProto, shim6::Shim6Hdr};
+
+// Creates a basic Shim6 header test packet with no variable extension (hdr_ext_len = 0)
+pub fn create_shim6_test_packet() -> (Vec<u8>, Shim6Hdr) {
+    let packet_size = 1 + Shim6Hdr::LEN; // discriminator + base header (8 bytes)
+    let mut packet_data = vec![0u8; packet_size];
+
+    // Byte 0: Packet type discriminator
+    packet_data[0] = PacketType::Shim6 as u8;
+
+    // Fill fixed Shim6 header starting at byte 1
+    // Next Header: typically No Next Header for control messages
+    packet_data[1] = IpProto::Ipv6NoNxt as u8;
+    // Hdr Ext Len: 0 => total 8 bytes
+    packet_data[2] = 0;
+    // P bit (0) | Type (example 0x2A = 42)
+    packet_data[3] = 0x2A; // P=0, Type=42
+    // Type-specific (0x12) | S bit (0)
+    packet_data[4] = 0x24; // 0b0100_100 => actually we want bits<<1 with S=0; choose 0x24
+    // Checksum 0x1234
+    packet_data[5] = 0x12;
+    packet_data[6] = 0x34;
+    // Type-specific data first 2 bytes
+    packet_data[7] = 0x56;
+    packet_data[8] = 0x78;
+
+    let expected = Shim6Hdr {
+        next_hdr: IpProto::Ipv6NoNxt,
+        hdr_ext_len: 0,
+        p_and_type: 0x2A,
+        type_specific_and_s: 0x24,
+        checksum: [0x12, 0x34],
+        type_specific_data: [0x56, 0x78],
+    };
+
+    // Sanity: computed lens
+    assert_eq!(expected.total_hdr_len(), 8);
+    assert_eq!(expected.variable_len(), 0);
+
+    (packet_data, expected)
+}
+
+// Creates a Shim6 header test packet with variable extension bytes (hdr_ext_len > 0)
+pub fn create_shim6_with_extension_test_packet() -> (Vec<u8>, Shim6Hdr) {
+    // Choose hdr_ext_len = 2 => total header 24 bytes, so 16 bytes variable after base 8
+    let hdr_ext_len = 2u8;
+    let total_len = (hdr_ext_len as usize + 1) * 8;
+    let packet_size = 1 + total_len; // discriminator + full header
+    let mut packet_data = vec![0u8; packet_size];
+
+    packet_data[0] = PacketType::Shim6 as u8;
+
+    // Fixed fields
+    packet_data[1] = IpProto::Tcp as u8; // Next Header points to TCP just for variety
+    packet_data[2] = hdr_ext_len; // Hdr Ext Len
+    packet_data[3] = 0x05; // Type=5, P=0
+    packet_data[4] = (0x7F << 1) | 0; // Type-specific bits = 0x7F, S=0
+    packet_data[5] = 0xAB; // checksum
+    packet_data[6] = 0xCD;
+    packet_data[7] = 0x00; // type-specific first 2 bytes in base part
+    packet_data[8] = 0x01;
+
+    // Fill variable bytes with a pattern
+    for i in 0..(total_len - Shim6Hdr::LEN) {
+        packet_data[9 + i] = (i as u8) ^ 0xAA;
+    }
+
+    let expected = Shim6Hdr {
+        next_hdr: IpProto::Tcp,
+        hdr_ext_len,
+        p_and_type: 0x05,
+        type_specific_and_s: (0x7F << 1) as u8,
+        checksum: [0xAB, 0xCD],
+        type_specific_data: [0x00, 0x01],
+    };
+
+    // Sanity
+    assert_eq!(expected.total_hdr_len(), total_len);
+
+    (packet_data, expected)
+}
+
+// Verifier for Shim6 header parsed from eBPF
+pub fn verify_shim6_header(received: ParsedHeader, expected: Shim6Hdr) {
+    assert_eq!(received.type_, PacketType::Shim6);
+    let parsed_header: Shim6Hdr = unsafe { received.data.shim6 };
+
+    assert_eq!(
+        parsed_header.next_hdr as u8, expected.next_hdr as u8,
+        "Next Header mismatch"
+    );
+    assert_eq!(
+        parsed_header.hdr_ext_len, expected.hdr_ext_len,
+        "Hdr Ext Len mismatch"
+    );
+    assert_eq!(
+        parsed_header.p_and_type, expected.p_and_type,
+        "p_and_type mismatch"
+    );
+    assert_eq!(
+        parsed_header.type_specific_and_s, expected.type_specific_and_s,
+        "type_specific_and_s mismatch"
+    );
+    assert_eq!(
+        parsed_header.checksum, expected.checksum,
+        "Checksum mismatch"
+    );
+    assert_eq!(
+        parsed_header.type_specific_data, expected.type_specific_data,
+        "Type-specific data mismatch"
+    );
+
+    let total_hdr_len_bytes = (parsed_header.hdr_ext_len as usize + 1) * 8;
+    match parsed_header.hdr_ext_len {
+        0 => assert_eq!(
+            total_hdr_len_bytes, 8,
+            "Expected 8-byte header for hdr_ext_len=0"
+        ),
+        2 => assert_eq!(
+            total_hdr_len_bytes, 24,
+            "Expected 24-byte header for hdr_ext_len=2"
+        ),
+        other => panic!("Unexpected hdr_ext_len for Shim6 test: {}", other),
+    }
+}


### PR DESCRIPTION
Add initial Shim6 header parsing support across the workspace:
- Introduce Shim6Hdr in network-types with helpers and length calculations.
- Add to eBPF parsing to recognize and step over Shim6 headers.
- Wire Shim6 into the integration tests (including variable-length header cases).

### What changed
- network-types/src/shim6.rs (new)
  - Define Shim6Hdr matching the Shim6 control header layout:
    - Fields: next_hdr (IpProto), hdr_ext_len, p_and_type (P bit + 7-bit type), type_specific_and_s (7-bit type-specific + S bit), checksum, type_specific_data (first 2 bytes).
  - Getters/setters for fields and bitfields (P, Type, S, type-specific bits), checksum and type-specific data accessors, total_hdr_len() and variable_len().
  - Unit tests for struct size (8 bytes), bitfield manipulation, and length math (hdr_ext_len mapping to total bytes).
- mermin-ebpf/src/main.rs
  - Add parse_shim6_header that loads Shim6Hdr at the current offset, advances by total_hdr_len(), and chains to the next header via next_hdr().
  - Route IpProto::Shim6 to parse_shim6_header in the main parse loop.
  - Unit tests for basic (hdr_ext_len=0), extended (hdr_ext_len=2 → 24 bytes), and OOB scenarios.
- network-types/tests/integration-common/src/lib.rs
  - Add PacketType::Shim6 (discriminator 18) and HeaderUnion::shim6.
- network-types/tests/integration-ebpf/src/main.rs
  - Map discriminator 18 to PacketType::Shim6 and load/return Shim6Hdr in ParsedHeader.
- network-types/tests/integration/src/
  - Add shim6.rs helpers to craft Shim6 test packets (with and without variable extension) and verify parsed headers.
  - Register two integration tests in main.rs for Shim6 base and extended headers.

### Testing
- Unit tests
  - network-types: shim6.rs validates size, bitfields, checksum/data setters, and length calculations.
  - mermin-ebpf: parser unit tests cover success and failure cases for Shim6 parsing.
- Integration tests (userspace + eBPF harness)
  - Added tests to validate ParsedHeader contents and total header length for hdr_ext_len=0 (8 bytes) and hdr_ext_len=2 (24 bytes).