### PR TITLE
feat(k8s): add selector-based resource relations support

### DIFF
--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -124,6 +124,8 @@ discovery "informer" "k8s" {
 
     Controls how Mermin walks K8s owner references (Pod <- Job <- CronJob <- ...)
     and attaches owner metadata to flows.
+    
+    Valid owner kinds: Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob
   */
   owner_relations = {
     # Limit the ownerReference walk depth and depth of attached metadata
@@ -144,8 +146,12 @@ discovery "informer" "k8s" {
   /*
     Selector-based K8s resource relations
 
-    Extracts selector s from K8s resource definitions and matches them against other resources
+    Extracts selectors from K8s resource definitions and matches them against other resources
     (e.g., NetworkPolicy selects Pods, Service selects Pods via spec.selector)
+
+    Supported resource kinds:
+    - NetworkPolicy, Service (network resources)
+    - Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob (workload controllers)
   */
   selector_relations = [
     # NetworkPolicy -> Pod association
@@ -163,7 +169,42 @@ discovery "informer" "k8s" {
       kind                        = "Service" # case insensitive
       to                          = "Pod"     # case insensitive
       selector_match_labels_field = "spec.selector"
-    }
+    },
+
+    # Workload controller examples (uncomment to enable)
+    # These provide reverse lookup: find all controllers that select a given pod via label selectors
+    # Complements owner_relations which walks the owner reference chain
+
+    # {
+    #   kind                        = "Deployment"
+    #   to                          = "Pod"
+    #   selector_match_labels_field = "spec.selector.matchLabels"
+    # },
+    # {
+    #   kind                        = "ReplicaSet"
+    #   to                          = "Pod"
+    #   selector_match_labels_field = "spec.selector.matchLabels"
+    # },
+    # {
+    #   kind                        = "StatefulSet"
+    #   to                          = "Pod"
+    #   selector_match_labels_field = "spec.selector.matchLabels"
+    # },
+    # {
+    #   kind                        = "DaemonSet"
+    #   to                          = "Pod"
+    #   selector_match_labels_field = "spec.selector.matchLabels"
+    # },
+    # {
+    #   kind                        = "Job"
+    #   to                          = "Pod"
+    #   selector_match_labels_field = "spec.selector.matchLabels"
+    # },
+    # {
+    #   kind                        = "CronJob"
+    #   to                          = "Pod"
+    #   selector_match_labels_field = "spec.jobTemplate.spec.selector.matchLabels"
+    # }
   ]
 }
 

--- a/docs/custom_crd_selector_relations.md
+++ b/docs/custom_crd_selector_relations.md
@@ -1,0 +1,969 @@
+# Custom Resource Definition (CRD) Support for K8s Relations
+
+## Overview
+
+This document outlines the design for extending Mermin's Kubernetes resource relations to support Custom Resource Definitions (CRDs). This includes both **selector-based relations** and **owner reference relations**. Unlike built-in Kubernetes resources, CRDs are dynamically defined and can have arbitrary schemas, making them significantly more complex to support.
+
+## Current State
+
+### Selector Relations
+
+Mermin supports selector-based relations for the following built-in Kubernetes resources:
+
+- **Network Resources**: NetworkPolicy, Service
+- **Workload Controllers**: Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob
+
+These resources are statically compiled into the codebase using `k8s-openapi` types, with hardcoded knowledge of where selectors exist in their schemas (e.g., `spec.selector`, `spec.podSelector`).
+
+### Owner Relations
+
+Mermin supports owner reference walking for the following built-in workload controllers:
+
+- **Workload Controllers**: Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob
+
+Owner relations work by:
+
+1. Reading `metadata.ownerReferences` from a Pod
+2. Looking up the owner resource in the `ResourceStore`
+3. Recursively walking up the ownership chain
+4. Filtering based on configured `include_kinds` and `exclude_kinds`
+
+**Example ownership chains:**
+
+- `Pod ← ReplicaSet ← Deployment`
+- `Pod ← Job ← CronJob`
+- `Pod ← StatefulSet`
+
+CRDs are **currently not supported** in owner relations, even though they may appear in `ownerReferences`.
+
+### Selector Relations vs Owner Relations
+
+Understanding when to use each relation type:
+
+| Feature                      | Selector Relations                               | Owner Relations                                  |
+|------------------------------|--------------------------------------------------|--------------------------------------------------|
+| **Mechanism**                | Match pod labels against resource selectors      | Walk `metadata.ownerReferences` chain            |
+| **Direction**                | Resource → Pod (top-down)                        | Pod → Owner (bottom-up)                          |
+| **Use Case**                 | Network policies, services, non-owning resources | Deployment hierarchy, operator-managed resources |
+| **Cardinality**              | One-to-many (one policy selects many pods)       | Many-to-one (many pods share one owner)          |
+| **Configuration Complexity** | Requires field paths to selectors                | Only requires resource kinds                     |
+| **Example (Built-in)**       | NetworkPolicy selects Pods via podSelector       | Pod owned by ReplicaSet owned by Deployment      |
+| **Example (CRD)**            | Istio VirtualService selects Pods                | ArgoCD Application owns Deployment               |
+
+**When to use Selector Relations:**
+
+- Network policy enforcement tracking
+- Service mesh configuration
+- Custom ingress/gateway associations
+- Any resource that "selects" pods but doesn't own them
+
+**When to use Owner Relations:**
+
+- Tracking deployment hierarchy
+- GitOps application tracking
+- Progressive delivery tracking
+- Operator-managed resource chains
+
+**Can use both:**
+
+- Knative Services (selectors for routing + ownership hierarchy)
+- Custom operators that both own and select resources
+
+## Challenges with CRD Support
+
+### 1. Dynamic Schema
+
+- CRDs are defined at runtime via CustomResourceDefinition manifests
+- Schema is not known at compile time
+- Each CRD can have selectors at arbitrary field paths
+- No standard location for selectors like built-in resources
+
+### 2. Type Safety
+
+- Current implementation uses strongly-typed `k8s-openapi` structs
+- CRDs require working with untyped JSON/YAML structures
+- Need to balance type safety with flexibility
+
+### 3. Discovery & Registration
+
+- System must discover available CRDs in the cluster
+- Users must specify which CRDs to track and where their selectors are
+- Configuration complexity increases significantly
+
+### 4. Resource Storage & Caching
+
+- Current `ResourceStore` uses generic type parameters with `kube::Resource` trait
+- CRDs would require dynamic typing or trait objects
+- Reflectors and watchers need to be created dynamically
+
+### 5. Performance & Memory
+
+- Watching many CRDs can significantly increase memory usage
+- Need to allow selective CRD watching to avoid resource exhaustion
+
+### 6. Owner Reference Ambiguity (Owner Relations)
+
+- `ownerReferences` only contain `apiVersion` and `kind`, not explicit CRD registration
+- Need to parse `apiVersion` to extract group and version
+- Multiple CRD versions may exist (v1alpha1, v1beta1, v1) with different schemas
+- Owner chain depth can be arbitrary with CRDs (e.g., `Pod ← CustomResource1 ← CustomResource2 ← CustomResource3`)
+
+### 7. Attribute Namespace Collision (Owner Relations)
+
+- Built-in resources use predictable attribute names: `k8s.deployment.name`, `k8s.job.name`
+- CRDs may have conflicting kind names across different API groups
+- Need strategy to avoid collision: `k8s.myoperator.io.myresource.name` vs `k8s.myresource.name`
+
+## Proposed Solution
+
+### Phase 1: Generic JSON-based CRD Support
+
+#### Configuration Extension for Selector Relations
+
+Extend `SelectorRelationRule` to support CRDs with explicit field paths:
+
+```hcl
+selector_relations = [
+  # Existing built-in resource
+  {
+    kind                             = "NetworkPolicy"
+    to                               = "Pod"
+    selector_match_labels_field      = "spec.podSelector.matchLabels"
+    selector_match_expressions_field = "spec.podSelector.matchExpressions"
+  },
+
+  # Custom CRD example: Istio VirtualService
+  {
+    kind                             = "VirtualService"
+    api_version                      = "networking.istio.io/v1beta1"  # NEW
+    to                               = "Pod"
+    selector_match_labels_field      = "spec.workloadSelector.labels"
+    custom_resource                  = true  # NEW: marks as CRD
+  },
+
+  # Custom CRD example: Cilium CiliumNetworkPolicy
+  {
+    kind                             = "CiliumNetworkPolicy"
+    api_version                      = "cilium.io/v2"
+    to                               = "Pod"
+    selector_match_labels_field      = "spec.endpointSelector.matchLabels"
+    selector_match_expressions_field = "spec.endpointSelector.matchExpressions"
+    custom_resource                  = true
+  }
+]
+```
+
+#### New Configuration Fields
+
+```rust
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SelectorRelationRule {
+    /// The kind of resource
+    pub kind: String,
+
+    /// API version (required for CRDs, optional for built-in resources)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+
+    /// The kind of resource to match against
+    pub to: String,
+
+    /// JSON path to the matchLabels field
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector_match_labels_field: Option<String>,
+
+    /// JSON path to the matchExpressions field
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector_match_expressions_field: Option<String>,
+
+    /// Marks this as a custom resource (CRD)
+    #[serde(default)]
+    pub custom_resource: bool,
+}
+```
+
+#### Configuration Extension for Owner Relations
+
+Extend `OwnerRelationsOptions` to support CRDs in ownership chains:
+
+```hcl
+discovery {
+  informer {
+    k8s {
+      owner_relations {
+        max_depth = 5
+
+        # Built-in resources
+        include_kinds = [
+          "Deployment", "ReplicaSet", "StatefulSet",
+          "DaemonSet", "Job", "CronJob"
+        ]
+
+        # NEW: Custom resources that participate in ownership chains
+        custom_owner_kinds = [
+          {
+            kind        = "ArgoCD"
+            api_version = "argoproj.io/v1alpha1"
+            # Attribute name for flow metadata (defaults to lowercased kind)
+            attribute_name = "argocd"  # Results in k8s.argocd.name
+          },
+          {
+            kind        = "Rollout"
+            api_version = "argoproj.io/v1alpha1"
+            attribute_name = "rollout"  # Results in k8s.rollout.name
+          },
+          {
+            kind        = "Application"
+            api_version = "app.k8s.io/v1beta1"
+            # Include API group in attribute to avoid collisions
+            attribute_name = "app.k8s.io.application"  # Results in k8s.app.k8s.io.application.name
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### New Configuration Structures for Owner Relations
+
+```rust
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct OwnerRelationsOptions {
+    /// Maximum depth to walk up the ownership chain
+    #[serde(default = "default_max_depth")]
+    pub max_depth: usize,
+
+    /// Built-in resource kinds to include (existing field)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include_kinds: Vec<String>,
+
+    /// Built-in resource kinds to exclude (existing field)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_kinds: Vec<String>,
+
+    /// NEW: Custom resources that can appear in owner chains
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_owner_kinds: Vec<CustomOwnerKind>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomOwnerKind {
+    /// The kind of custom resource
+    pub kind: String,
+
+    /// API version (e.g., "argoproj.io/v1alpha1")
+    pub api_version: String,
+
+    /// Attribute name for flow metadata (optional, defaults to lowercased kind)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribute_name: Option<String>,
+}
+```
+
+#### ResourceStore Extension
+
+Create a new `DynamicResourceStore` for CRDs:
+
+```rust
+pub struct ResourceStore {
+    // Existing typed stores
+    pub pods: reflector::Store<Pod>,
+    pub services: reflector::Store<Service>,
+    // ... other built-in types
+
+    // NEW: Dynamic stores for CRDs
+    pub custom_resources: DynamicResourceStore,
+}
+
+pub struct DynamicResourceStore {
+    /// Map from (api_version, kind) to dynamic resource store
+    stores: Arc<RwLock<HashMap<(String, String), reflector::Store<DynamicObject>>>>,
+}
+
+impl DynamicResourceStore {
+    pub async fn add_resource_type(
+        &mut self,
+        client: Client,
+        api_version: &str,
+        kind: &str,
+    ) -> Result<(), K8sError> {
+        let api_resource = ApiResource {
+            group: parse_group(api_version),
+            version: parse_version(api_version),
+            kind: kind.to_string(),
+            plural: kind.to_lowercase() + "s", // TODO: proper pluralization
+        };
+
+        let api: Api<DynamicObject> = Api::all_with(client, &api_resource);
+        let (store, writer) = reflector::store();
+
+        tokio::spawn(async move {
+            reflector(writer, watcher(api, Config::default()))
+                .applied_objects()
+                .try_for_each(|_| async { Ok(()) })
+                .await
+        });
+
+        self.stores.write().unwrap().insert(
+            (api_version.to_string(), kind.to_string()),
+            store
+        );
+
+        Ok(())
+    }
+
+    pub fn get(&self, api_version: &str, kind: &str) -> Vec<DynamicObject> {
+        self.stores
+            .read()
+            .unwrap()
+            .get(&(api_version.to_string(), kind.to_string()))
+            .map(|store| store.state())
+            .unwrap_or_default()
+    }
+}
+```
+
+#### Selector Extraction for CRDs
+
+Implement generic field path extraction:
+
+```rust
+impl SelectorRelationsManager {
+    fn extract_selector_from_custom_resource(
+        &self,
+        obj: &DynamicObject,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        let data = obj.data.as_object()?;
+
+        let mut selector = LabelSelector::default();
+
+        // Extract matchLabels if field path is specified
+        if let Some(labels_path) = &rule.selector_match_labels_field {
+            if let Some(labels) = self.extract_json_field(data, labels_path) {
+                if let Some(labels_map) = labels.as_object() {
+                    selector.match_labels = Some(
+                        labels_map
+                            .iter()
+                            .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
+                            .collect()
+                    );
+                }
+            }
+        }
+
+        // Extract matchExpressions if field path is specified
+        if let Some(expr_path) = &rule.selector_match_expressions_field {
+            if let Some(expressions) = self.extract_json_field(data, expr_path) {
+                if let Some(expr_array) = expressions.as_array() {
+                    selector.match_expressions = Some(
+                        expr_array
+                            .iter()
+                            .filter_map(|e| self.parse_match_expression(e))
+                            .collect()
+                    );
+                }
+            }
+        }
+
+        Some(selector)
+    }
+
+    fn extract_json_field<'a>(
+        &self,
+        obj: &'a serde_json::Map<String, serde_json::Value>,
+        path: &str,
+    ) -> Option<&'a serde_json::Value> {
+        let parts: Vec<&str> = path.split('.').collect();
+        let mut current: &serde_json::Value = &serde_json::Value::Object(obj.clone());
+
+        for part in parts {
+            current = current.get(part)?;
+        }
+
+        Some(current)
+    }
+
+    fn parse_match_expression(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<LabelSelectorRequirement> {
+        let obj = value.as_object()?;
+
+        Some(LabelSelectorRequirement {
+            key: obj.get("key")?.as_str()?.to_string(),
+            operator: obj.get("operator")?.as_str()?.to_string(),
+            values: obj.get("values")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()),
+        })
+    }
+}
+```
+
+#### Owner Relations Implementation for CRDs
+
+Extend `OwnerRelationsManager` to handle CRD owners:
+
+```rust
+impl OwnerRelationsManager {
+    pub fn new(options: OwnerRelationsOptions) -> Self {
+        // Existing normalization for built-in kinds
+        let include_kinds: HashSet<String> = options
+            .include_kinds
+            .iter()
+            .map(|k| k.to_lowercase())
+            .collect();
+
+        let exclude_kinds: HashSet<String> = options
+            .exclude_kinds
+            .iter()
+            .map(|k| k.to_lowercase())
+            .collect();
+
+        // NEW: Build lookup map for custom owners
+        // Map from (api_version, kind) -> attribute_name
+        let custom_owners: HashMap<(String, String), String> = options
+            .custom_owner_kinds
+            .iter()
+            .map(|co| {
+                let key = (co.api_version.clone(), co.kind.to_lowercase());
+                let attribute = co.attribute_name
+                    .clone()
+                    .unwrap_or_else(|| co.kind.to_lowercase());
+                (key, attribute)
+            })
+            .collect();
+
+        Self {
+            max_depth: options.max_depth,
+            include_kinds,
+            exclude_kinds,
+            custom_owners,  // NEW field
+        }
+    }
+
+    /// Looks up a single owner reference (extended to support CRDs)
+    fn lookup_owner(
+        &self,
+        owner_ref: &OwnerReference,
+        namespace: &str,
+        store: &ResourceStore,
+    ) -> Option<(WorkloadOwner, Option<Vec<OwnerReference>>)> {
+        let name = &owner_ref.name;
+        let kind = &owner_ref.kind;
+        let api_version = &owner_ref.api_version;
+
+        // Try built-in resources first (existing logic)
+        let result = match kind.to_lowercase().as_str() {
+            "replicaset" => find_in_store!(ReplicaSet, ReplicaSet),
+            "deployment" => find_in_store!(Deployment, Deployment),
+            "statefulset" => find_in_store!(StatefulSet, StatefulSet),
+            "daemonset" => find_in_store!(DaemonSet, DaemonSet),
+            "job" => find_in_store!(Job, Job),
+            "cronjob" => find_in_store!(CronJob, CronJob),
+            _ => None,
+        };
+
+        if result.is_some() {
+            return result;
+        }
+
+        // NEW: Try custom resources
+        let lookup_key = (api_version.clone(), kind.to_lowercase());
+        if let Some(attribute_name) = self.custom_owners.get(&lookup_key) {
+            return self.lookup_custom_owner(
+                name,
+                api_version,
+                kind,
+                attribute_name,
+                namespace,
+                store,
+            );
+        }
+
+        None
+    }
+
+    /// Looks up a custom resource owner from the dynamic store
+    fn lookup_custom_owner(
+        &self,
+        name: &str,
+        api_version: &str,
+        kind: &str,
+        attribute_name: &str,
+        namespace: &str,
+        store: &ResourceStore,
+    ) -> Option<(WorkloadOwner, Option<Vec<OwnerReference>>)> {
+        let resources = store.custom_resources.get(api_version, kind);
+
+        resources
+            .iter()
+            .find(|obj| {
+                obj.metadata.name.as_ref() == Some(&name.to_string())
+                    && obj.metadata.namespace.as_ref() == Some(&namespace.to_string())
+            })
+            .map(|obj| {
+                let meta = K8sObjectMeta {
+                    name: obj.metadata.name.clone().unwrap_or_default(),
+                    kind: kind.to_string(),
+                    uid: obj.metadata.uid.clone(),
+                    namespace: obj.metadata.namespace.clone(),
+                    labels: obj.metadata.labels.clone(),
+                    annotations: obj.metadata.annotations.clone(),
+                };
+
+                let next_owners = obj.metadata.owner_references.clone();
+
+                // Use the configured attribute name for this CRD
+                let owner = WorkloadOwner::Custom {
+                    meta,
+                    attribute_name: attribute_name.to_string(),
+                };
+
+                (owner, next_owners)
+            })
+    }
+}
+```
+
+#### Extended WorkloadOwner Enum
+
+Add support for custom resources:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum WorkloadOwner {
+    // Built-in resources
+    ReplicaSet(K8sObjectMeta),
+    Deployment(K8sObjectMeta),
+    StatefulSet(K8sObjectMeta),
+    DaemonSet(K8sObjectMeta),
+    Job(K8sObjectMeta),
+    CronJob(K8sObjectMeta),
+
+    // NEW: Generic custom resource
+    Custom {
+        meta: K8sObjectMeta,
+        attribute_name: String,  // e.g., "argocd", "app.k8s.io.application"
+    },
+}
+```
+
+#### Flow Attribute Population for CRD Owners
+
+Extend `parser.rs` to handle custom owners:
+
+```rust
+impl SpanDecorator {
+    fn populate_workload_attributes(
+        &self,
+        flow_span: &mut FlowSpan,
+        owner: &WorkloadOwner,
+        is_source: bool,
+    ) {
+        match owner {
+            // Existing built-in types
+            WorkloadOwner::Deployment(meta) => {
+                self.set_k8s_attr(flow_span, "deployment.name", &meta.name, is_source);
+            }
+            WorkloadOwner::ReplicaSet(meta) => {
+                self.set_k8s_attr(flow_span, "replicaset.name", &meta.name, is_source);
+            }
+            // ... other built-in types ...
+
+            // NEW: Custom resource
+            WorkloadOwner::Custom { meta, attribute_name } => {
+                // Use the configured attribute name
+                let attr_key = format!("{}.name", attribute_name);
+                self.set_k8s_attr(flow_span, &attr_key, &meta.name, is_source);
+
+                trace!(
+                    event.name = "k8s.custom_owner.attribute_set",
+                    k8s.resource.kind = %meta.kind,
+                    k8s.resource.name = %meta.name,
+                    k8s.attribute_name = %attribute_name,
+                    "set custom resource owner attribute"
+                );
+            }
+        }
+    }
+}
+```
+
+### Phase 2: CRD Auto-Discovery (Future Enhancement)
+
+In a future iteration, we could implement automatic CRD discovery:
+
+1. Watch CustomResourceDefinition resources
+2. Parse OpenAPIv3 schemas to identify selector fields
+3. Auto-generate configuration based on common patterns
+4. Allow opt-in/opt-out of discovered CRDs
+
+```hcl
+discovery {
+  informer {
+    k8s {
+      # Auto-discover CRDs with selector fields
+      auto_discover_crds = true
+
+      # Whitelist/blacklist patterns
+      crd_discovery {
+        include_groups = ["istio.io", "cilium.io"]
+        exclude_groups = ["internal.mycompany.com"]
+
+        # Automatic field detection
+        # Look for fields matching these patterns
+        selector_field_patterns = [
+          "*.selector.matchLabels",
+          "*.podSelector.matchLabels",
+          "*.endpointSelector.matchLabels",
+          "*.workloadSelector.labels"
+        ]
+      }
+    }
+  }
+}
+```
+
+## Implementation Roadmap
+
+### Milestone 1: Foundation (2-3 weeks)
+
+**Selector Relations:**
+
+- [ ] Extend `SelectorRelationRule` configuration struct
+- [ ] Implement `DynamicResourceStore` for CRDs
+- [ ] Add configuration parsing and validation
+- [ ] Unit tests for configuration parsing
+
+**Owner Relations:**
+
+- [ ] Extend `OwnerRelationsOptions` with `custom_owner_kinds`
+- [ ] Add `CustomOwnerKind` configuration struct
+- [ ] Extend `WorkloadOwner` enum with `Custom` variant
+- [ ] Update configuration parsing and validation
+
+### Milestone 2: Core CRD Support (3-4 weeks)
+
+**Selector Relations:**
+
+- [ ] Implement dynamic reflector creation for CRDs
+- [ ] Implement generic JSON field path extraction
+- [ ] Integrate CRD matching into `SelectorRelationsManager`
+- [ ] Add CRD metadata to flow attributes via `populate_selector_relation_attributes()`
+- [ ] Integration tests with sample CRDs (Istio, Cilium)
+
+**Owner Relations:**
+
+- [ ] Extend `OwnerRelationsManager` to lookup CRD owners
+- [ ] Implement `lookup_custom_owner()` method
+- [ ] Build custom owners lookup map in manager constructor
+- [ ] Add CRD owner attributes to flow spans in `populate_workload_attributes()`
+- [ ] Integration tests with ownership chains (ArgoCD, Argo Rollouts)
+
+### Milestone 3: Production Readiness (2-3 weeks)
+
+- [ ] Performance testing and optimization (both relation types)
+- [ ] Memory usage analysis with multiple CRDs
+- [ ] Error handling and recovery for missing CRDs
+- [ ] Documentation and examples for common platforms
+- [ ] Operator validation in real clusters
+- [ ] Handle edge cases: circular ownership, deep chains, missing references
+
+### Milestone 4: Auto-Discovery (4-6 weeks, optional)
+
+- [ ] CRD watch and schema parsing
+- [ ] Pattern-based selector field detection
+- [ ] Dynamic configuration updates
+- [ ] Advanced testing with diverse CRDs
+
+## Risks & Mitigations
+
+| Risk                                                                     | Mitigation                                                                |
+|--------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| **Memory exhaustion from watching too many CRDs**                        | Require explicit opt-in per CRD; provide memory usage warnings            |
+| **Invalid field paths causing runtime errors** (Selector Relations)      | Comprehensive validation on startup; graceful error handling              |
+| **CRD schema changes breaking selector extraction** (Selector Relations) | Version field paths per API version; emit warnings on extraction failures |
+| **Attribute name collisions** (Owner Relations)                          | Require explicit `attribute_name` config; validate uniqueness on startup  |
+| **Circular ownership chains** (Owner Relations)                          | Track visited resources in ownership walk; enforce `max_depth` limit      |
+| **Missing CRD in ownership chain** (Owner Relations)                     | Gracefully stop chain walk; log missing resource at debug level           |
+| **Performance degradation with many CRDs** (Both)                        | Benchmarking; lazy loading; caching strategies; selective watching        |
+| **Complex configuration increases user error** (Both)                    | Provide pre-built examples for common CRDs (Istio, Cilium, Argo, Knative) |
+
+## Example Use Cases
+
+### Use Case 1: Istio VirtualService
+
+Match pods selected by Istio VirtualService resources:
+
+```hcl
+selector_relations = [
+  {
+    kind                        = "VirtualService"
+    api_version                 = "networking.istio.io/v1beta1"
+    to                          = "Pod"
+    selector_match_labels_field = "spec.workloadSelector.labels"
+    custom_resource             = true
+  }
+]
+```
+
+Result: Flows will have `k8s.virtualservice.name` attribute.
+
+### Use Case 2: Cilium CiliumNetworkPolicy
+
+Match pods selected by Cilium network policies:
+
+```hcl
+selector_relations = [
+  {
+    kind                             = "CiliumNetworkPolicy"
+    api_version                      = "cilium.io/v2"
+    to                               = "Pod"
+    selector_match_labels_field      = "spec.endpointSelector.matchLabels"
+    selector_match_expressions_field = "spec.endpointSelector.matchExpressions"
+    custom_resource                  = true
+  }
+]
+```
+
+Result: Flows will have `k8s.ciliumnetworkpolicy.name` attribute.
+
+### Use Case 3: Custom Application CRD
+
+Match pods selected by a custom application deployment CRD:
+
+```hcl
+selector_relations = [
+  {
+    kind                        = "AppDeployment"
+    api_version                 = "apps.mycompany.io/v1"
+    to                          = "Pod"
+    selector_match_labels_field = "spec.template.selector"
+    custom_resource             = true
+  }
+]
+```
+
+Result: Flows will have `k8s.appdeployment.name` attribute.
+
+---
+
+### Use Case 4: Argo Rollouts (Owner Relations)
+
+Track pods managed by Argo Rollouts progressive delivery:
+
+```hcl
+owner_relations {
+  max_depth = 5
+  include_kinds = ["Deployment", "ReplicaSet", "StatefulSet"]
+
+  custom_owner_kinds = [
+    {
+      kind        = "Rollout"
+      api_version = "argoproj.io/v1alpha1"
+      attribute_name = "rollout"
+    }
+  ]
+}
+```
+
+**Ownership chain**: `Pod ← ReplicaSet ← Rollout`
+
+**Result**: Flows will have:
+
+- `k8s.pod.name`
+- `k8s.replicaset.name`
+- `k8s.rollout.name` (custom CRD)
+
+### Use Case 5: ArgoCD Applications (Owner Relations)
+
+Track pods deployed by ArgoCD applications:
+
+```hcl
+owner_relations {
+  max_depth = 5
+  include_kinds = ["Deployment", "ReplicaSet", "StatefulSet"]
+
+  custom_owner_kinds = [
+    {
+      kind        = "Application"
+      api_version = "argoproj.io/v1alpha1"
+      attribute_name = "argocd.application"
+    }
+  ]
+}
+```
+
+**Ownership chain**: `Pod ← ReplicaSet ← Deployment ← Application`
+
+**Result**: Flows will have:
+
+- `k8s.pod.name`
+- `k8s.replicaset.name`
+- `k8s.deployment.name`
+- `k8s.argocd.application.name` (custom CRD)
+
+### Use Case 6: Knative Services (Owner & Selector Relations)
+
+Track serverless workloads with both owner and selector relations:
+
+```hcl
+owner_relations {
+  max_depth = 5
+  custom_owner_kinds = [
+    {
+      kind        = "Configuration"
+      api_version = "serving.knative.dev/v1"
+      attribute_name = "knative.configuration"
+    },
+    {
+      kind        = "Revision"
+      api_version = "serving.knative.dev/v1"
+      attribute_name = "knative.revision"
+    }
+  ]
+}
+
+selector_relations = [
+  {
+    kind                        = "Service"
+    api_version                 = "serving.knative.dev/v1"
+    to                          = "Pod"
+    selector_match_labels_field = "spec.template.metadata.labels"
+    custom_resource             = true
+  }
+]
+```
+
+**Ownership chain**: `Pod ← ReplicaSet ← Revision ← Configuration`
+
+**Selector match**: Knative Service → Pod (via labels)
+
+**Result**: Comprehensive tracking of serverless workloads with both ownership and selector-based metadata.
+
+### Use Case 7: Operator-Managed Workloads
+
+Track pods managed by custom operators:
+
+```hcl
+owner_relations {
+  max_depth = 6
+  custom_owner_kinds = [
+    {
+      kind        = "PostgresCluster"
+      api_version = "postgres-operator.crunchydata.com/v1beta1"
+      # Use full group name to avoid collisions
+      attribute_name = "postgres-operator.postgrescluster"
+    },
+    {
+      kind        = "RedisCluster"
+      api_version = "redis.redis.opstreelabs.in/v1beta1"
+      attribute_name = "redis.opstreelabs.rediscluster"
+    }
+  ]
+}
+```
+
+**Ownership chains**:
+
+- `Pod ← StatefulSet ← PostgresCluster`
+- `Pod ← StatefulSet ← RedisCluster`
+
+**Result**: Attribute names are scoped to avoid collisions between different operators.
+
+## Open Questions
+
+1. **Pluralization**: How do we handle resource name pluralization for dynamic APIs?
+   - Use `kube::discovery::ApiResource` with known plurals?
+   - Require users to specify plural form in config?
+
+2. **Namespace Scoping**: Should CRD watching be cluster-scoped or namespace-scoped?
+   - Default to cluster-scoped like built-in resources?
+   - Allow per-CRD configuration?
+
+3. **Attribute Naming**: How should CRD attributes be named in flows?
+   - Use `k8s.<lowercased-kind>.name`?
+   - Include API group: `k8s.<group>.<kind>.name`?
+   - Make it configurable?
+
+4. **Version Conflicts**: How do we handle multiple versions of the same CRD?
+   - Require explicit API version in config?
+   - Use preferred version from CRD definition?
+
+5. **Selector Validation**: Should we validate that specified field paths exist?
+   - Fail fast on startup if invalid?
+   - Warn and continue, logging errors at runtime?
+
+6. **Owner Relations Filtering** (Owner Relations): How should `include_kinds`/`exclude_kinds` interact with CRDs?
+   - Apply same filtering rules to CRDs?
+   - Require explicit opt-in via `custom_owner_kinds`?
+   - Default: CRDs in `custom_owner_kinds` are always included unless globally disabled
+
+7. **Mixed Ownership Chains** (Owner Relations): How do we handle chains mixing built-in and CRDs?
+   - Example: `Pod ← ReplicaSet ← Deployment ← ArgoCD Application`
+   - Should filtering apply independently at each level?
+   - Should we support filtering "after CRD" vs "before CRD"?
+
+8. **CRD Version Migration** (Both): How do we handle CRD version upgrades?
+   - User upgrades Istio from v1alpha1 to v1beta1
+   - Old config with v1alpha1 stops matching
+   - Should we support version wildcards or prefer explicit versions?
+
+## Security Considerations
+
+1. **RBAC Requirements**: Mermin will need RBAC permissions to list/watch CRDs
+2. **Resource Limits**: Consider adding resource limits to prevent DoS from malicious CRDs
+3. **Field Path Validation**: Sanitize user-provided field paths to prevent injection attacks
+4. **API Server Load**: Watching many CRDs increases load on the API server
+
+## Conclusion
+
+Supporting CRDs in both selector relations and owner relations is a valuable feature that would enable Mermin to work with extended Kubernetes ecosystems (Istio, Cilium, ArgoCD, Argo Rollouts, Knative, and custom operators). However, it introduces significant complexity due to the dynamic nature of CRDs.
+
+### Key Benefits
+
+**Selector Relations:**
+
+- Track network policies and services from service meshes (Istio, Linkerd)
+- Support CNI-specific policies (Cilium, Calico)
+- Enable custom application-level selectors
+
+**Owner Relations:**
+
+- Track GitOps deployments (ArgoCD Applications)
+- Support progressive delivery (Argo Rollouts)
+- Enable serverless workloads (Knative)
+- Track operator-managed stateful workloads (PostgreSQL, Redis operators)
+
+### Implementation Strategy
+
+The phased approach outlined here allows us to:
+
+1. **Phase 1**: Start with explicit, user-configured CRD support for both relation types
+   - Lower complexity, predictable behavior
+   - Users explicitly opt-in to specific CRDs
+   - Easier to debug and validate
+2. **Phase 2**: Gather real-world usage patterns and feedback
+   - Identify common CRDs and patterns
+   - Collect performance metrics
+   - Refine configuration model
+3. **Phase 3**: Optionally add auto-discovery (based on actual needs)
+   - Automatic detection of common CRDs
+   - Reduced configuration burden
+   - Intelligent defaults
+
+### Unified Architecture
+
+Both selector and owner relations share the same underlying `DynamicResourceStore`, which:
+
+- Reduces code duplication
+- Ensures consistent CRD watching behavior
+- Simplifies configuration (one place to register CRDs)
+- Enables CRDs to participate in both relation types simultaneously
+
+**Recommendation**: Begin with Phase 1 implementation after validating the design with key users who have specific CRD use cases. Priority should be given to widely-used platforms like ArgoCD, Argo Rollouts, and Istio.

