### PR TITLE
feat: subscribe to opentelemetry logs

### DIFF
--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -381,7 +381,7 @@ async fn run() -> Result<()> {
         }
         Err(e) => {
             error!(
-                event.name = "k8s.client_init_failed",
+                event.name = "k8s.client.init.failed",
                 error.message = %e,
                 "failed to initialize kubernetes client; metadata lookup will be unavailable"
             );

--- a/mermin/src/otlp/provider.rs
+++ b/mermin/src/otlp/provider.rs
@@ -32,6 +32,7 @@ use tracing_subscriber::{
 use crate::{
     otlp::{
         OtlpError,
+        log_interceptor::{ExportFailureTracker, LogInterceptorLayer, LogPattern},
         opts::{OtlpExportOptions, StdoutExportOptions, defaults},
     },
     runtime::opts::SpanFmt,
@@ -501,7 +502,10 @@ pub async fn init_internal_tracing(
         }
     }
 
-    let filter = EnvFilter::new(format!("warn,mermin={log_level}"));
+    let filter = EnvFilter::new(format!(
+        "warn,mermin={log_level},opentelemetry_sdk={log_level},opentelemetry={log_level},opentelemetry_otlp={log_level}"
+    ));
+
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)


### PR DESCRIPTION
## Description

Small change to allow our tracing subscriber to pick up logs that come from the open telemetry tracing fascade.