### PR TITLE
Add IP-in-IP support and expose try_mermin to tests

### DIFF
--- a/mermin-ebpf/src/main.rs
+++ b/mermin-ebpf/src/main.rs
@@ -60,7 +60,7 @@ pub enum Error {
 #[cfg(not(feature = "test"))]
 #[classifier]
 pub fn mermin(ctx: TcContext) -> i32 {
-    let (res, ctx) = try_mermin(ctx);
+    let (ctx, res) = try_mermin(ctx);
     match res {
         Ok((binding, packet_meta)) => {
             unsafe {
@@ -75,7 +75,7 @@ pub fn mermin(ctx: TcContext) -> i32 {
     }
 }
 
-fn try_mermin(ctx: TcContext) -> (Result<(i32, PacketMeta), ()>, TcContext) {
+fn try_mermin(ctx: TcContext) -> (TcContext, Result<(i32, PacketMeta), ()>) {
     const MAX_HEADER_PARSE_DEPTH: usize = 12;
 
     // Information for building flow records (prioritizes innermost headers).
@@ -248,7 +248,7 @@ fn try_mermin(ctx: TcContext) -> (Result<(i32, PacketMeta), ()>, TcContext) {
                 break;
             }
             HeaderType::StopProcessing => break, // Graceful stop
-            HeaderType::ErrorOccurred => return (Ok((TC_ACT_PIPE, PacketMeta::default())), ctx), // Error, pass packet
+            HeaderType::ErrorOccurred => return (ctx, Ok((TC_ACT_PIPE, PacketMeta::default()))), // Error, pass packet
         };
 
         if result.is_err() {
@@ -276,7 +276,7 @@ fn try_mermin(ctx: TcContext) -> (Result<(i32, PacketMeta), ()>, TcContext) {
         tunnel_proto,
     };
 
-    (Ok((TC_ACT_PIPE, packet_meta)), ctx)
+    (ctx, Ok((TC_ACT_PIPE, packet_meta)))
 }
 
 struct Parser {
@@ -1229,7 +1229,7 @@ mod tests {
         let ctx = TcContext::new(packet);
 
         // Call try_mermin and get the populated packet_meta
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -1281,7 +1281,7 @@ mod tests {
         .concat();
 
         let ctx = TcContext::new(packet.clone());
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -2154,7 +2154,7 @@ mod tests {
 
         let packet: Vec<u8> = [eth, outer_v6.clone(), inner_v6.clone(), tcp].concat();
         let ctx = TcContext::new(packet.clone());
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -2199,7 +2199,7 @@ mod tests {
 
         let packet: Vec<u8> = [eth, outer_v4.clone(), inner_v6.clone(), tcp].concat();
         let ctx = TcContext::new(packet);
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -2264,7 +2264,7 @@ mod tests {
 
         let packet: Vec<u8> = [eth, outer.clone(), middle.clone(), inner.clone(), tcp].concat();
         let ctx = TcContext::new(packet);
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -2305,7 +2305,7 @@ mod tests {
 
         let packet: Vec<u8> = [eth, outer.clone(), middle, inner.clone(), tcp].concat();
         let ctx = TcContext::new(packet);
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -2364,7 +2364,7 @@ mod tests {
         ]
         .concat();
         let ctx = TcContext::new(packet);
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 
@@ -2420,7 +2420,7 @@ mod tests {
         ]
         .concat();
         let ctx = TcContext::new(packet);
-        let (result, _ctx) = try_mermin(ctx);
+        let (_ctx, result) = try_mermin(ctx);
         assert!(result.is_ok());
         let (_code, packet_meta) = result.unwrap();
 


### PR DESCRIPTION
### Summary
This PR enhances the packet parser in the eBPF agent to recognize and extract tunnel metadata for IP-in-IP encapsulation, and makes `try_mermin` callable in tests to inspect the resulting `PacketMeta` alongside the TC return code.

I made these changes to try_mermin to make it a bit easier to test more complicated sequence of packets inside the mermin-ebpf test suite. SURELY, there are some ramifications of this change that I'm not fully aware of. Still, I thought this would be a convenient way to run tests in development and ensure our parsing logic is working. We can always revert try_mermin to its original state after confirming the test functionality. 

### What changed
- IP-in-IP detection and metadata capture
  - IPv4 outer header with `proto` = `Ipv4` or `Ipv6` is treated as a tunnel and recorded in `PacketMeta.tunnel_*` fields.
  - IPv6 outer header with `next_hdr` = `Ipv4` or `Ipv6` is similarly treated as a tunnel and recorded.
- Test access to parsing results
  - `try_mermin` now returns `(i32, PacketMeta)` and is directly callable from tests, enabling validation of parsed fields.
- Parser behavior around encapsulations
  - If there are multiple IP-in-IP encapsulations, the outer values are only set once, and the inner values are repeatedly overwritten until the innermost header. Thus, only the outermost and innermost would be saved.
- Unit tests added (host test shim usage)
  - Added tests for IPv4-in-IPv4 and IPv6→IPv4 (IPv4-in-IPv6) verifying tunnel and inner flow fields, ports, and protocol handling.
     - Can add more tests for multiple encapsulation and other combinations, but I wanted feedback on how I'm doing the tests first.

### Notes
- The eBPF entrypoint `mermin` remains unchanged for runtime; the expanded return from `try_mermin` is used for tests only.
- Tunnel L4 ports are captured before inner L4 parsing and remain `0` for IP-in-IP, as expected.
