### PR TITLE
fix: Bump the mermin dependency in the "mermin-netobserv-os-stack"

### DIFF
--- a/charts/mermin-netobserv-os-stack/Chart.lock
+++ b/charts/mermin-netobserv-os-stack/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: mermin
   repository: https://raw.githubusercontent.com/elastiflow/mermin/gh-pages
-  version: 0.1.0-beta.12
+  version: 0.1.0-beta.13
 - name: netobserv-flow
   repository: https://elastiflow.github.io/helm-chart-netobserv/
   version: 0.5.0
@@ -11,5 +11,5 @@ dependencies:
 - name: opensearch-dashboards
   repository: https://opensearch-project.github.io/helm-charts/
   version: 3.3.0
-digest: sha256:319cef089692b1bf209b5b17b78ffb80a4a6310c26f2ffd76e5be18661410e7f
-generated: "2025-11-04T20:42:32.607497+02:00"
+digest: sha256:7e1c8c886d319b52823ad48d98cc5ffb3db9c2f1895edd95eb5504c8356ae55d
+generated: "2025-11-04T23:11:24.162864+02:00"

--- a/charts/mermin-netobserv-os-stack/Chart.yaml
+++ b/charts/mermin-netobserv-os-stack/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     # TODO(Cleanup for GA): Should be https://elastiflow.github.io/mermin/, raw.githubusercontent.com... is used whilst repo is private
     # repository: https://elastiflow.github.io/mermin/
     repository: https://raw.githubusercontent.com/elastiflow/mermin/gh-pages
-    version: ">= 0.1.0-beta.12"
+    version: ">= 0.1.0-beta.13"
     condition: mermin.enabled
   - name: netobserv-flow
     repository: https://elastiflow.github.io/helm-chart-netobserv/


### PR DESCRIPTION
## Description
Bump the mermin dependency in the "mermin-netobserv-os-stack"