### PR TITLE
fix(ci): "fetch-depth" should be 0 for releases

### DIFF
--- a/.github/workflows/release_mermin-netobserv-os.yml
+++ b/.github/workflows/release_mermin-netobserv-os.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Prepare Release
         id: prepare_release
         uses: elastiflow/gha-reusable/actions/prepare-release@v0

--- a/.github/workflows/release_mermin.yml
+++ b/.github/workflows/release_mermin.yml
@@ -52,6 +52,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Prepare Release
         id: prepare_release
         uses: elastiflow/gha-reusable/actions/prepare-release@v0


### PR DESCRIPTION
## Description

Since underlying GHA action uses locally cloned repository all references must be fetched (`fetch-depth: 0`) for it to work correctly

## Type of Change

<!-- Please check the box that applies to this pull request. -->

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):

## How Has This Been Tested?

With local GitHub Actions emuilator

## Checklist

<!-- Confirm the following by checking the boxes. -->

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.

