### PR TITLE
fix(helm): Set the reasonable security defaults

### DIFF
--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -12,11 +12,8 @@ imagePullSecrets: []
 updateStrategy:
   type: RollingUpdate
   rollingUpdate:
-    maxUnavailable: 1
-    maxSurge: 0
-    # TODO(mack#lgo-406|2025-11-04): If hostNetwork: false, following may be used
-    # maxUnavailable: 0
-    # maxSurge: "10%"
+    maxUnavailable: 0
+    maxSurge: "10%"
 
 # Mermin container extra args
 extraArgs: []
@@ -44,20 +41,17 @@ commonLabels: {}
 podAnnotations: {}
 podLabels: {}
 
-# Enable host networking mode for the pod, incompatible with surge upgrades
-# TODO(mack#lgo-406|2025-11-04): Check if eBPF program can switch namespaces
+# Enable host networking mode for the pod, incompatible with surge upgrades, may require "dnsPolicy: ClusterFirstWithHostNet"
 hostNetwork: false
-dnsPolicy: ClusterFirstWithHostNet
-hostPID: false
+dnsPolicy: ClusterFirst
+hostPID: true
 
-# TODO(mack#lgo-406|2025-11-04): Reiterate on defaults
 podSecurityContext:
-  runAsNonRoot: false
+  runAsNonRoot: true
 
-# TODO(mack#lgo-406|2025-11-04): Reiterate on defaults
 securityContext:
-  # namespace switching requires specific capabilities but not full privileged mode
-  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: false
   capabilities:
     drop:
       - ALL
@@ -67,8 +61,6 @@ securityContext:
       - PERFMON
       - SYS_ADMIN
       - SYS_RESOURCE
-  readOnlyRootFilesystem: true
-  runAsNonRoot: false
 
 resources: {}
   # TODO(mack#ENG-123|2025-09-29): Set default resources relative to the flows per second

--- a/examples/netobserv_os_simple_svc/README.md
+++ b/examples/netobserv_os_simple_svc/README.md
@@ -55,25 +55,6 @@ Notes on the example deployment:
     mermin mermin/mermin-netobserv-os-stack
   ```
 
-```sh
-# mack testing
-docker build -t mermin:latest --target runner-debug .
-kind load docker-image -n atlantis mermin:latest
-
-helm upgrade -i --wait --timeout 15m -n elastiflow \
-  -f examples/netobserv_os_simple_svc/values.yaml \
-  --set-file mermin.config.content=examples/netobserv_os_simple_svc/config.hcl \
-  --devel \
-  mermin mermin/mermin-netobserv-os-stack
-
-rm -rf helm_rendered; helm template -n elastiflow \
-  -f examples/netobserv_os_simple_svc/values.yaml \
-  --set-file mermin.config.content=examples/netobserv_os_simple_svc/config.hcl \
-  --output-dir helm_rendered \
-  --devel \
-  mermin mermin/mermin-netobserv-os-stack  
-```
-
 - Optionally install `metrics-server` to get metrics if it has not been installed yet
 
   ```sh

--- a/examples/netobserv_os_simple_svc/config.hcl
+++ b/examples/netobserv_os_simple_svc/config.hcl
@@ -1,15 +1,10 @@
-log_level = "debug"
-# discovery "instrument" {
-#   # Network interfaces to monitor
-#   interfaces = ["*"]
-# }
-
 # OTLP exporter configuration
 # See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
-  stdout = {
-    format = "text_indent" // text, text_indent(*new), json, json_indent
-  }
+  # Uncomment to receive spans in STDOUT
+  # stdout = {
+  #   format = "text_indent" // text, text_indent(*new), json, json_indent
+  # }
 
   otlp = {
     endpoint = "https://netobserv-flow.elastiflow.svc:4317"

--- a/examples/netobserv_os_simple_svc/values.yaml
+++ b/examples/netobserv_os_simple_svc/values.yaml
@@ -1,47 +1,8 @@
 mermin:
   enabled: true
-  # TODO(mack#lgo-406|2025-11-04): Should be remove and defaults to be used
-  image:
-    repository: mermin
-    tag: latest
   # TODO(Cleanup for GA): image pull secrets not needed when going public
   imagePullSecrets:
     - name: ghcr
-
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 1
-      maxSurge: 0
-
-  # Enable host networking mode for the pod, incompatible with surge upgrades
-  # TODO(mack#lgo-406|2025-11-04): Check if eBPF program can switch namespaces
-  hostNetwork: false
-  dnsPolicy: ClusterFirst
-  hostPID: true
-
-  # TODO(mack#lgo-406|2025-11-04): Reiterate on defaults
-  podSecurityContext:
-    runAsNonRoot: true
-
-  # TODO(mack#lgo-406|2025-11-04): Reiterate on defaults
-  securityContext:
-    readOnlyRootFilesystem: true
-    runAsNonRoot: false
-    capabilities:
-      drop:
-        - ALL
-      add:
-        # TC attachment
-        - NET_ADMIN
-        # eBPF operations (kernel 5.8+)
-        - BPF
-        # Ring buffers (kernel 5.8+)
-        - PERFMON
-        # setns() and BPF filesystem access
-        - SYS_ADMIN
-        # memlock limits
-        - SYS_RESOURCE
 
 netobserv-flow:
   enabled: true

--- a/makefiles/helm.mk
+++ b/makefiles/helm.mk
@@ -35,14 +35,14 @@ EXTRA_HELM_ARGS?=
 
 .PHONY: helm-template
 helm-template:
-	rm -rf ${HELM_OUTPUT_DIR}
+	rm -rf ${HELM_OUTPUT_DIR_PREFIX}
 	helm template ${APP} ${HELM_CHART} \
 		--output-dir ${HELM_OUTPUT_DIR_PREFIX} \
 		${HELM_ARGS} ${EXTRA_HELM_ARGS}
 
 .PHONY: helm-template-silent
 helm-template-silent:
-	@rm -rf ${HELM_OUTPUT_DIR} > /dev/null
+	@rm -rf ${HELM_OUTPUT_DIR_PREFIX} > /dev/null
 	@helm template ${APP} ${HELM_CHART} \
 		--output-dir ${HELM_OUTPUT_DIR_PREFIX} \
 		${HELM_ARGS} ${EXTRA_HELM_ARGS} > /dev/null


### PR DESCRIPTION
## Description

* fix: Set the reasonable security defaults
  * Add only required `capabilities`
  * Use `hostPID` to allow network namespace switching for eBPF program
  * Disable `hostNetwork` since eBPF program can now switch namespaces
  * Enable "surge" upgrades back, cause `hostNetwork` is not used anymore
* chore: Cleanup the "Simple SVC" example
* fix: New `discovery "instrument"` default example config
* chore: Remove full `helm_rendered` when debugging charts locally