### PR TITLE
fix: Docker tags should not have `v` prefix

### DIFF
--- a/.github/workflows/release_mermin.yml
+++ b/.github/workflows/release_mermin.yml
@@ -138,8 +138,8 @@ jobs:
     env:
       TARGET_IMAGE_TAG: |
         {
-            "runner": "v${{ needs.release.outputs.new_release_version }}",
-            "runner-debug": "v${{ needs.release.outputs.new_release_version }}-debug"
+            "runner": "${{ needs.release.outputs.new_release_version }}",
+            "runner-debug": "${{ needs.release.outputs.new_release_version }}-debug"
         }
     steps:
       - name: Checkout

--- a/charts/mermin/templates/daemonset.yaml
+++ b/charts/mermin/templates/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports: {{ .Values.ports | toYaml | nindent 12 }}
           {{- if or .Values.config.content .Values.extraArgs }}


### PR DESCRIPTION
## Description

Grafana, go, influxdb don't have `v` prefix, although our tags has `v` prefix, it makes sense to have image without the prefix