### PR TITLE
feat(chart): add optional host networking in daemonset

### DIFF
--- a/charts/mermin/templates/daemonset.yaml
+++ b/charts/mermin/templates/daemonset.yaml
@@ -36,6 +36,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       hostPID: {{ .Values.config.hostPidEnrichment }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "mermin.serviceAccountName" . }}

--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -104,6 +104,9 @@ tolerations:
 
 affinity: {}
 
+# Enable host networking mode for the pod
+hostNetwork: false
+
 config:
   # Inject config hash to the pod label to force pod restart
   restartOnConfigChange: true


### PR DESCRIPTION
## Description

Allow chart users to enable or disable host networking on the mermin daemonset.

## Type of Change

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes, just code improvements)
- [ ] Other (please describe):

## How Has This Been Tested?

```sh
helm template test-release ./charts/mermin
# Test with `hostNetwork: true` to verify it can be enabled:
helm template test-release ./charts/mermin --set hostNetwork=true
# Dry-run:
helm upgrade --install mermin ./charts/mermin --dry-run --debug
# Render full YAML to review the complete output:
helm template test-release ./charts/mermin > /tmp/mermin-rendered.yaml
cat /tmp/mermin-rendered.yaml
```

## Checklist

<!-- Confirm the following by checking the boxes. -->

- [x] My code follows the project's coding style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where necessary.
- [x] My changes generate no new warnings or errors.
- [x] I have added or updated tests that verify my changes.
- [x] All new and existing tests pass.

