### PR TITLE
fix: flow timestamp ordering and refactor export config structure

### DIFF
--- a/.cursor/commands/commit-msg.md
+++ b/.cursor/commands/commit-msg.md
@@ -1,0 +1,21 @@
+# Generate Commit Message
+
+Analyze the currently staged git changes and generate a concise, descriptive commit message.
+
+## Instructions
+
+1. Run `git diff --cached` to view all staged changes
+2. Analyze the changes to understand:
+   - What functionality was added, modified, or removed
+   - Bug fixes or refactoring that was done
+   - Any configuration or structural changes
+3. Generate a commit message that:
+   - Uses imperative mood (e.g., "Fix", "Add", "Refactor", not "Fixed", "Added")
+   - Has a clear, concise subject line (50-72 characters)
+   - Optionally includes bullet points for multiple significant changes
+   - Groups related changes together logically
+4. Provide both a single-line version and a detailed version (if needed)
+
+## Output Format
+
+Provide the commit message in a code block so it can be easily copied.

--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -691,7 +691,9 @@ span {
 # OTLP exporter configuration
 # See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
-  stdout = "" // text, text_indent(*new), json, json_indent
+  stdout = {
+    format = "text_indent" // text, text_indent(*new), json, json_indent
+  }
 
   otlp = {
     endpoint               = "http://otelcol:4317"

--- a/charts/mermin/config/examples/config.yaml
+++ b/charts/mermin/config/examples/config.yaml
@@ -392,7 +392,8 @@ internal:
         client_key: /etc/certs/cert.key
         insecure_skip_verify: false
     span_format: full
-    stdout: ""
+    stdout:
+      format: "text_indent" # text, text_indent(*new), json, json_indent
 log_level: info
 metrics:
   enabled: true

--- a/examples/local_otel/config.hcl
+++ b/examples/local_otel/config.hcl
@@ -1,8 +1,6 @@
 # OTLP exporter configuration
 # See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
-  stdout = ""
-
   otlp = {
     endpoint = "https://otel-collector.default.svc.cluster.local:4317"
 

--- a/examples/netobserv_os_simple_gke_gw/config.hcl
+++ b/examples/netobserv_os_simple_gke_gw/config.hcl
@@ -1,7 +1,9 @@
 # OTLP exporter configuration
 # See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
-  # stdout = "" # Uncomment if you need spans in the stdout
+  # stdout = {
+  #   format = "text_indent" // text, text_indent(*new), json, json_indent
+  # }
 
   otlp = {
     endpoint = "https://10.0.7.231:443"

--- a/examples/netobserv_os_simple_svc/config.hcl
+++ b/examples/netobserv_os_simple_svc/config.hcl
@@ -1,7 +1,9 @@
 # OTLP exporter configuration
 # See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
-  # stdout = "" # Uncomment if you need spans in the stdout
+  # stdout = {
+  #   format = "text_indent" // text, text_indent(*new), json, json_indent
+  # }
 
   otlp = {
     endpoint = "https://netobserv-flow.elastiflow.svc.cluster.local:4317"

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -167,14 +167,17 @@ async fn run() -> Result<()> {
         init_internal_tracing(
             conf.log_level,
             conf.internal.traces.span_fmt,
-            conf.internal.traces.stdout,
+            conf.internal.traces.stdout.clone(),
             conf.internal.traces.otlp.clone(),
         )
         .await?;
 
         if conf.export.traces.stdout.is_some() || conf.export.traces.otlp.is_some() {
-            let app_tracer_provider =
-                init_provider(conf.export.traces.stdout, conf.export.traces.otlp.clone()).await?;
+            let app_tracer_provider = init_provider(
+                conf.export.traces.stdout.clone(),
+                conf.export.traces.otlp.clone(),
+            )
+            .await?;
             info!(
                 event.name = "task.started",
                 task.name = "exporter",

--- a/mermin/src/runtime/opts.rs
+++ b/mermin/src/runtime/opts.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    otlp::opts::{OtlpExporterOptions, StdoutFmt},
-    runtime::conf::conf_serde::stdout_fmt,
-};
+use crate::otlp::opts::{OtlpExportOptions, StdoutExportOptions};
 
 /// Represents the entire top-level `traces` block for internal monitoring.
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
@@ -23,12 +20,11 @@ pub struct InternalTraceOptions {
     /// - `FmtSpan::ACTIVE`: Only span events for spans that are active (i.e., not closed) are recorded.
     pub span_fmt: SpanFmt,
 
-    /// Defines the format for a stdout exporter.
-    #[serde(with = "stdout_fmt")]
-    pub stdout: Option<StdoutFmt>,
+    /// Stdout exporter configuration options.
+    pub stdout: Option<StdoutExportOptions>,
 
     /// OTLP (OpenTelemetry Protocol) exporter configurations.
-    pub otlp: Option<OtlpExporterOptions>,
+    pub otlp: Option<OtlpExportOptions>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Description

- Restructure stdout export configuration to use nested format object instead of simple string, improving consistency with other exporters
- Rename OtlpExporterOptions to OtlpExportOptions for consistency
- Remove default OTLP configuration, making export opt-in rather than default-enabled
- Fix flow span timestamp handling for out-of-order packets from per-CPU ring buffers by tracking both earliest start and latest end
- Add validation to reject empty stdout format strings
- Update config examples and tests to reflect new structure

## Type of Change

- [x] Bug fix (non-breaking change that resolves an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes, just code improvements)

## How Has This Been Tested?

- Updated unit tests.
- Performed manual verification.

- **Environment**:
    - OS: Debian 12
    - Rust: 1.88.0

## Checklist

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.