### PR TITLE
feat(ENG-172): Attach mermin to multiple interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1295,15 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
@@ -1534,7 +1549,7 @@ dependencies = [
  "figment",
  "futures",
  "humantime",
- "ipnetwork",
+ "ipnetwork 0.21.1",
  "k8s-openapi",
  "kube",
  "kube-runtime",
@@ -1542,6 +1557,7 @@ dependencies = [
  "log",
  "mermin-common",
  "network-types",
+ "pnet",
  "serde",
  "sha1",
  "socket2 0.5.10",
@@ -1597,6 +1613,12 @@ dependencies = [
 [[package]]
 name = "network-types"
 version = "0.1.0"
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1813,6 +1835,97 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pnet"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130c5b738eeda2dc5796fe2671e49027e6935e817ab51b930a36ec9e6a206a64"
+dependencies = [
+ "ipnetwork 0.20.0",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
+name = "pnet_base"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cf6fb3ab38b68d01ab2aea03ed3d1132b4868fa4e06285f29f16da01c5f4c"
+dependencies = [
+ "no-std-net",
+]
+
+[[package]]
+name = "pnet_datalink"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad5854abf0067ebbd3967f7d45ebc8976ff577ff0c7bd101c4973ae3c70f98fe"
+dependencies = [
+ "ipnetwork 0.20.0",
+ "libc",
+ "pnet_base",
+ "pnet_sys",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_macros"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688b17499eee04a0408aca0aa5cba5fc86401d7216de8a63fdf7a4c227871804"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea925b72f4bd37f8eab0f221bbe4c78b63498350c983ffa9dd4bcde7e030f56"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a005825396b7fe7a38a8e288dbc342d5034dac80c15212436424fef8ea90ba"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
+name = "pnet_sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417c0becd1b573f6d544f73671070b039051e5ad819cc64aa96377b536128d00"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2637e14d7de974ee2f74393afccbc8704f3e54e6eb31488715e72481d1662cc3"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2851,6 +2964,28 @@ dependencies = [
  "rustix 0.38.44",
  "winsafe",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/charts/mermin/templates/configmap.yaml
+++ b/charts/mermin/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mermin.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mermin.labels" . | nindent 4 }}
+data:
+  mermin-config.yaml: |
+    {{- toYaml .Values.merminConfig | nindent 4 }}

--- a/charts/mermin/templates/daemonset.yaml
+++ b/charts/mermin/templates/daemonset.yaml
@@ -43,6 +43,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/etc/mermin/mermin-config.yaml"
           env:
             - name: POD_NODE_NAME
               valueFrom:
@@ -83,8 +86,14 @@ spec:
             - name: bpf-fs
               mountPath: /sys/fs/bpf
               readOnly: false
+            - name: mermin-config-volume
+              mountPath: /etc/mermin
+              readOnly: true
       volumes:
         - name: bpf-fs
           hostPath:
             path: /sys/fs/bpf
             type: DirectoryOrCreate
+        - name: mermin-config-volume
+          configMap:
+            name: {{ include "mermin.fullname" . }}-config

--- a/local/values.yaml
+++ b/local/values.yaml
@@ -2,3 +2,6 @@ fullNameOverride: mermin
 image:
   repository: mermin
   tag: latest
+merminConfig:
+  interface:
+    - eth0

--- a/mermin-common/src/lib.rs
+++ b/mermin-common/src/lib.rs
@@ -20,6 +20,7 @@ pub enum IpAddrType {
 #[repr(C, align(8))]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct PacketMeta {
+    pub ifindex: u32,
     // Fields with 16-byte alignment
     // ---
     /// Source IPv6 address (innermost)
@@ -95,7 +96,7 @@ mod tests {
     // Test FlowRecord size and alignment
     #[test]
     fn test_flow_record_layout() {
-        let expected_size = 96;
+        let expected_size = 104;
         let actual_size = size_of::<PacketMeta>();
 
         assert_eq!(
@@ -137,6 +138,7 @@ mod tests {
         let tunnel_dst_port: u16 = 81;
 
         let record = PacketMeta {
+            ifindex: 1,
             src_ipv6_addr: src_ipv6_val,
             dst_ipv6_addr: dst_ipv6_val,
             src_ipv4_addr: src_ipv4_val,
@@ -157,6 +159,7 @@ mod tests {
         };
 
         // Test field access
+        assert_eq!(record.ifindex, 1);
         assert_eq!(record.src_ipv4_addr, src_ipv4_val);
         assert_eq!(record.dst_ipv4_addr, dst_ipv4_val);
         assert_eq!(record.src_ipv6_addr, src_ipv6_val);

--- a/mermin-ebpf/src/main.rs
+++ b/mermin-ebpf/src/main.rs
@@ -220,7 +220,9 @@ fn try_mermin(ctx: TcContext) -> Result<i32, ()> {
         }
     }
 
+    let ifindex = unsafe { (*ctx.skb.skb).ifindex };
     let packet_meta = PacketMeta {
+        ifindex,
         src_ipv6_addr,
         dst_ipv6_addr,
         tunnel_src_ipv6_addr,

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -42,6 +42,7 @@ tracing = "0.1.41"
 humantime = "2.2.0"
 base64 = "0.21"
 sha1 = "0.10"
+pnet = "0.34"
 [build-dependencies]
 anyhow = { workspace = true }
 aya-build = { workspace = true }


### PR DESCRIPTION
## Description

This pull request enhances the mermin eBPF network monitoring agent by adding support for attaching to multiple network interfaces and improving packet logging with interface identification.

**Key changes:**
- **Multi-interface support**: Modified the agent to attach eBPF programs to all interfaces specified in the configuration, rather than just the first one
- **Interface tracking**: Added interface index mapping using the `pnet` crate to identify which interface packets originate from
- **Enhanced logging**: Updated packet logs to include the source interface name for better observability
- **Kubernetes configuration**: Added ConfigMap and DaemonSet templates to support configuration-driven interface selection in Kubernetes deployments
- **Data structure updates**: Extended `PacketMeta` struct with `ifindex` field to track packet source interface

**Problem solved:**
Previously, the agent could only monitor traffic on a single interface (the first one in the config). This enhancement allows monitoring multiple interfaces simultaneously while providing clear identification of packet sources in logs.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):

## How Has This Been Tested?

The changes have been tested through:

- **Code compilation**: All workspace members build successfully with the new dependencies
- **Integration testing**: eBPF program attachment to multiple interfaces verified
- **Kubernetes deployment**: ConfigMap and DaemonSet templates tested in local kind cluster
- **Interface mapping**: Verified interface index to name mapping works correctly with pnet crate
- **Log verification**: Confirmed enhanced logging includes interface names in packet traces

- **Environment**:
    - OS: Debian 12
    - Rust: 1.88.0
    - Kubernetes: kind cluster
    - Network interfaces: eth0 (primary test interface)

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.

## Screenshots (if applicable)

<img width="1162" height="130" alt="Screenshot 2025-09-11 at 8 39 25 PM" src="https://github.com/user-attachments/assets/ae6dd158-c610-4e81-a81d-46ed7c52b227" />


## Additional Notes

**Dependencies added:**
- `pnet = "0.34"` for network interface enumeration and management

**Configuration changes:**
- The `interface` field in configuration now supports multiple interfaces as an array
- Kubernetes deployments now use ConfigMap-driven configuration via `/etc/mermin/mermin-config.yaml`

**Potential considerations:**
- The interface mapping is built at startup; dynamic interface changes during runtime are not automatically detected
- Each configured interface will have the eBPF program attached, which may increase resource usage proportionally
- Interface names must exist on the target system, or the program will fail to attach

**Areas for reviewer focus:**
- Verify the interface index mapping logic is robust
- Review the channel communication changes for the additional interface name parameter