### PR TITLE
chore: remove unused tls enabled

### DIFF
--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -33,7 +33,6 @@ internal "traces" {
     }
 
     tls = {
-      enabled     = false
       insecure    = false
       ca_cert     = "/etc/certs/ca.crt"
       client_cert = "/etc/certs/cert.crt"
@@ -584,7 +583,6 @@ export "traces" {
     }
 
     tls = {
-      enabled     = false
       insecure    = false
       ca_cert     = "/etc/certs/ca.crt"
       client_cert = "/etc/certs/cert.crt"

--- a/charts/mermin/config/examples/config.yaml
+++ b/charts/mermin/config/examples/config.yaml
@@ -1,376 +1,373 @@
 api:
-    enabled: true
-    listen_address: 0.0.0.0
-    port: 8080
+  enabled: true
+  listen_address: 0.0.0.0
+  port: 8080
 attributes:
-    destination:
-        k8s:
-            association:
-                endpoint:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - subsets[*].addresses[*].ip
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - subsets[*].ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - subsets[*].ports[*].protocol
-                endpointslice:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - endpoints[*].addresses[*]
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - ports[*].protocol
-                gateway:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - spec.addresses[*].value
-                            - status.addresses[*].value
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - spec.listeners[*].port
-                ingress:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - status.loadBalancer.ingress[*].ip
-                            - status.loadBalancer.ingress[*].hostname
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - spec.defaultBackend.service.port
-                            - spec.rules[*].http.paths[*].backend.service.port.number
-                networkpolicy:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - spec.ingress[*].from[*].ipBlock.cidr
-                            - spec.egress[*].to[*].ipBlock.cidr
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - spec.ingress[*].ports[*].port
-                            - spec.egress[*].ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - spec.ingress[*].ports[*].protocol
-                            - spec.egress[*].ports[*].protocol
-                node:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - status.addresses[*].address
-                pod:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - status.podIP
-                            - status.podIPs[*]
-                            - status.hostIP
-                            - status.hostIPs[*]
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - spec.containers[*].ports[*].containerPort
-                            - spec.containers[*].ports[*].hostPort
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - spec.containers[*].ports[*].protocol
-                service:
-                    sources:
-                        - from: flow
-                          name: destination.ip
-                          to:
-                            - spec.clusterIP
-                            - spec.clusterIPs[*]
-                            - spec.externalIPs[*]
-                            - spec.loadBalancerIP
-                            - spec.externalName
-                        - from: flow
-                          name: destination.port
-                          to:
-                            - spec.ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - spec.ports[*].protocol
-                        - from: flow
-                          name: network.type
-                          to:
-                            - spec.ipFamilies[*]
-            extract:
-                metadata:
-                    - '[*].metadata.name'
-                    - '[*].metadata.namespace'
-                    - pod.metadata.uid
-    source:
-        k8s:
-            association:
-                endpoint:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - subsets[*].addresses[*].ip
-                        - from: flow
-                          name: source.port
-                          to:
-                            - subsets[*].ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - subsets[*].ports[*].protocol
-                endpointslice:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - endpoints[*].addresses[*]
-                        - from: flow
-                          name: source.port
-                          to:
-                            - ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - ports[*].protocol
-                        - from: flow
-                          name: network.type
-                          to:
-                            - addressType
-                gateway:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - spec.addresses[*].value
-                            - status.addresses[*].value
-                        - from: flow
-                          name: source.port
-                          to:
-                            - spec.listeners[*].port
-                ingress:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - status.loadBalancer.ingress[*].ip
-                            - status.loadBalancer.ingress[*].hostname
-                        - from: flow
-                          name: source.port
-                          to:
-                            - spec.defaultBackend.service.port
-                            - spec.rules[*].http.paths[*].backend.service.port.number
-                networkpolicy:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - spec.ingress[*].from[*].ipBlock.cidr
-                            - spec.egress[*].to[*].ipBlock.cidr
-                        - from: flow
-                          name: source.port
-                          to:
-                            - spec.ingress[*].ports[*].port
-                            - spec.egress[*].ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - spec.ingress[*].ports[*].protocol
-                            - spec.egress[*].ports[*].protocol
-                node:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - status.addresses[*].address
-                pod:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - status.podIP
-                            - status.podIPs[*]
-                            - status.hostIP
-                            - status.hostIPs[*]
-                        - from: flow
-                          name: source.port
-                          to:
-                            - spec.containers[*].ports[*].containerPort
-                            - spec.containers[*].ports[*].hostPort
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - spec.containers[*].ports[*].protocol
-                service:
-                    sources:
-                        - from: flow
-                          name: source.ip
-                          to:
-                            - spec.clusterIP
-                            - spec.clusterIPs[*]
-                            - spec.externalIPs[*]
-                            - spec.loadBalancerIP
-                            - spec.externalName
-                        - from: flow
-                          name: source.port
-                          to:
-                            - spec.ports[*].port
-                        - from: flow
-                          name: network.transport
-                          to:
-                            - spec.ports[*].protocol
-                        - from: flow
-                          name: network.type
-                          to:
-                            - spec.ipFamilies[*]
-            extract:
-                metadata:
-                    - '[*].metadata.name'
-                    - '[*].metadata.namespace'
-                    - '[*].metadata.uid'
+  destination:
+    k8s:
+      association:
+        endpoint:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - subsets[*].addresses[*].ip
+            - from: flow
+              name: destination.port
+              to:
+                - subsets[*].ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - subsets[*].ports[*].protocol
+        endpointslice:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - endpoints[*].addresses[*]
+            - from: flow
+              name: destination.port
+              to:
+                - ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - ports[*].protocol
+        gateway:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - spec.addresses[*].value
+                - status.addresses[*].value
+            - from: flow
+              name: destination.port
+              to:
+                - spec.listeners[*].port
+        ingress:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - status.loadBalancer.ingress[*].ip
+                - status.loadBalancer.ingress[*].hostname
+            - from: flow
+              name: destination.port
+              to:
+                - spec.defaultBackend.service.port
+                - spec.rules[*].http.paths[*].backend.service.port.number
+        networkpolicy:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - spec.ingress[*].from[*].ipBlock.cidr
+                - spec.egress[*].to[*].ipBlock.cidr
+            - from: flow
+              name: destination.port
+              to:
+                - spec.ingress[*].ports[*].port
+                - spec.egress[*].ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - spec.ingress[*].ports[*].protocol
+                - spec.egress[*].ports[*].protocol
+        node:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - status.addresses[*].address
+        pod:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - status.podIP
+                - status.podIPs[*]
+                - status.hostIP
+                - status.hostIPs[*]
+            - from: flow
+              name: destination.port
+              to:
+                - spec.containers[*].ports[*].containerPort
+                - spec.containers[*].ports[*].hostPort
+            - from: flow
+              name: network.transport
+              to:
+                - spec.containers[*].ports[*].protocol
+        service:
+          sources:
+            - from: flow
+              name: destination.ip
+              to:
+                - spec.clusterIP
+                - spec.clusterIPs[*]
+                - spec.externalIPs[*]
+                - spec.loadBalancerIP
+                - spec.externalName
+            - from: flow
+              name: destination.port
+              to:
+                - spec.ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - spec.ports[*].protocol
+            - from: flow
+              name: network.type
+              to:
+                - spec.ipFamilies[*]
+      extract:
+        metadata:
+          - "[*].metadata.name"
+          - "[*].metadata.namespace"
+          - pod.metadata.uid
+  source:
+    k8s:
+      association:
+        endpoint:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - subsets[*].addresses[*].ip
+            - from: flow
+              name: source.port
+              to:
+                - subsets[*].ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - subsets[*].ports[*].protocol
+        endpointslice:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - endpoints[*].addresses[*]
+            - from: flow
+              name: source.port
+              to:
+                - ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - ports[*].protocol
+            - from: flow
+              name: network.type
+              to:
+                - addressType
+        gateway:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - spec.addresses[*].value
+                - status.addresses[*].value
+            - from: flow
+              name: source.port
+              to:
+                - spec.listeners[*].port
+        ingress:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - status.loadBalancer.ingress[*].ip
+                - status.loadBalancer.ingress[*].hostname
+            - from: flow
+              name: source.port
+              to:
+                - spec.defaultBackend.service.port
+                - spec.rules[*].http.paths[*].backend.service.port.number
+        networkpolicy:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - spec.ingress[*].from[*].ipBlock.cidr
+                - spec.egress[*].to[*].ipBlock.cidr
+            - from: flow
+              name: source.port
+              to:
+                - spec.ingress[*].ports[*].port
+                - spec.egress[*].ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - spec.ingress[*].ports[*].protocol
+                - spec.egress[*].ports[*].protocol
+        node:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - status.addresses[*].address
+        pod:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - status.podIP
+                - status.podIPs[*]
+                - status.hostIP
+                - status.hostIPs[*]
+            - from: flow
+              name: source.port
+              to:
+                - spec.containers[*].ports[*].containerPort
+                - spec.containers[*].ports[*].hostPort
+            - from: flow
+              name: network.transport
+              to:
+                - spec.containers[*].ports[*].protocol
+        service:
+          sources:
+            - from: flow
+              name: source.ip
+              to:
+                - spec.clusterIP
+                - spec.clusterIPs[*]
+                - spec.externalIPs[*]
+                - spec.loadBalancerIP
+                - spec.externalName
+            - from: flow
+              name: source.port
+              to:
+                - spec.ports[*].port
+            - from: flow
+              name: network.transport
+              to:
+                - spec.ports[*].protocol
+            - from: flow
+              name: network.type
+              to:
+                - spec.ipFamilies[*]
+      extract:
+        metadata:
+          - "[*].metadata.name"
+          - "[*].metadata.namespace"
+          - "[*].metadata.uid"
 auto_reload: false
 discovery:
-    informer:
-        k8s:
-            owner_relations:
-                exclude_kinds:
-                    - EndpointSlice
-                include_kinds:
-                    - Service
-                max_depth: 5
-            selector_relations:
-                - kind: NetworkPolicy
-                  selector_match_expressions_field: spec.podSelector.matchExpressions
-                  selector_match_labels_field: spec.podSelector.matchLabels
-                  to: Pod
-                - kind: Service
-                  selector_match_labels_field: spec.selector
-                  to: Pod
-            selectors:
-                - kind: Service
-                - kind: Endpoint
-                - kind: EndpointSlice
-                - kind: Gateway
-                - kind: Ingress
-                - kind: Pod
-                - kind: ReplicaSet
-                - kind: Deployment
-                - kind: Daemonset
-                - kind: StatefulSet
-                - kind: Job
-                - kind: CronJob
-                - kind: NetworkPolicy
-    instrument:
-        interfaces:
-            - eth0
-export:
-    traces:
-        otlp:
-            auth:
-                basic:
-                    pass: PASSWORD
-                    user: USERNAME
-            endpoint: http://otelcol:4317
-            protocol: grpc
-            timeout: 10s
-            tls:
-                ca_cert: /etc/certs/ca.crt
-                client_cert: /etc/certs/cert.crt
-                client_key: /etc/certs/cert.key
-                enabled: false
-                insecure: false
-        stdout: ""
-filter:
-    destination:
-        address:
-            match: ""
-            not_match: ""
-        port:
-            match: ""
-            not_match: ""
-    flow:
-        connection:
-            state:
-                match: ""
-                not_match: ""
-    network:
-        transport:
-            match: ""
-            not_match: ""
-        type:
-            match: ""
-            not_match: ""
-    source:
-        address:
-            match: ""
-            not_match: ""
-        port:
-            match: ""
-            not_match: ""
-informer:
+  informer:
     k8s:
-        informers_resync_period: 30m
-        informers_sync_timeout: 30s
-        kubeconfig_path: ""
+      owner_relations:
+        exclude_kinds:
+          - EndpointSlice
+        include_kinds:
+          - Service
+        max_depth: 5
+      selector_relations:
+        - kind: NetworkPolicy
+          selector_match_expressions_field: spec.podSelector.matchExpressions
+          selector_match_labels_field: spec.podSelector.matchLabels
+          to: Pod
+        - kind: Service
+          selector_match_labels_field: spec.selector
+          to: Pod
+      selectors:
+        - kind: Service
+        - kind: Endpoint
+        - kind: EndpointSlice
+        - kind: Gateway
+        - kind: Ingress
+        - kind: Pod
+        - kind: ReplicaSet
+        - kind: Deployment
+        - kind: Daemonset
+        - kind: StatefulSet
+        - kind: Job
+        - kind: CronJob
+        - kind: NetworkPolicy
+  instrument:
+    interfaces:
+      - eth0
+export:
+  traces:
+    otlp:
+      auth:
+        basic:
+          pass: PASSWORD
+          user: USERNAME
+      endpoint: http://otelcol:4317
+      protocol: grpc
+      timeout: 10s
+      tls:
+        ca_cert: /etc/certs/ca.crt
+        client_cert: /etc/certs/cert.crt
+        client_key: /etc/certs/cert.key
+        insecure: false
+    stdout: ""
+filter:
+  destination:
+    address:
+      match: ""
+      not_match: ""
+    port:
+      match: ""
+      not_match: ""
+  flow:
+    connection:
+      state:
+        match: ""
+        not_match: ""
+  network:
+    transport:
+      match: ""
+      not_match: ""
+    type:
+      match: ""
+      not_match: ""
+  source:
+    address:
+      match: ""
+      not_match: ""
+    port:
+      match: ""
+      not_match: ""
+informer:
+  k8s:
+    informers_resync_period: 30m
+    informers_sync_timeout: 30s
+    kubeconfig_path: ""
 internal:
-    traces:
-        otlp:
-            auth:
-                basic:
-                    pass: PASSWORD
-                    user: USERNAME
-            endpoint: http://otelcol:4317
-            protocol: grpc
-            timeout: 10s
-            tls:
-                ca_cert: /etc/certs/ca.crt
-                client_cert: /etc/certs/cert.crt
-                client_key: /etc/certs/cert.key
-                enabled: false
-                insecure: false
-        span_format: full
-        stdout: ""
+  traces:
+    otlp:
+      auth:
+        basic:
+          pass: PASSWORD
+          user: USERNAME
+      endpoint: http://otelcol:4317
+      protocol: grpc
+      timeout: 10s
+      tls:
+        ca_cert: /etc/certs/ca.crt
+        client_cert: /etc/certs/cert.crt
+        client_key: /etc/certs/cert.key
+        insecure: false
+    span_format: full
+    stdout: ""
 log_level: info
 metrics:
-    enabled: true
-    listen_address: 0.0.0.0
-    port: 10250
+  enabled: true
+  listen_address: 0.0.0.0
+  port: 10250
 packet_channel_capacity: 1024
 packet_worker_count: 2
 parser:
-    geneve_port: 6081
-    vxlan_port: 4789
-    wireguard_port: 51820
+  geneve_port: 6081
+  vxlan_port: 4789
+  wireguard_port: 51820
 shutdown_timeout: 5s
 span:
-    generic_timeout: 30s
-    icmp_timeout: 10s
-    max_record_interval: 60s
-    tcp_fin_timeout: 5s
-    tcp_rst_timeout: 5s
-    tcp_timeout: 20s
-    udp_timeout: 60s
-
+  generic_timeout: 30s
+  icmp_timeout: 10s
+  max_record_interval: 60s
+  tcp_fin_timeout: 5s
+  tcp_rst_timeout: 5s
+  tcp_timeout: 20s
+  udp_timeout: 60s

--- a/charts/mermin/config/examples/cr.yaml
+++ b/charts/mermin/config/examples/cr.yaml
@@ -258,5 +258,4 @@ spec:
     caCert: /etc/certs/ca.crt
     clientCert: /etc/certs/cert.crt
     clientKey: /etc/certs/cert.key
-    enabled: true
     insecure: false

--- a/examples/netobserv_os_simple_gke_gw/config.hcl
+++ b/examples/netobserv_os_simple_gke_gw/config.hcl
@@ -71,7 +71,6 @@ export "traces" {
   //   }
 
   //   tls = {
-  //     enabled     = true
   //     insecure    = false
   //     ca_cert     = "/etc/certs/ca.crt"
   //     client_cert = "/etc/certs/cert.crt"

--- a/mermin/src/otlp/opts.rs
+++ b/mermin/src/otlp/opts.rs
@@ -130,7 +130,6 @@ impl std::str::FromStr for StdoutFmt {
 ///           user: foo
 ///           pass: env("MY_SECRET_PASS")
 ///       tls:
-///         enabled: true
 ///         insecure: false
 ///         ca_cert: /etc/certs/ca.crt
 ///         client_cert: /etc/certs/cert.crt
@@ -200,20 +199,17 @@ pub struct BasicAuthOptions {
 ///
 /// This struct defines the options for enabling and customizing TLS when connecting
 /// to telemetry backends (such as OTLP collectors). It allows specifying whether
-/// TLS is enabled, whether to skip certificate verification (insecure mode), and
-/// provides fields for custom certificate authority (CA) certificates and client
+/// to skip certificate verification (insecure mode) and provides fields
+/// for custom certificate authority (CA) certificates and client
 /// certificates/keys for mutual TLS authentication.
 ///
 /// # Fields
-/// - `enabled`: If true, TLS is enabled for the exporter connection.
 /// - `insecure`: If true, disables certificate verification (not recommended for production).
 /// - `ca_cert`: Optional path to a custom CA certificate file for server verification.
 /// - `client_cert`: Optional path to a client certificate file for mutual TLS.
 /// - `client_key`: Optional path to a client private key file for mutual TLS.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TlsOptions {
-    /// Enable TLS for the exporter connection.
-    pub enabled: bool,
     /// Disable certificate verification (insecure mode).
     pub insecure: bool,
     /// Path to the CA certificate file for server verification.

--- a/mermin/tests/e2e/grafana/config/mermin.ci.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.ci.hcl
@@ -56,6 +56,5 @@ exporter "otlp" "main" {
 
   tls {
     insecure    = true
-    enabled     = false
   }
 }

--- a/mermin/tests/e2e/grafana/config/mermin.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.hcl
@@ -56,6 +56,5 @@ exporter "otlp" "main" {
 
   tls {
     insecure    = true
-    enabled     = false
   }
 }


### PR DESCRIPTION
## Description

This PR removes `tls.enabled` configuration option for otlp exporting. It was unused at the moment but does not align with other configuration that we implicitly decide when to enable or disable features based on their relevant configuration flags. In the case of mutual TLS, if the cert paths are defined then mutual TLS will be enabled.

## Type of Change

<!-- Please check the box that applies to this pull request. -->

- [ ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):