### PR TITLE
fix: Set security context to privileged mode

### DIFF
--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -38,9 +38,7 @@ rbac:
 # global common labels, applied to all ressources
 commonLabels: {}
 
-podAnnotations:
-  # Allow unconfined apparmor profile for the mermin container to allow ptrace access to the host network namespace
-  container.apparmor.security.beta.kubernetes.io/mermin: unconfined
+podAnnotations: {}
 podLabels: {}
 
 # Enable host networking mode for the pod, incompatible with surge upgrades, may require "dnsPolicy: ClusterFirstWithHostNet"
@@ -50,25 +48,13 @@ hostPID: true
 
 podSecurityContext:
   runAsNonRoot: true
-  # Allow unconfined seccomp profile for the mermin container to allow BPF syscalls and ring buffer writes
-  seccompProfile:
-    type: Unconfined
 
 securityContext:
+  privileged: true
   readOnlyRootFilesystem: true
   runAsNonRoot: false
   runAsUser: 0
   runAsGroup: 0
-  capabilities:
-    drop:
-      - ALL
-    add:
-      - NET_ADMIN
-      - BPF
-      - PERFMON
-      - SYS_ADMIN
-      - SYS_PTRACE
-      - SYS_RESOURCE
 
 resources: {}
   # TODO(mack#ENG-123|2025-09-29): Set default resources relative to the flows per second


### PR DESCRIPTION
## Changes

* Instead of constantly modifying capabilities, use privileged mode for the security context to ensure Mermin can make all necessary host calls to gather network data. 

Fixes #(issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other:

## Testing

* This has been set in gke, k3s, and kind. Each works with privileged mode set to true and individual capabilities removed.

## Proof it works

<img width="1650" height="91" alt="Screenshot 2025-11-08 at 11 15 01 AM" src="https://github.com/user-attachments/assets/a44a236a-9388-434d-8d39-c2025b310421" />

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass
