### PR TITLE
refactor: remove pipeline name from configuration

### DIFF
--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -3,7 +3,7 @@ global_opt = "global_opt_value"
 /*
   Agent config for type "flows" with name main
 */
-agent "traces" "main" {
+agent "traces" {
   /*
     Define which flow will be processed and sent to the output.
     Impacts the "In-mem K8s objects cache" build by K8s informer (https://www.plural.sh/blog/manage-kubernetes-events-informers/)
@@ -44,7 +44,7 @@ agent "traces" "main" {
   }
 
   # Include configurations
-  flow_connection = "flow.connection.main"
+  flow_connection = "flow.connection"
   network_interface = {
     include_names = [] # ["lo", "eth0"], empty list means all
     exclude_names = [] # ["lo", "eth0"], empty list means none
@@ -55,8 +55,8 @@ agent "traces" "main" {
 
   include_network_transports = [] # ["tcp", "udp"], empty list means all
   exclude_network_transports = [] # ["tcp", "udp"], empty list means none
-  include_network_types      = [] # ["ipv4", "ipv6"], empty list means all
-  exclude_network_types      = [] # ["ipv4", "ipv6"], empty list means none
+  include_network_types = [] # ["ipv4", "ipv6"], empty list means all
+  exclude_network_types = [] # ["ipv4", "ipv6"], empty list means none
 
   discovery_owner    = "discovery.k8s_owner.main"
   discovery_selector = "discovery.k8s_selector.main"
@@ -69,7 +69,7 @@ agent "traces" "main" {
 
 # Network Filtering options, includes but not limited to https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#network-attributes
 
-flow "connection" "main" {
+flow "connection" {
   include_states = [] # close_wait, empty list means all
   exclude_states = [] # close_wait, empty list means none
 }
@@ -89,7 +89,7 @@ flow "span" "destination" {
 }
 
 # Discovery config of type "k8s_owner" with name "main"
-discovery "k8s_owner" "main" {
+discovery "k8s_owner" {
   /*
     Limit the ownerReference walk depth, e.g. If `walk_max_depth = 3`
     If Pod <- Job <- CronJob <- Controller1 <- Controller2 <- Controller3 <- ...
@@ -116,14 +116,14 @@ discovery "k8s_owner" "main" {
 }
 
 # Discovery config of type "k8s_selector" with name "main"
-discovery "k8s_selector" "main" {
+discovery "k8s_selector" {
   /*
     Extract selector fields from the NetworkPolicy definition, select Pods (`to` field) based on the selectors,
     attach NetworkPolicy metadata to flows related to the selected pods
   */
   k8s_object {
-    kind                             = "NetworkPolicy" # case insensitive
-    to                               = "Pod"           # case insensitive
+    kind = "NetworkPolicy" # case insensitive
+    to = "Pod"           # case insensitive
     selector_match_labels_field      = "spec.podSelector.matchLabels"
     selector_match_expressions_field = "spec.podSelector.matchExpressions"
   }
@@ -133,8 +133,8 @@ discovery "k8s_selector" "main" {
     attach Service metadata to flows related to the selected pods
   */
   k8s_object {
-    kind                        = "Service" # case insensitive
-    to                          = "Pod"     # case insensitive
+    kind = "Service" # case insensitive
+    to = "Pod"     # case insensitive
     selector_match_labels_field = "spec.selector"
   }
 }
@@ -149,9 +149,9 @@ association "k8s_flow_attributes" "source" {
   */
   extract {
     metadata = [
-      "[*].metadata.name",      # All kinds, metadata.name
+      "[*].metadata.name", # All kinds, metadata.name
       "[*].metadata.namespace", # All kinds, metadata.namespace
-      "[*].metadata.uid",       # All kinds, metadata.uid (if present)
+      "[*].metadata.uid", # All kinds, metadata.uid (if present)
     ]
 
     /*
@@ -282,9 +282,9 @@ association "k8s_flow_attributes" "source" {
 association "k8s_flow_attributes" "destination" {
   extract {
     metadata = [
-      "[*].metadata.name",      # All kinds, metadata.name
+      "[*].metadata.name", # All kinds, metadata.name
       "[*].metadata.namespace", # All kinds, metadata.namespace
-      "pod.metadata.uid",       # All kinds, metadata.uid
+      "pod.metadata.uid", # All kinds, metadata.uid
     ]
 
     /*
@@ -420,7 +420,7 @@ exporter "otlp" "main" {
   auth {
     basic = {
       user = "USERNAME"
-      pass = env("USER_SPECIFIED_ENV_VAR_TRITON_PASS")
+      pass = "USER_SPECIFIED_ENV_VAR_TRITON_PASS"
     }
   }
 

--- a/examples/local/config.hcl
+++ b/examples/local/config.hcl
@@ -37,16 +37,16 @@ metrics {
 # Flow Span configuration
 span {
   max_record_interval = "60s"
-  generic_timeout = "30s"
-  icmp_timeout = "10s"
-  tcp_timeout = "20s"
-  tcp_fin_timeout = "5s"
-  tcp_rst_timeout = "5s"
-  udp_timeout = "60s"
+  generic_timeout     = "30s"
+  icmp_timeout        = "10s"
+  tcp_timeout         = "20s"
+  tcp_fin_timeout     = "5s"
+  tcp_rst_timeout     = "5s"
+  udp_timeout         = "60s"
 }
 
 # Specify which exporters are enabled
-agent "traces" "main" {
+agent "traces" {
   exporters = [
     "exporter.stdout.main"
   ]

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
         properties: props, ..
     } = runtime;
 
-    let span_level = props.internal_traces.span_level;
+    let span_level = props.internal_trace.span_level;
     let (otlp_agent_exporters, stdout_agent_exporters) = props.get_agent_exporters();
     let (otlp_internal_exporters, stdout_internal_exporters) = props.get_internal_exporters();
 


### PR DESCRIPTION
## Description

This pull request refactors the configuration system to remove the concept of multiple, named trace pipelines (e.g., `agent.traces.main`, `agent.traces.foo`). The design is simplified to support a single, primary agent pipeline and a single, internal trace pipeline, which aligns with our current requirements and reduces complexity for both users and developers.

This change introduces a simpler, more direct configuration schema:

**Before:**
```yaml
agent:
  traces:
    main: # <-- This level of nesting is removed
      exporters: [...]
      source: ...
```

**After:**
```yaml
agent:
  traces: # <-- Configuration is now directly under `traces`
    exporters: [...]
    source: ...
```

To support this, the configuration structs in `conf.rs` and the resolved property structs in `props.rs` have been significantly simplified:
- `TracesConfig` and other multi-pipeline structs have been removed.
- They are replaced by specific, purpose-built structs: `AgentTraceOptions` (for the rich agent pipeline) and `InternalTraceOptions` (for the simple internal pipeline).
- The `Properties` struct no longer holds `HashMap`s of resolved pipelines, but single instances (`agent_trace` and `internal_trace`).
- The resolution logic in `Properties::new()` is now cleaner, more direct, and no longer needs to loop over maps.

## Type of Change

<!-- Please check the box that applies to this pull request. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):

## How Has This Been Tested?

- **Unit Tests**:
  - Updated existing unit tests in `conf.rs` and `props.rs` that were testing the old multi-pipeline structure.
  - Tests for serialization, default value creation, and the `reload()` method were refactored to use the new, simplified `Conf` and `Properties` structs.

- **Manual Testing**:
  1. Created a `config.hcl` file using the new, simplified format (without the `main:` pipeline name).
  2. Ran the `mermin` application, pointing to the new configuration file via the `--config` flag.
  3. Verified that the application starts without any configuration parsing errors.
  4. Checked the startup logs (`DEBUG` level) to confirm that the agent exporters and internal exporters are correctly identified and initialized from their respective configuration blocks.

- **Environment**:
    - OS: Debian 12
    - Rust: 1.88.0

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.

## Evidence 

Resulting parsed and resolved configuration:

```
[mermin/src/main.rs:45:5] &props = Properties {
    interfaces: [
        "eth0",
    ],
    resolved_interfaces: [
        "eth0",
    ],
    auto_reload: false,
    log_level: Level(
        Info,
    ),
    api: ApiConf {
        enabled: true,
        listen_address: "0.0.0.0",
        port: 8080,
    },
    metrics: MetricsConf {
        enabled: true,
        listen_address: "0.0.0.0",
        port: 10250,
    },
    packet_channel_capacity: 1024,
    packet_worker_count: 2,
    shutdown_timeout: 5s,
    span: SpanOptions {
        max_record_interval: 60s,
        generic_timeout: 30s,
        icmp_timeout: 10s,
        tcp_timeout: 20s,
        tcp_fin_timeout: 5s,
        tcp_rst_timeout: 5s,
        udp_timeout: 60s,
    },
    agent_trace: AgentTrace {
        exporters: [
            Stdout(
                StdoutExporterOptions {
                    format: "json",
                },
            ),
            Otlp(
                OtlpExporterOptions {
                    scheme: "http",
                    address: "example.com",
                    port: 4317,
                    protocol: Grpc,
                    connection_timeout: 10s,
                    auth: Some(
                        AuthOptions {
                            basic: Some(
                                BasicAuthOptions {
                                    user: "USERNAME",
                                    pass: "USER_SPECIFIED_ENV_VAR_TRITON_PASS",
                                },
                            ),
                        },
                    ),
                    tls: Some(
                        TlsOptions {
                            enabled: true,
                            insecure: false,
                            ca_cert: Some(
                                "/etc/certs/ca.crt",
                            ),
                            client_cert: Some(
                                "/etc/certs/cert.crt",
                            ),
                            client_key: Some(
                                "/etc/certs/cert.key",
                            ),
                        },
                    ),
                },
            ),
        ],
    },
    internal_trace: InternalTrace {
        span_level: Full,
        exporters: [],
    },
    config_path: Some(
        "charts/mermin/config/examples/config.hcl",
    ),
}
```


## Additional Notes

- **IMPORTANT:** This is a **breaking change** for the configuration file format. Any existing `config.yaml` or `config.hcl` files will need to be updated to remove the named pipeline level (e.g., `main:`).

- **Review Focus:** Please pay close attention to the new struct design in `conf.rs` (`AgentOptions`, `InternalTraceOptions`) and the simplified resolution logic in `props.rs` (`Properties::new`). The goal was to make this flow more direct and easier to follow.

- No new external dependencies have been added. This is purely a structural refactoring.