### PR TITLE
fix: Wrong arch in the GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,8 @@ jobs:
         with:
           platforms: ${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }}
           target: ${{ matrix.target }}
-          cache_from: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }}-${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }}
-          cache_to: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }}-${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }},mode=max
+          cache_from: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-ci-${{ matrix.target }}-${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }}
+          cache_to: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-ci-${{ matrix.target }}-${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }},mode=max
 
   all_checks:
     name: All Checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,8 @@ jobs:
 
   docker_build_push:
     name: Docker build/push
-    needs: [release]
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    runs-on: ubuntu-latest-8c
+    timeout-minutes: 90
     permissions:
       contents: read
       packages: write
@@ -107,14 +106,8 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        runner: [ubuntu-latest, ubuntu-latest-arm]
         target: [runner, runner-debug]
     env:
-      RUNNER_PLATFORM: |
-        {
-            "ubuntu-latest": "linux/amd64",
-            "ubuntu-latest-arm": "linux/arm64"
-        }
       TARGET_IMAGE_TAG: |
         {
             "runner": "v${{ needs.release.outputs.new_release_version }}",
@@ -142,10 +135,10 @@ jobs:
           registry: ghcr.io
           image: ${{ github.repository }}
           tag: ${{ fromJson(env.TARGET_IMAGE_TAG)[matrix.target] }}
-          platforms: ${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }}
+          platforms: linux/amd64,linux/arm64
           target: ${{ matrix.target }}
           push: true
-          cache_from: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }}-${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }}
-          cache_to: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }}-${{ fromJson(env.RUNNER_PLATFORM)[matrix.runner] }},mode=max
+          cache_from: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }}
+          cache_to: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }},mode=max
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Unfortunately parallel multi-arch builds for the same tag have not worked out. GHCR does not append new arch to an artifact with the same version, but makes another package release instead.

Solution is to build multiple platforms for the same tag on a single host (runner)

Additionally add missing `v` prefix in debug image

GHA Runners:
* 8 cores ~ 60min
* 16 cores ~43min