### PR TITLE
chore: Config syntax suggestion

### DIFF
--- a/charts/mermin/config/examples/config.yaml
+++ b/charts/mermin/config/examples/config.yaml
@@ -234,6 +234,15 @@ attributes:
                     - '[*].metadata.name'
                     - '[*].metadata.namespace'
                     - '[*].metadata.uid'
+    select:
+        - attr: flow_ipv4_*
+          exclude:
+            - foobar
+          include:
+            - '*'
+        - attr: flow_ipv6_tcp
+          include:
+            - baz
 auto_reload: false
 discovery:
     exclude_instrument: []

--- a/charts/mermin/config/examples/temp.hcl
+++ b/charts/mermin/config/examples/temp.hcl
@@ -518,27 +518,25 @@ attributes {
 
 # OTLP exporter configuration
 # See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
-otel {
-  traces = {
-    export = {
-      endpoint = "http://otelcol:4317"
-      protocol = "grpc"
-      timeout  = "10s"
+otel "traces" {
+  export = {
+    endpoint = "http://otelcol:4317"
+    protocol = "grpc"
+    timeout  = "10s"
 
-      auth = {
-        basic = {
-          user = "USERNAME"
-          pass = "PASSWORD"
-        }
+    auth = {
+      basic = {
+        user = "USERNAME"
+        pass = "PASSWORD"
       }
+    }
 
-      tls = {
-        enabled     = false
-        insecure    = false
-        ca_cert     = "/etc/certs/ca.crt"
-        client_cert = "/etc/certs/cert.crt"
-        client_key  = "/etc/certs/cert.key"
-      }
+    tls = {
+      enabled     = false
+      insecure    = false
+      ca_cert     = "/etc/certs/ca.crt"
+      client_cert = "/etc/certs/cert.crt"
+      client_key  = "/etc/certs/cert.key"
     }
   }
 }


### PR DESCRIPTION
## Description

* Re-generate YAML
* Strip whitespaces, `hcl format`
* Named "filter" blocks
  No changes to underlying structure
* Misused `select` block in `attributes.kubernetes.source`/`attributes.kubernetes.destination`
* "association" blocks to be a list rather than a map.
  Instead of using `attributes.kubernetes.source.pod` we should have a list of associations that defines how to map K8s attrs to a flow, it seems to be more idiomatic, or we use  "named by kind" association blocks, but in this case we should drop the "kind" from association block itself. E.g:
  ```hcl
        pod {
          sources = [
            { from = "flow", name = "source.ip", to = ["status.podIP", "status.podIPs[*]", "status.hostIP", "status.hostIPs[*]"] },
            { from = "flow", name = "source.port", to = ["spec.containers[*].ports[*].containerPort", "spec.containers[*].ports[*].hostPort"] },
            { from = "flow", name = "network.transport", to = ["spec.containers[*].ports[*].protocol"] },
          ]
        }
  ```
  vs
  ```hcl
        association {
          sources = [
            { from = "flow", name = "source.ip", to = ["pod.status.podIP", "pod.status.podIPs[*]", "pod.status.hostIP", "pod.status.hostIPs[*]"] },
            { from = "flow", name = "source.port", to = ["pod.spec.containers[*].ports[*].containerPort", "pod.spec.containers[*].ports[*].hostPort"] },
            { from = "flow", name = "network.transport", to = ["pod.spec.containers[*].ports[*].protocol"] },
          ]
        }
  ```
  The later feels more idiomatic to me.
* Add OBI's "select"
* Use named "otel" block
  Underlying structure should stay same whilst improving readability.