--- a/mermin/src/k8s.rs
+++ b/mermin/src/k8s.rs
@@ -2,5 +2,6 @@ pub mod decorator;
 pub mod error;
 pub mod owner_relations;
 pub mod parser;
+pub mod selector_relations;
 
 pub use error::K8sError;

--- a/mermin/src/k8s/selector_relations.rs
+++ b/mermin/src/k8s/selector_relations.rs
@@ -1,0 +1,1262 @@
+// selector_relations.rs - Selector-based K8s resource relations
+//
+// This module provides functionality for matching Kubernetes resources based on
+// label selectors defined in other resources (e.g., NetworkPolicy -> Pod via podSelector,
+// Service -> Pod via spec.selector).
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::{
+    api::{
+        apps::v1::{DaemonSet, Deployment, ReplicaSet, StatefulSet},
+        batch::v1::{CronJob, Job},
+        core::v1::Service,
+        networking::v1::NetworkPolicy,
+    },
+    apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement},
+};
+use kube::ResourceExt;
+use serde_json::Value;
+use tracing::{debug, trace, warn};
+
+use crate::{
+    k8s::decorator::{K8sObjectMeta, ResourceStore},
+    runtime::conf::SelectorRelationRule,
+};
+
+/// Manages selector-based resource relations according to configuration rules.
+///
+/// This type is thread-safe (`Send + Sync`) and can be shared across tasks.
+/// All state is immutable after construction.
+pub struct SelectorRelationsManager {
+    pub(crate) rules: Vec<NormalizedRule>,
+}
+
+/// Internal representation of a selector relation rule with normalized (lowercase) kinds
+#[derive(Clone, Debug)]
+pub(crate) struct NormalizedRule {
+    /// Source resource kind (normalized to lowercase)
+    pub(crate) kind: String,
+    /// Target resource kind (normalized to lowercase)
+    pub(crate) to: String,
+    /// JSON path to matchLabels field
+    pub(crate) selector_match_labels_field: Option<String>,
+    /// JSON path to matchExpressions field
+    pub(crate) selector_match_expressions_field: Option<String>,
+}
+
+impl SelectorRelationsManager {
+    /// Creates a new SelectorRelationsManager from configuration rules
+    ///
+    /// All kind names are normalized to lowercase for case-insensitive matching.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mermin::k8s::selector_relations::SelectorRelationsManager;
+    /// use mermin::runtime::conf::SelectorRelationRule;
+    ///
+    /// let rules = vec![
+    ///     SelectorRelationRule {
+    ///         kind: "NetworkPolicy".to_string(),
+    ///         to: "Pod".to_string(),
+    ///         selector_match_labels_field: Some("spec.podSelector.matchLabels".to_string()),
+    ///         selector_match_expressions_field: Some("spec.podSelector.matchExpressions".to_string()),
+    ///     },
+    /// ];
+    /// let manager = SelectorRelationsManager::new(rules);
+    /// ```
+    pub fn new(rules: Vec<SelectorRelationRule>) -> Self {
+        let normalized_rules = rules
+            .into_iter()
+            .map(|rule| NormalizedRule {
+                kind: rule.kind.to_lowercase(),
+                to: rule.to.to_lowercase(),
+                selector_match_labels_field: rule.selector_match_labels_field,
+                selector_match_expressions_field: rule.selector_match_expressions_field,
+            })
+            .collect();
+
+        Self {
+            rules: normalized_rules,
+        }
+    }
+
+    /// Finds all resources that have selectors matching the given Pod's labels.
+    ///
+    /// Returns metadata for resources (e.g., NetworkPolicies, Services) whose selectors
+    /// match the pod's labels according to the configured rules.
+    ///
+    /// Returns None if no matching resources are found.
+    #[must_use]
+    pub fn get_related_resources(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        store: &ResourceStore,
+    ) -> Option<Vec<K8sObjectMeta>> {
+        let mut related = Vec::new();
+
+        for rule in &self.rules {
+            // Only process rules that target Pods
+            if rule.to != "pod" {
+                continue;
+            }
+
+            match rule.kind.as_str() {
+                "networkpolicy" => {
+                    related.extend(self.find_matching_network_policies(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                "service" => {
+                    related.extend(self.find_matching_services(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                "replicaset" => {
+                    related.extend(self.find_matching_replicasets(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                "deployment" => {
+                    related.extend(self.find_matching_deployments(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                "statefulset" => {
+                    related.extend(self.find_matching_statefulsets(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                "daemonset" => {
+                    related.extend(self.find_matching_daemonsets(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                "job" => {
+                    related.extend(self.find_matching_jobs(pod_labels, pod_namespace, rule, store));
+                }
+                "cronjob" => {
+                    related.extend(self.find_matching_cronjobs(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                    ));
+                }
+                _ => {
+                    debug!(
+                        event.name = "selector_relations.unsupported_kind",
+                        k8s.selector_rule.kind = %rule.kind,
+                        "selector relation matching for this resource kind is not implemented"
+                    );
+                }
+            }
+        }
+
+        if related.is_empty() {
+            None
+        } else {
+            Some(related)
+        }
+    }
+
+    /// Finds NetworkPolicies whose podSelector matches the given pod labels
+    fn find_matching_network_policies(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let policies = store.get_by_namespace::<NetworkPolicy>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_network_policies",
+            k8s.namespace = %pod_namespace,
+            k8s.policies.count = policies.len(),
+            "checking NetworkPolicies for selector matches"
+        );
+
+        policies
+            .iter()
+            .filter_map(|policy| {
+                let policy_name = policy.name_any();
+
+                // Extract selector from the NetworkPolicy spec
+                let selector = self.extract_selector_from_network_policy(policy, rule)?;
+
+                // Check if selector matches pod labels
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.networkpolicy.name = %policy_name,
+                        k8s.namespace = %pod_namespace,
+                        "NetworkPolicy selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(policy.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Finds Services whose selector matches the given pod labels
+    fn find_matching_services(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let services = store.get_by_namespace::<Service>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_services",
+            k8s.namespace = %pod_namespace,
+            k8s.services.count = services.len(),
+            "checking Services for selector matches"
+        );
+
+        services
+            .iter()
+            .filter_map(|service| {
+                let service_name = service.name_any();
+
+                // Extract selector from the Service spec
+                let selector = self.extract_selector_from_service(service, rule)?;
+
+                // Check if selector matches pod labels
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.service.name = %service_name,
+                        k8s.namespace = %pod_namespace,
+                        "Service selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(service.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a NetworkPolicy based on the rule configuration
+    fn extract_selector_from_network_policy(
+        &self,
+        policy: &NetworkPolicy,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(policy, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.podSelector
+        policy.spec.as_ref().map(|spec| spec.pod_selector.clone())
+    }
+
+    /// Extracts a LabelSelector from a Service based on the rule configuration
+    fn extract_selector_from_service(
+        &self,
+        service: &Service,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(service, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.selector as matchLabels
+        let selector_map = service.spec.as_ref()?.selector.as_ref()?;
+
+        if selector_map.is_empty() {
+            return None;
+        }
+
+        // Convert the selector map to a LabelSelector
+        Some(LabelSelector {
+            match_labels: Some(selector_map.clone()),
+            match_expressions: None,
+        })
+    }
+
+    /// Finds ReplicaSets whose selector matches the given pod labels
+    fn find_matching_replicasets(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let replicasets = store.get_by_namespace::<ReplicaSet>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_replicasets",
+            k8s.namespace = %pod_namespace,
+            k8s.replicasets.count = replicasets.len(),
+            "checking ReplicaSets for selector matches"
+        );
+
+        replicasets
+            .iter()
+            .filter_map(|rs| {
+                let rs_name = rs.name_any();
+                let selector = self.extract_selector_from_replicaset(rs, rule)?;
+
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.replicaset.name = %rs_name,
+                        k8s.namespace = %pod_namespace,
+                        "ReplicaSet selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(rs.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a ReplicaSet
+    fn extract_selector_from_replicaset(
+        &self,
+        replicaset: &ReplicaSet,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(replicaset, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.selector
+        Some(replicaset.spec.as_ref()?.selector.clone())
+    }
+
+    /// Finds Deployments whose selector matches the given pod labels
+    fn find_matching_deployments(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let deployments = store.get_by_namespace::<Deployment>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_deployments",
+            k8s.namespace = %pod_namespace,
+            k8s.deployments.count = deployments.len(),
+            "checking Deployments for selector matches"
+        );
+
+        deployments
+            .iter()
+            .filter_map(|deployment| {
+                let deployment_name = deployment.name_any();
+                let selector = self.extract_selector_from_deployment(deployment, rule)?;
+
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.deployment.name = %deployment_name,
+                        k8s.namespace = %pod_namespace,
+                        "Deployment selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(deployment.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a Deployment
+    fn extract_selector_from_deployment(
+        &self,
+        deployment: &Deployment,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(deployment, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.selector
+        Some(deployment.spec.as_ref()?.selector.clone())
+    }
+
+    /// Finds StatefulSets whose selector matches the given pod labels
+    fn find_matching_statefulsets(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let statefulsets = store.get_by_namespace::<StatefulSet>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_statefulsets",
+            k8s.namespace = %pod_namespace,
+            k8s.statefulsets.count = statefulsets.len(),
+            "checking StatefulSets for selector matches"
+        );
+
+        statefulsets
+            .iter()
+            .filter_map(|sts| {
+                let sts_name = sts.name_any();
+                let selector = self.extract_selector_from_statefulset(sts, rule)?;
+
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.statefulset.name = %sts_name,
+                        k8s.namespace = %pod_namespace,
+                        "StatefulSet selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(sts.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a StatefulSet
+    fn extract_selector_from_statefulset(
+        &self,
+        statefulset: &StatefulSet,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(statefulset, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.selector
+        Some(statefulset.spec.as_ref()?.selector.clone())
+    }
+
+    /// Finds DaemonSets whose selector matches the given pod labels
+    fn find_matching_daemonsets(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let daemonsets = store.get_by_namespace::<DaemonSet>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_daemonsets",
+            k8s.namespace = %pod_namespace,
+            k8s.daemonsets.count = daemonsets.len(),
+            "checking DaemonSets for selector matches"
+        );
+
+        daemonsets
+            .iter()
+            .filter_map(|ds| {
+                let ds_name = ds.name_any();
+                let selector = self.extract_selector_from_daemonset(ds, rule)?;
+
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.daemonset.name = %ds_name,
+                        k8s.namespace = %pod_namespace,
+                        "DaemonSet selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(ds.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a DaemonSet
+    fn extract_selector_from_daemonset(
+        &self,
+        daemonset: &DaemonSet,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(daemonset, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.selector
+        Some(daemonset.spec.as_ref()?.selector.clone())
+    }
+
+    /// Finds Jobs whose selector matches the given pod labels
+    fn find_matching_jobs(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let jobs = store.get_by_namespace::<Job>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_jobs",
+            k8s.namespace = %pod_namespace,
+            k8s.jobs.count = jobs.len(),
+            "checking Jobs for selector matches"
+        );
+
+        jobs.iter()
+            .filter_map(|job| {
+                let job_name = job.name_any();
+                let selector = self.extract_selector_from_job(job, rule)?;
+
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.job.name = %job_name,
+                        k8s.namespace = %pod_namespace,
+                        "Job selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(job.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a Job
+    fn extract_selector_from_job(&self, job: &Job, rule: &NormalizedRule) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(job, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.selector
+        job.spec.as_ref()?.selector.clone()
+    }
+
+    /// Finds CronJobs whose job template selector matches the given pod labels
+    fn find_matching_cronjobs(
+        &self,
+        pod_labels: &BTreeMap<String, String>,
+        pod_namespace: &str,
+        rule: &NormalizedRule,
+        store: &ResourceStore,
+    ) -> Vec<K8sObjectMeta> {
+        let cronjobs = store.get_by_namespace::<CronJob>(pod_namespace);
+
+        trace!(
+            event.name = "selector_relations.check_cronjobs",
+            k8s.namespace = %pod_namespace,
+            k8s.cronjobs.count = cronjobs.len(),
+            "checking CronJobs for selector matches"
+        );
+
+        cronjobs
+            .iter()
+            .filter_map(|cronjob| {
+                let cronjob_name = cronjob.name_any();
+                let selector = self.extract_selector_from_cronjob(cronjob, rule)?;
+
+                if self.selector_matches(&selector, pod_labels) {
+                    trace!(
+                        event.name = "selector_relations.match_found",
+                        k8s.cronjob.name = %cronjob_name,
+                        k8s.namespace = %pod_namespace,
+                        "CronJob selector matches pod labels"
+                    );
+                    Some(K8sObjectMeta::from(cronjob.as_ref()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Extracts a LabelSelector from a CronJob's job template
+    fn extract_selector_from_cronjob(
+        &self,
+        cronjob: &CronJob,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // If custom field paths are specified in the rule, use generic extraction
+        if rule.selector_match_labels_field.is_some()
+            || rule.selector_match_expressions_field.is_some()
+        {
+            return self.extract_selector_generic(cronjob, rule);
+        }
+
+        // Otherwise, use default built-in extraction: spec.jobTemplate.spec.selector
+        cronjob
+            .spec
+            .as_ref()?
+            .job_template
+            .spec
+            .as_ref()?
+            .selector
+            .clone()
+    }
+
+    /// Checks if a label selector matches the given labels
+    ///
+    /// This implements the Kubernetes label selector matching logic:
+    /// - All matchLabels must be present with exact values
+    /// - All matchExpressions must evaluate to true
+    pub(crate) fn selector_matches(
+        &self,
+        selector: &LabelSelector,
+        labels: &BTreeMap<String, String>,
+    ) -> bool {
+        // Check match_labels
+        if let Some(match_labels) = &selector.match_labels {
+            for (key, value) in match_labels {
+                if labels.get(key) != Some(value) {
+                    return false;
+                }
+            }
+        }
+
+        // Check match_expressions
+        if let Some(match_expressions) = &selector.match_expressions {
+            for expr in match_expressions {
+                if !self.expression_matches(expr, labels) {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Checks if a label selector requirement matches the given labels
+    fn expression_matches(
+        &self,
+        expr: &LabelSelectorRequirement,
+        labels: &BTreeMap<String, String>,
+    ) -> bool {
+        let label_value = labels.get(&expr.key);
+        let binding = vec![];
+        let values = expr.values.as_ref().unwrap_or(&binding);
+
+        match expr.operator.as_str() {
+            "In" => {
+                if let Some(value) = label_value {
+                    values.contains(value)
+                } else {
+                    false
+                }
+            }
+            "NotIn" => {
+                if let Some(value) = label_value {
+                    !values.contains(value)
+                } else {
+                    true
+                }
+            }
+            "Exists" => label_value.is_some(),
+            "DoesNotExist" => label_value.is_none(),
+            _ => {
+                warn!(
+                    event.name = "selector_relations.unknown_operator",
+                    k8s.selector.operator = %expr.operator,
+                    "unknown label selector operator"
+                );
+                false
+            }
+        }
+    }
+
+    /// Generic selector extraction using JSON field paths from rule configuration.
+    ///
+    /// This method enables dynamic field path extraction for CRDs and custom resources
+    /// where selectors may be at non-standard locations.
+    ///
+    /// # Arguments
+    /// * `resource` - The resource to extract selector from (must be serializable to JSON)
+    /// * `rule` - The rule containing field paths to matchLabels and matchExpressions
+    ///
+    /// # Returns
+    /// A `LabelSelector` if extraction succeeds, None otherwise
+    pub(crate) fn extract_selector_generic<T: serde::Serialize>(
+        &self,
+        resource: &T,
+        rule: &NormalizedRule,
+    ) -> Option<LabelSelector> {
+        // Serialize resource to JSON for field path extraction
+        let json_value = serde_json::to_value(resource).ok()?;
+
+        let mut selector = LabelSelector::default();
+        let mut has_content = false;
+
+        // Extract matchLabels if field path is specified
+        if let Some(labels_path) = &rule.selector_match_labels_field
+            && let Some(labels_value) = self.extract_json_field(&json_value, labels_path)
+            && let Some(labels_map) = labels_value.as_object()
+        {
+            let match_labels: BTreeMap<String, String> = labels_map
+                .iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect();
+
+            if !match_labels.is_empty() {
+                selector.match_labels = Some(match_labels);
+                has_content = true;
+            }
+        }
+
+        // Extract matchExpressions if field path is specified
+        if let Some(expr_path) = &rule.selector_match_expressions_field
+            && let Some(expressions_value) = self.extract_json_field(&json_value, expr_path)
+            && let Some(expr_array) = expressions_value.as_array()
+        {
+            let match_expressions: Vec<LabelSelectorRequirement> = expr_array
+                .iter()
+                .filter_map(|e| self.parse_label_selector_requirement(e))
+                .collect();
+
+            if !match_expressions.is_empty() {
+                selector.match_expressions = Some(match_expressions);
+                has_content = true;
+            }
+        }
+
+        if has_content { Some(selector) } else { None }
+    }
+
+    /// Extracts a field from a JSON value using a dot-separated path.
+    ///
+    /// # Examples
+    /// - Path "spec.selector" on {"spec": {"selector": {...}}} returns the selector object
+    /// - Path "spec.podSelector.matchLabels" navigates through nested objects
+    fn extract_json_field<'a>(&self, value: &'a Value, path: &str) -> Option<&'a Value> {
+        let parts: Vec<&str> = path.split('.').collect();
+        let mut current = value;
+
+        for part in parts {
+            current = current.get(part)?;
+        }
+
+        Some(current)
+    }
+
+    /// Parses a JSON value into a LabelSelectorRequirement.
+    ///
+    /// Expected JSON structure:
+    /// ```json
+    /// {
+    ///   "key": "environment",
+    ///   "operator": "In",
+    ///   "values": ["prod", "staging"]
+    /// }
+    /// ```
+    fn parse_label_selector_requirement(&self, value: &Value) -> Option<LabelSelectorRequirement> {
+        let obj = value.as_object()?;
+
+        let key = obj.get("key")?.as_str()?.to_string();
+        let operator = obj.get("operator")?.as_str()?.to_string();
+        let values = obj.get("values").and_then(|v| v.as_array()).map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        });
+
+        Some(LabelSelectorRequirement {
+            key,
+            operator,
+            values,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_rule(
+        kind: &str,
+        to: &str,
+        match_labels_field: Option<&str>,
+        match_expressions_field: Option<&str>,
+    ) -> SelectorRelationRule {
+        SelectorRelationRule {
+            kind: kind.to_string(),
+            to: to.to_string(),
+            selector_match_labels_field: match_labels_field.map(String::from),
+            selector_match_expressions_field: match_expressions_field.map(String::from),
+        }
+    }
+
+    fn create_label_selector(
+        match_labels: Option<BTreeMap<String, String>>,
+        match_expressions: Option<Vec<LabelSelectorRequirement>>,
+    ) -> LabelSelector {
+        LabelSelector {
+            match_labels,
+            match_expressions,
+        }
+    }
+
+    fn create_labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_manager_creation() {
+        let rules = vec![
+            create_test_rule("NetworkPolicy", "Pod", Some("spec.podSelector"), None),
+            create_test_rule("Service", "Pod", Some("spec.selector"), None),
+        ];
+
+        let manager = SelectorRelationsManager::new(rules);
+        assert_eq!(manager.rules.len(), 2);
+        assert_eq!(manager.rules[0].kind, "networkpolicy");
+        assert_eq!(manager.rules[1].kind, "service");
+    }
+
+    #[test]
+    fn test_case_insensitive_kind_matching() {
+        let rules = vec![
+            create_test_rule("NETWORKPOLICY", "pod", Some("spec.podSelector"), None),
+            create_test_rule("service", "POD", Some("spec.selector"), None),
+        ];
+
+        let manager = SelectorRelationsManager::new(rules);
+        assert_eq!(manager.rules[0].kind, "networkpolicy");
+        assert_eq!(manager.rules[0].to, "pod");
+        assert_eq!(manager.rules[1].kind, "service");
+        assert_eq!(manager.rules[1].to, "pod");
+    }
+
+    #[test]
+    fn test_selector_matches_with_match_labels() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let selector = create_label_selector(
+            Some(create_labels(&[("app", "nginx"), ("env", "prod")])),
+            None,
+        );
+
+        // Exact match
+        let labels = create_labels(&[("app", "nginx"), ("env", "prod"), ("version", "1.0")]);
+        assert!(manager.selector_matches(&selector, &labels));
+
+        // Missing label
+        let labels = create_labels(&[("app", "nginx")]);
+        assert!(!manager.selector_matches(&selector, &labels));
+
+        // Wrong value
+        let labels = create_labels(&[("app", "nginx"), ("env", "dev")]);
+        assert!(!manager.selector_matches(&selector, &labels));
+    }
+
+    #[test]
+    fn test_selector_matches_with_empty_selector() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let selector = create_label_selector(None, None);
+        let labels = create_labels(&[("app", "nginx")]);
+
+        // Empty selector matches everything
+        assert!(manager.selector_matches(&selector, &labels));
+    }
+
+    #[test]
+    fn test_expression_matches_in_operator() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let expr = LabelSelectorRequirement {
+            key: "env".to_string(),
+            operator: "In".to_string(),
+            values: Some(vec!["dev".to_string(), "staging".to_string()]),
+        };
+
+        // Match
+        let labels = create_labels(&[("env", "dev")]);
+        assert!(manager.expression_matches(&expr, &labels));
+
+        // No match
+        let labels = create_labels(&[("env", "prod")]);
+        assert!(!manager.expression_matches(&expr, &labels));
+
+        // Missing label
+        let labels = create_labels(&[("app", "nginx")]);
+        assert!(!manager.expression_matches(&expr, &labels));
+    }
+
+    #[test]
+    fn test_expression_matches_notin_operator() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let expr = LabelSelectorRequirement {
+            key: "env".to_string(),
+            operator: "NotIn".to_string(),
+            values: Some(vec!["prod".to_string()]),
+        };
+
+        // Match (value not in list)
+        let labels = create_labels(&[("env", "dev")]);
+        assert!(manager.expression_matches(&expr, &labels));
+
+        // No match (value in list)
+        let labels = create_labels(&[("env", "prod")]);
+        assert!(!manager.expression_matches(&expr, &labels));
+
+        // Match (label doesn't exist)
+        let labels = create_labels(&[("app", "nginx")]);
+        assert!(manager.expression_matches(&expr, &labels));
+    }
+
+    #[test]
+    fn test_expression_matches_exists_operator() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let expr = LabelSelectorRequirement {
+            key: "app".to_string(),
+            operator: "Exists".to_string(),
+            values: None,
+        };
+
+        // Match (label exists)
+        let labels = create_labels(&[("app", "nginx")]);
+        assert!(manager.expression_matches(&expr, &labels));
+
+        // No match (label doesn't exist)
+        let labels = create_labels(&[("env", "prod")]);
+        assert!(!manager.expression_matches(&expr, &labels));
+    }
+
+    #[test]
+    fn test_expression_matches_doesnotexist_operator() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let expr = LabelSelectorRequirement {
+            key: "deprecated".to_string(),
+            operator: "DoesNotExist".to_string(),
+            values: None,
+        };
+
+        // Match (label doesn't exist)
+        let labels = create_labels(&[("app", "nginx")]);
+        assert!(manager.expression_matches(&expr, &labels));
+
+        // No match (label exists)
+        let labels = create_labels(&[("deprecated", "true")]);
+        assert!(!manager.expression_matches(&expr, &labels));
+    }
+
+    #[test]
+    fn test_selector_matches_combined() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let selector = create_label_selector(
+            Some(create_labels(&[("app", "nginx")])),
+            Some(vec![LabelSelectorRequirement {
+                key: "env".to_string(),
+                operator: "In".to_string(),
+                values: Some(vec!["dev".to_string(), "staging".to_string()]),
+            }]),
+        );
+
+        // Both match
+        let labels = create_labels(&[("app", "nginx"), ("env", "dev")]);
+        assert!(manager.selector_matches(&selector, &labels));
+
+        // matchLabels fails
+        let labels = create_labels(&[("app", "apache"), ("env", "dev")]);
+        assert!(!manager.selector_matches(&selector, &labels));
+
+        // matchExpressions fails
+        let labels = create_labels(&[("app", "nginx"), ("env", "prod")]);
+        assert!(!manager.selector_matches(&selector, &labels));
+    }
+
+    #[test]
+    fn test_expression_matches_unknown_operator() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let expr = LabelSelectorRequirement {
+            key: "app".to_string(),
+            operator: "UnknownOperator".to_string(),
+            values: None,
+        };
+
+        let labels = create_labels(&[("app", "nginx")]);
+        assert!(!manager.expression_matches(&expr, &labels));
+    }
+
+    #[test]
+    fn test_empty_rules_list() {
+        let manager = SelectorRelationsManager::new(vec![]);
+        assert_eq!(manager.rules.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_match_expressions() {
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let selector = create_label_selector(
+            None,
+            Some(vec![
+                LabelSelectorRequirement {
+                    key: "tier".to_string(),
+                    operator: "In".to_string(),
+                    values: Some(vec!["frontend".to_string(), "backend".to_string()]),
+                },
+                LabelSelectorRequirement {
+                    key: "deprecated".to_string(),
+                    operator: "DoesNotExist".to_string(),
+                    values: None,
+                },
+            ]),
+        );
+
+        // Both expressions match
+        let labels = create_labels(&[("tier", "frontend"), ("app", "web")]);
+        assert!(manager.selector_matches(&selector, &labels));
+
+        // First matches, second fails
+        let labels = create_labels(&[("tier", "frontend"), ("deprecated", "true")]);
+        assert!(!manager.selector_matches(&selector, &labels));
+
+        // First fails, second matches
+        let labels = create_labels(&[("tier", "database"), ("app", "web")]);
+        assert!(!manager.selector_matches(&selector, &labels));
+    }
+
+    #[test]
+    fn test_generic_field_path_extraction_with_deployment() {
+        use serde_json::json;
+
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        // Create a deployment-like JSON structure with custom field paths
+        let deployment_json = json!({
+            "metadata": {
+                "name": "test-deployment",
+                "namespace": "default"
+            },
+            "spec": {
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx",
+                        "tier": "frontend"
+                    }
+                }
+            }
+        });
+
+        // Extract selector using custom field path
+        let rule = NormalizedRule {
+            kind: "deployment".to_string(),
+            to: "pod".to_string(),
+            selector_match_labels_field: Some("spec.selector.matchLabels".to_string()),
+            selector_match_expressions_field: None,
+        };
+
+        let selector = manager.extract_selector_generic(&deployment_json, &rule);
+        assert!(selector.is_some());
+
+        let selector = selector.unwrap();
+        assert!(selector.match_labels.is_some());
+
+        let match_labels = selector.match_labels.unwrap();
+        assert_eq!(match_labels.get("app"), Some(&"nginx".to_string()));
+        assert_eq!(match_labels.get("tier"), Some(&"frontend".to_string()));
+    }
+
+    #[test]
+    fn test_generic_field_path_extraction_with_match_expressions() {
+        use serde_json::json;
+
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        // Create a JSON structure with matchExpressions
+        let resource_json = json!({
+            "spec": {
+                "podSelector": {
+                    "matchLabels": {
+                        "app": "web"
+                    },
+                    "matchExpressions": [
+                        {
+                            "key": "environment",
+                            "operator": "In",
+                            "values": ["prod", "staging"]
+                        }
+                    ]
+                }
+            }
+        });
+
+        // Extract selector using custom field paths for both matchLabels and matchExpressions
+        let rule = NormalizedRule {
+            kind: "networkpolicy".to_string(),
+            to: "pod".to_string(),
+            selector_match_labels_field: Some("spec.podSelector.matchLabels".to_string()),
+            selector_match_expressions_field: Some("spec.podSelector.matchExpressions".to_string()),
+        };
+
+        let selector = manager.extract_selector_generic(&resource_json, &rule);
+        assert!(selector.is_some());
+
+        let selector = selector.unwrap();
+
+        // Verify matchLabels
+        assert!(selector.match_labels.is_some());
+        let match_labels = selector.match_labels.unwrap();
+        assert_eq!(match_labels.get("app"), Some(&"web".to_string()));
+
+        // Verify matchExpressions
+        assert!(selector.match_expressions.is_some());
+        let match_expressions = selector.match_expressions.unwrap();
+        assert_eq!(match_expressions.len(), 1);
+        assert_eq!(match_expressions[0].key, "environment");
+        assert_eq!(match_expressions[0].operator, "In");
+        assert_eq!(
+            match_expressions[0].values,
+            Some(vec!["prod".to_string(), "staging".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_generic_field_path_extraction_with_nested_path() {
+        use serde_json::json;
+
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        // Create a JSON structure with deeply nested selector (like CronJob)
+        let cronjob_json = json!({
+            "spec": {
+                "jobTemplate": {
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "controller": "cronjob",
+                                "job": "backup"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Extract selector using deeply nested field path
+        let rule = NormalizedRule {
+            kind: "cronjob".to_string(),
+            to: "pod".to_string(),
+            selector_match_labels_field: Some(
+                "spec.jobTemplate.spec.selector.matchLabels".to_string(),
+            ),
+            selector_match_expressions_field: None,
+        };
+
+        let selector = manager.extract_selector_generic(&cronjob_json, &rule);
+        assert!(selector.is_some());
+
+        let selector = selector.unwrap();
+        assert!(selector.match_labels.is_some());
+
+        let match_labels = selector.match_labels.unwrap();
+        assert_eq!(match_labels.get("controller"), Some(&"cronjob".to_string()));
+        assert_eq!(match_labels.get("job"), Some(&"backup".to_string()));
+    }
+
+    #[test]
+    fn test_generic_field_path_extraction_returns_none_for_invalid_path() {
+        use serde_json::json;
+
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let resource_json = json!({
+            "spec": {
+                "selector": {
+                    "matchLabels": {
+                        "app": "test"
+                    }
+                }
+            }
+        });
+
+        // Try to extract with an invalid field path
+        let rule = NormalizedRule {
+            kind: "test".to_string(),
+            to: "pod".to_string(),
+            selector_match_labels_field: Some("spec.nonexistent.matchLabels".to_string()),
+            selector_match_expressions_field: None,
+        };
+
+        let selector = manager.extract_selector_generic(&resource_json, &rule);
+        assert!(selector.is_none());
+    }
+
+    #[test]
+    fn test_generic_field_path_extraction_returns_none_for_empty_selector() {
+        use serde_json::json;
+
+        let manager = SelectorRelationsManager::new(vec![]);
+
+        let resource_json = json!({
+            "spec": {
+                "selector": {
+                    "matchLabels": {}
+                }
+            }
+        });
+
+        // Extract selector with empty matchLabels
+        let rule = NormalizedRule {
+            kind: "test".to_string(),
+            to: "pod".to_string(),
+            selector_match_labels_field: Some("spec.selector.matchLabels".to_string()),
+            selector_match_expressions_field: None,
+        };
+
+        let selector = manager.extract_selector_generic(&resource_json, &rule);
+        // Should return None because the selector has no actual content
+        assert!(selector.is_none());
+    }
+}

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -343,7 +343,7 @@ async fn run() -> Result<()> {
         "initializing kubernetes client"
     );
 
-    // Extract owner_relations configuration from discovery.informer.k8s if present
+    // Extract owner_relations and selector_relations configuration from discovery.informer.k8s if present
     let owner_relations_opts = conf
         .discovery
         .informer
@@ -351,7 +351,20 @@ async fn run() -> Result<()> {
         .and_then(|informer| informer.k8s.as_ref())
         .and_then(|k8s_conf| k8s_conf.owner_relations.clone());
 
-    let k8s_decorator = match Decorator::new(health_state.clone(), owner_relations_opts).await {
+    let selector_relations_opts = conf
+        .discovery
+        .informer
+        .as_ref()
+        .and_then(|informer| informer.k8s.as_ref())
+        .and_then(|k8s_conf| k8s_conf.selector_relations.clone());
+
+    let k8s_decorator = match Decorator::new(
+        health_state.clone(),
+        owner_relations_opts,
+        selector_relations_opts,
+    )
+    .await
+    {
         Ok(decorator) => {
             info!(
                 event.name = "k8s.client.init.success",


### PR DESCRIPTION
Implements configurable selector-based matching between Kubernetes resources, enabling custom CRD relationships through label selectors and match expressions. Adds new selector_relations module with support for matchLabels and matchExpressions fields, configuration structures, and comprehensive documentation.

Key changes:
- Add selector_relations module with matching logic
- Extend K8s decorator to support selector-based relations
- Add configuration schema for selector relation rules
- Include examples for NetworkPolicy and Service selectors
- Add comprehensive documentation in custom_crd_selector_relations.md

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
