### PR TITLE
feat: add configurable TCX ordering and optimize tunnel port lookups

### DIFF
--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -142,8 +142,15 @@ discovery "instrument" {
   # Higher values = lower priority = runs later in TC chain
   # Default: 50 (runs after most CNI programs like Cilium which use 1-20)
   # Range: 1-32767 (values < 30 will log warning - may conflict with CNI programs)
-  # On kernel >= 6.6, TCX is used automatically (no priority needed)
   tc_priority = 50
+
+  # TCX ordering strategy (TCX only, kernel >= 6.6)
+  # Controls where mermin attaches in the TCX program chain
+  # Options:
+  #   "last"  (default) - Attach at tail, runs after all programs (recommended for observability)
+  #   "first"           - Attach at head, runs before all programs (use with caution!)
+  # Default: "last" (ensures mermin runs after Cilium's service load balancing)
+  tcx_order = "last"
 
   # Automatically discover and attach to new interfaces matching patterns
   # Recommended for ephemeral interfaces like veth* (created/destroyed with pods)

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -204,6 +204,7 @@ async fn run() -> Result<()> {
         event.name = "ebpf.attach_method_determined",
         ebpf.attach.method = attach_method,
         ebpf.attach.priority = conf.discovery.instrument.tc_priority,
+        ebpf.attach.tcx_order = %conf.discovery.instrument.tcx_order,
         system.kernel.version = %kernel_version,
         "determined TC attachment method and priority"
     );
@@ -239,6 +240,7 @@ async fn run() -> Result<()> {
         Arc::clone(&ebpf),
         use_tcx,
         conf.discovery.instrument.tc_priority,
+        conf.discovery.instrument.tcx_order.clone(),
     )?;
 
     // DashMap allows lock-free reads during packet processing while controller updates it dynamically


### PR DESCRIPTION
## Changes

- Add tcx_order configuration option for kernel >= 6.6
  * New TcxOrderStrategy enum with "last" (default) and "first" options
  * Controls whether mermin attaches at head or tail of TCX chain
  * "last" recommended for observability (runs after Cilium/CNI)
  * Validation warns if using "first" due to potential conflicts
  * Update controller to use LinkOrder API with configured strategy

- Optimize eBPF tunnel port lookups
  * Cache tunnel_ports configuration alongside parser_options
  * Pass as parameter to parse_udp_header instead of repeated map lookups
  * Reduces overhead during packet processing
  * Update tests to construct TunnelPorts for parse_udp_header calls

- Update example configuration with tcx_order documentation

Fixes #(issue)

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other:

## Testing

Local deployment

## Proof it works

n/a

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass
