### PR TITLE
refactor(conf): restructure interface configuration into discovery.instrument hierarchy

### DIFF
--- a/.cursor/commands/pr-description.md
+++ b/.cursor/commands/pr-description.md
@@ -14,7 +14,7 @@ This command provides a complete eBPF-focused PR workflow for the Mermin project
    - Uses the existing `.github/PULL_REQUEST_TEMPLATE.md`
    - Pre-analyzes changes to suggest PR description content
    - Ensures all testing requirements are documented
-   - Keep the output concise and to the point. Avoid fluff.
+   - Keep the output very concise and to the point. Avoid fluff as much as possible.
    - **Always** generate the output as a markdown file so I can easily copy it.
 
 ## Usage

--- a/mermin/tests/e2e/grafana/config/mermin.ci.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.ci.hcl
@@ -1,11 +1,3 @@
-# Network interfaces to monitor
-# Literal example (default)
-interfaces = ["eth0"]
-# Glob example: match all ethernet interfaces starting with "eth"
-# interfaces = ["eth*"]
-# Regex example: match slot-based PNIN like en0p<digits>
-# interfaces = ["/^en0p\\d+$/"]
-
 # Logging configuration
 log_level = "debug"
 
@@ -29,6 +21,17 @@ metrics {
   enabled        = true
   listen_address = "0.0.0.0"
   port           = 10250
+}
+
+# Discovery configuration
+discovery "instrument" {
+  # Network interfaces to monitor
+  #
+  # Glob example: match all ethernet interfaces starting with "eth"
+  # interfaces = ["eth*"]
+  # Regex example: match slot-based PNIN like en0p<digits>
+  # interfaces = ["/^en0p\\d+$/"]
+  interfaces = ["eth0"]
 }
 
 # Flow Span configuration

--- a/mermin/tests/e2e/grafana/config/mermin.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.hcl
@@ -1,11 +1,3 @@
-# Network interfaces to monitor
-# Literal example (default)
-interfaces = ["eth0"]
-# Glob example: match all ethernet interfaces starting with "eth"
-# interfaces = ["eth*"]
-# Regex example: match slot-based PNIN like en0p<digits>
-# interfaces = ["/^en0p\\d+$/"]
-
 # Logging configuration
 log_level = "debug"
 
@@ -29,6 +21,17 @@ metrics {
   enabled        = true
   listen_address = "0.0.0.0"
   port           = 10250
+}
+
+# Discovery configuration
+discovery "instrument" {
+  # Network interfaces to monitor
+  #
+  # Glob example: match all ethernet interfaces starting with "eth"
+  # interfaces = ["eth*"]
+  # Regex example: match slot-based PNIN like en0p<digits>
+  # interfaces = ["/^en0p\\d+$/"]
+  interfaces = ["eth0"]
 }
 
 # Flow Span configuration


### PR DESCRIPTION
## Description

Restructured interface configuration from flat `interfaces` field to nested `discovery.instrument.interfaces` hierarchy. This change improves configuration organization and sets foundation for future discovery feature expansion.

**Breaking Change**: Configuration files must be updated to use new nested structure.

### Migration

**Before:**
```hcl
interfaces = ["eth0"]
```

**After:**
```hcl
discovery "instrument" {
  interfaces = ["eth0"]
}
```

### Key Changes

- Moved `interfaces` → `discovery.instrument.interfaces`
- Added `DiscoveryConf` and `InstrumentConf` structs
- Enhanced documentation for interface resolution (glob/regex/literal patterns)
- Added ReDoS protection (256-char max regex pattern length)
- Improved glob matching algorithm documentation
- Added 20+ edge case tests for interface resolution

## Type of Change

- [x] Refactoring (no functional changes, just code improvements)
- [x] Breaking change (requires configuration migration)

## How Has This Been Tested?

- **Unit Tests**: Added comprehensive edge case coverage:
  - Empty patterns/available interfaces
  - Malformed regex patterns
  - Overly long regex patterns (ReDoS protection)
  - Unicode interface names
  - Complex glob/regex/literal pattern mixing
  - Multiple consecutive wildcards
  - Pattern precedence and deduplication
- **Integration**: Updated existing e2e config files (`mermin.hcl`, `mermin.ci.hcl`)
- **Environment**: macOS 14.6, Rust 1.88.0

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added or updated tests that verify my changes
- [x] All new and existing tests pass

## Additional Notes

**Migration Required**: All configuration files using `interfaces` must migrate to `discovery.instrument.interfaces`. Example configs updated: `mermin.hcl`, `mermin.ci.hcl`.

**Future Work**: This structure enables future discovery features (auto-discovery, dynamic interface registration, etc.) without further breaking changes.
