### PR TITLE
feat: add Prometheus metrics server and stability improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
+ "lazy_static",
  "libc",
  "log",
  "mermin-common",
@@ -1972,6 +1973,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "pnet",
+ "prometheus",
  "regex",
  "rtnetlink",
  "rustls",
@@ -2625,6 +2627,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2663,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -36,6 +36,7 @@ jsonpath-rust = "1.0.4"
 k8s-openapi = { version = "0.25.0", features = ["v1_30"] }
 kube = { version = "1.1.0", features = ["runtime", "derive", "client"] }
 kube-runtime = "1.1.0"
+lazy_static = "1.4"
 libc = { workspace = true }
 log = { workspace = true }
 mermin-common = { path = "../mermin-common", features = ["user"] }
@@ -51,6 +52,7 @@ opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic"] }
 opentelemetry-stdout = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["experimental_async_runtime", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
 pnet = "0.34"
+prometheus = "0.13"
 regex = "1"
 rtnetlink = "0.18.1"
 rustls = "0.23"

--- a/mermin/src/ip.rs
+++ b/mermin/src/ip.rs
@@ -5,7 +5,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use mermin_common::IpVersion;
+use mermin_common::{FlowKey, IpVersion};
 
 /// Resolve IP addresses from raw byte arrays based on the provided IP address type.
 #[allow(dead_code)]
@@ -28,6 +28,23 @@ pub fn resolve_addrs(
             let dst = IpAddr::V6(Ipv6Addr::from(dst_ipv6_addr));
             Ok((src, dst))
         }
+    }
+}
+
+/// Convert FlowKey IPs to IpAddr for Community ID generation.
+pub fn flow_key_to_ip_addrs(key: &FlowKey) -> Result<(IpAddr, IpAddr), Error> {
+    match key.ip_version {
+        IpVersion::V4 => {
+            let src = Ipv4Addr::new(key.src_ip[0], key.src_ip[1], key.src_ip[2], key.src_ip[3]);
+            let dst = Ipv4Addr::new(key.dst_ip[0], key.dst_ip[1], key.dst_ip[2], key.dst_ip[3]);
+            Ok((IpAddr::V4(src), IpAddr::V4(dst)))
+        }
+        IpVersion::V6 => {
+            let src = Ipv6Addr::from(key.src_ip);
+            let dst = Ipv6Addr::from(key.dst_ip);
+            Ok((IpAddr::V6(src), IpAddr::V6(dst)))
+        }
+        _ => Err(Error::UnknownIpAddrType),
     }
 }
 

--- a/mermin/src/metrics.rs
+++ b/mermin/src/metrics.rs
@@ -1,0 +1,6 @@
+pub mod ebpf;
+pub mod error;
+pub mod export;
+pub mod flow;
+pub mod registry;
+pub mod server;

--- a/mermin/src/metrics/ebpf.rs
+++ b/mermin/src/metrics/ebpf.rs
@@ -1,0 +1,58 @@
+//! Helper functions for eBPF-related metrics.
+
+use crate::metrics::registry;
+
+/// Increment the orphan cleanup counter.
+///
+/// Call this when the orphan scanner successfully removes a stale entry.
+///
+/// ### Arguments:
+///
+/// - `count` - Number of orphaned entries cleaned up
+pub fn inc_orphans_cleaned(count: u64) {
+    registry::EBPF_ORPHANS_CLEANED.inc_by(count);
+}
+
+/// Set the current number of entries in the eBPF map.
+///
+/// ### Arguments:
+///
+/// - `entries` - Current number of entries in the flow stats map
+pub fn set_map_entries(entries: u64) {
+    registry::EBPF_MAP_ENTRIES
+        .with_label_values(&["flow_stats"])
+        .set(entries as i64);
+}
+
+/// Set the current number of flows tracked in userspace.
+///
+/// ### Arguments:
+///
+/// - `flows` - Current number of flows in the userspace flow store
+pub fn set_userspace_flows(flows: u64) {
+    registry::EBPF_USERSPACE_FLOWS.set(flows as i64);
+}
+
+/// Increment the TC program attached counter.
+///
+/// ### Arguments:
+///
+/// - `interface` - Network interface name
+/// - `direction` - Traffic direction ("ingress" or "egress")
+pub fn inc_tc_programs_attached(interface: &str, direction: &str) {
+    registry::TC_PROGRAMS_ATTACHED
+        .with_label_values(&[interface, direction])
+        .inc();
+}
+
+/// Increment the TC program detached counter.
+///
+/// ### Arguments:
+///
+/// - `interface` - Network interface name
+/// - `direction` - Traffic direction ("ingress" or "egress")
+pub fn inc_tc_programs_detached(interface: &str, direction: &str) {
+    registry::TC_PROGRAMS_DETACHED
+        .with_label_values(&[interface, direction])
+        .inc();
+}

--- a/mermin/src/metrics/error.rs
+++ b/mermin/src/metrics/error.rs
@@ -1,0 +1,37 @@
+//! Error types for the metrics module.
+
+use std::io;
+
+use thiserror::Error;
+
+/// Errors that can occur in the metrics system.
+#[derive(Debug, Error)]
+pub enum MetricsError {
+    /// Failed to bind to the configured address and port.
+    #[error("failed to bind metrics server to {address}: {source}")]
+    BindAddress {
+        /// The address that failed to bind.
+        address: String,
+        /// The underlying I/O error.
+        #[source]
+        source: io::Error,
+    },
+
+    /// Failed to serve HTTP requests.
+    #[error("metrics server error: {0}")]
+    ServeError(#[from] io::Error),
+
+    /// Prometheus registry error.
+    #[error("prometheus registry error: {0}")]
+    PrometheusError(#[from] prometheus::Error),
+}
+
+impl MetricsError {
+    /// Create a bind address error.
+    pub fn bind_address(address: impl Into<String>, source: io::Error) -> Self {
+        Self::BindAddress {
+            address: address.into(),
+            source,
+        }
+    }
+}

--- a/mermin/src/metrics/export.rs
+++ b/mermin/src/metrics/export.rs
@@ -1,0 +1,23 @@
+//! Helper functions for export-related metrics.
+
+use std::time::Duration;
+
+use crate::metrics::registry;
+
+/// Increment the spans exported counter.
+///
+/// ### Arguments
+///
+/// - `count` - Number of spans successfully exported
+pub fn inc_spans_exported(count: u64) {
+    registry::SPANS_EXPORTED.inc_by(count);
+}
+
+/// Record export operation latency.
+///
+/// ### Arguments
+///
+/// - `duration` - Time taken for the export operation
+pub fn observe_export_latency(duration: Duration) {
+    registry::EXPORT_LATENCY.observe(duration.as_secs_f64());
+}

--- a/mermin/src/metrics/flow.rs
+++ b/mermin/src/metrics/flow.rs
@@ -1,0 +1,39 @@
+//! Helper functions for flow lifecycle metrics.
+
+use std::time::Duration;
+
+use crate::metrics::registry;
+
+/// Increment the flow creation counter.
+///
+/// ### Arguments
+///
+/// - `interface` - Network interface name
+pub fn inc_flows_created(interface: &str) {
+    registry::FLOWS_CREATED
+        .with_label_values(&[interface])
+        .inc();
+
+    registry::FLOWS_ACTIVE.with_label_values(&[interface]).inc();
+}
+
+/// Increment the flow expiry counter and decrement active count.
+///
+/// ### Arguments
+///
+/// - `interface` - Network interface name
+/// - `reason` - Reason for expiry: "timeout", "recorded", "error", "guard_cleanup"
+pub fn inc_flows_expired(interface: &str, reason: &str) {
+    registry::FLOWS_EXPIRED.with_label_values(&[reason]).inc();
+
+    registry::FLOWS_ACTIVE.with_label_values(&[interface]).dec();
+}
+
+/// Record flow duration.
+///
+/// ### Arguments
+///
+/// - `duration` - Duration from first to last packet
+pub fn observe_flow_duration(duration: Duration) {
+    registry::FLOW_DURATION.observe(duration.as_secs_f64());
+}

--- a/mermin/src/metrics/registry.rs
+++ b/mermin/src/metrics/registry.rs
@@ -1,0 +1,186 @@
+//! Global metrics registry and collector definitions.
+//!
+//! This module defines all Prometheus metrics used by Mermin and provides
+//! a centralized registry for metric collection.
+
+use lazy_static::lazy_static;
+use prometheus::{
+    GaugeVec, Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+    Registry,
+};
+
+lazy_static! {
+    /// Global Prometheus registry for all Mermin metrics.
+    pub static ref REGISTRY: Registry = Registry::new();
+
+    // ============================================================================
+    // eBPF Resource Metrics
+    // ============================================================================
+
+    /// Current number of entries in the eBPF FLOW_STATS_MAP.
+    pub static ref EBPF_MAP_ENTRIES: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("mermin_ebpf_map_entries", "Current number of entries in eBPF maps")
+            .namespace("mermin"),
+        &["map"]
+    ).expect("failed to create ebpf_map_entries metric");
+
+    /// Maximum capacity of eBPF maps.
+    pub static ref EBPF_MAP_CAPACITY: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("mermin_ebpf_map_capacity", "Maximum capacity of eBPF maps")
+            .namespace("mermin"),
+        &["map"]
+    ).expect("failed to create ebpf_map_capacity metric");
+
+    /// Utilization ratio of eBPF maps (entries/capacity).
+    pub static ref EBPF_MAP_UTILIZATION: GaugeVec = GaugeVec::new(
+        Opts::new("mermin_ebpf_map_utilization_ratio", "Utilization ratio of eBPF maps (0.0-1.0)")
+            .namespace("mermin"),
+        &["map"]
+    ).expect("failed to create ebpf_map_utilization metric");
+
+    /// Total number of dropped ring buffer events due to buffer full.
+    pub static ref EBPF_RING_BUFFER_DROPS: IntCounter = IntCounter::new(
+        "mermin_ebpf_ring_buffer_drops_total",
+        "Total number of ring buffer events dropped due to buffer full"
+    ).expect("failed to create ebpf_ring_buffer_drops metric");
+
+    /// Total number of orphaned entries cleaned up by the orphan scanner.
+    pub static ref EBPF_ORPHANS_CLEANED: IntCounter = IntCounter::new(
+        "mermin_ebpf_orphans_cleaned_total",
+        "Total number of orphaned eBPF map entries cleaned up"
+    ).expect("failed to create ebpf_orphans_cleaned metric");
+
+    /// Current number of flows tracked in userspace flow store.
+    pub static ref EBPF_USERSPACE_FLOWS: IntGauge = IntGauge::new(
+        "mermin_ebpf_userspace_flows",
+        "Current number of flows tracked in userspace"
+    ).expect("failed to create ebpf_userspace_flows metric");
+
+    /// Total number of TC programs attached to interfaces.
+    pub static ref TC_PROGRAMS_ATTACHED: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_tc_programs_attached_total", "Total number of TC programs attached")
+            .namespace("mermin"),
+        &["interface", "direction"]
+    ).expect("failed to create tc_programs_attached metric");
+
+    /// Total number of TC programs detached from interfaces.
+    pub static ref TC_PROGRAMS_DETACHED: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_tc_programs_detached_total", "Total number of TC programs detached")
+            .namespace("mermin"),
+        &["interface", "direction"]
+    ).expect("failed to create tc_programs_detached metric");
+
+    // ============================================================================
+    // Flow Lifecycle Metrics
+    // ============================================================================
+
+    /// Total number of flows created.
+    pub static ref FLOWS_CREATED: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_flows_created_total", "Total number of flows created")
+            .namespace("mermin"),
+        &["interface"]
+    ).expect("failed to create flows_created metric");
+
+    /// Total number of flows expired/removed.
+    pub static ref FLOWS_EXPIRED: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_flows_expired_total", "Total number of flows expired")
+            .namespace("mermin"),
+        &["reason"]  // timeout, recorded, error, guard_cleanup
+    ).expect("failed to create flows_expired metric");
+
+    /// Current number of active flows being tracked.
+    pub static ref FLOWS_ACTIVE: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("mermin_flows_active", "Current number of active flows")
+            .namespace("mermin"),
+        &["interface"]
+    ).expect("failed to create flows_active metric");
+
+    /// Histogram of flow durations.
+    pub static ref FLOW_DURATION: Histogram = Histogram::with_opts(
+        HistogramOpts::new("mermin_flow_duration_seconds", "Duration of flows from first to last packet")
+            .namespace("mermin")
+            .buckets(vec![1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1800.0])
+    ).expect("failed to create flow_duration metric");
+
+    // ============================================================================
+    // Export Metrics
+    // ============================================================================
+
+    /// Total number of spans successfully exported.
+    pub static ref SPANS_EXPORTED: IntCounter = IntCounter::new(
+        "mermin_spans_exported_total",
+        "Total number of flow spans successfully exported"
+    ).expect("failed to create spans_exported metric");
+
+    /// Total number of span export errors.
+    pub static ref SPANS_EXPORT_ERRORS: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_spans_export_errors_total", "Total number of span export errors")
+            .namespace("mermin"),
+        &["reason"]
+    ).expect("failed to create spans_export_errors metric");
+
+    /// Histogram of export batch sizes.
+    pub static ref EXPORT_BATCH_SIZE: Histogram = Histogram::with_opts(
+        HistogramOpts::new("mermin_export_batch_size", "Number of spans per export batch")
+            .namespace("mermin")
+            .buckets(vec![1.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0])
+    ).expect("failed to create export_batch_size metric");
+
+    /// Histogram of export operation latency.
+    pub static ref EXPORT_LATENCY: Histogram = Histogram::with_opts(
+        HistogramOpts::new("mermin_export_latency_seconds", "Latency of span export operations")
+            .namespace("mermin")
+            .buckets(vec![0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0])
+    ).expect("failed to create export_latency metric");
+
+    // ============================================================================
+    // Per-Interface Statistics
+    // ============================================================================
+
+    /// Total number of packets processed.
+    pub static ref PACKETS_TOTAL: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_packets_total", "Total number of packets processed")
+            .namespace("mermin"),
+        &["interface", "direction"]  // direction: ingress/egress
+    ).expect("failed to create packets_total metric");
+
+    /// Total number of bytes processed.
+    pub static ref BYTES_TOTAL: IntCounterVec = IntCounterVec::new(
+        Opts::new("mermin_bytes_total", "Total number of bytes processed")
+            .namespace("mermin"),
+        &["interface", "direction"]
+    ).expect("failed to create bytes_total metric");
+}
+
+/// Initialize the metrics registry by registering all collectors.
+///
+/// This should be called once at application startup before any metrics are used.
+pub fn init_registry() -> Result<(), prometheus::Error> {
+    // eBPF metrics
+    REGISTRY.register(Box::new(EBPF_MAP_ENTRIES.clone()))?;
+    REGISTRY.register(Box::new(EBPF_MAP_CAPACITY.clone()))?;
+    REGISTRY.register(Box::new(EBPF_MAP_UTILIZATION.clone()))?;
+    REGISTRY.register(Box::new(EBPF_RING_BUFFER_DROPS.clone()))?;
+    REGISTRY.register(Box::new(EBPF_ORPHANS_CLEANED.clone()))?;
+    REGISTRY.register(Box::new(EBPF_USERSPACE_FLOWS.clone()))?;
+    REGISTRY.register(Box::new(TC_PROGRAMS_ATTACHED.clone()))?;
+    REGISTRY.register(Box::new(TC_PROGRAMS_DETACHED.clone()))?;
+
+    // Flow metrics
+    REGISTRY.register(Box::new(FLOWS_CREATED.clone()))?;
+    REGISTRY.register(Box::new(FLOWS_EXPIRED.clone()))?;
+    REGISTRY.register(Box::new(FLOWS_ACTIVE.clone()))?;
+    REGISTRY.register(Box::new(FLOW_DURATION.clone()))?;
+
+    // Export metrics
+    REGISTRY.register(Box::new(SPANS_EXPORTED.clone()))?;
+    REGISTRY.register(Box::new(SPANS_EXPORT_ERRORS.clone()))?;
+    REGISTRY.register(Box::new(EXPORT_BATCH_SIZE.clone()))?;
+    REGISTRY.register(Box::new(EXPORT_LATENCY.clone()))?;
+
+    // Interface metrics
+    REGISTRY.register(Box::new(PACKETS_TOTAL.clone()))?;
+    REGISTRY.register(Box::new(BYTES_TOTAL.clone()))?;
+
+    Ok(())
+}

--- a/mermin/src/metrics/server.rs
+++ b/mermin/src/metrics/server.rs
@@ -1,0 +1,118 @@
+//! Prometheus metrics collection and HTTP server.
+//!
+//! This module provides comprehensive observability for Mermin through Prometheus-compatible
+//! metrics exposed via HTTP at `/metrics`.
+//!
+//! ## Metric Categories
+//!
+//! - **eBPF Resource Metrics**: Map utilization, ring buffer drops, orphan cleanup
+//! - **Flow Lifecycle**: Creation, expiry, duration, active counts
+//! - **Export Performance**: Success/error rates, batch sizes, latency
+//! - **Interface Statistics**: Packet/byte counters per interface
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use mermin::metrics::{self, registry};
+//!
+//! // Initialize registry once at startup
+//! registry::init_registry()?;
+//!
+//! // Start metrics HTTP server
+//! let metrics_handle = tokio::spawn(metrics::start_metrics_server(config.metrics));
+//!
+//! // Instrument code
+//! registry::FLOWS_CREATED.with_label_values(&["eth0"]).inc();
+//! ```
+
+use axum::{Router, http::StatusCode, response::IntoResponse, routing::get};
+use tokio::net::TcpListener;
+use tower_http::trace::TraceLayer;
+use tracing::info;
+
+use crate::{
+    metrics::{error::MetricsError, registry},
+    runtime::conf::MetricsConf,
+};
+
+/// Handler for the `/metrics` endpoint.
+///
+/// Returns Prometheus text format metrics for all registered collectors.
+async fn metrics_handler() -> impl IntoResponse {
+    let encoder = prometheus::TextEncoder::new();
+    let metric_families = registry::REGISTRY.gather();
+
+    match encoder.encode_to_string(&metric_families) {
+        Ok(body) => (StatusCode::OK, body),
+        Err(e) => {
+            tracing::error!(
+                event.name = "metrics.encode_failed",
+                error.message = %e,
+                "failed to encode metrics"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to encode metrics: {e}"),
+            )
+        }
+    }
+}
+
+/// Create the metrics HTTP router.
+fn create_metrics_router() -> Router {
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .layer(TraceLayer::new_for_http())
+}
+
+/// Start the Prometheus metrics HTTP server.
+///
+/// Serves metrics at `<listen_address>:<port>/metrics` in Prometheus text format.
+///
+/// ### Arguments
+///
+/// - `config` - Metrics server configuration (address, port, enabled flag)
+///
+/// ### Returns
+///
+/// Returns `Ok(())` on successful shutdown, or `MetricsError` if startup fails.
+///
+/// ### Example
+///
+/// ```rust,ignore
+/// let config = MetricsConf {
+///     enabled: true,
+///     listen_address: "0.0.0.0".to_string(),
+///     port: 10250,
+/// };
+///
+/// tokio::spawn(start_metrics_server(config));
+/// ```
+pub async fn start_metrics_server(config: MetricsConf) -> Result<(), MetricsError> {
+    if !config.enabled {
+        info!(
+            event.name = "metrics.disabled",
+            "metrics server is disabled in configuration"
+        );
+        return Ok(());
+    }
+
+    let app = create_metrics_router();
+
+    let bind_address = format!("{}:{}", config.listen_address, config.port);
+    let listener = TcpListener::bind(&bind_address)
+        .await
+        .map_err(|e| MetricsError::bind_address(&bind_address, e))?;
+
+    info!(
+        event.name = "metrics.started",
+        net.listen.address = %bind_address,
+        "metrics server started"
+    );
+
+    axum::serve(listener, app)
+        .await
+        .map_err(MetricsError::ServeError)?;
+
+    Ok(())
+}

--- a/mermin/src/otlp/provider.rs
+++ b/mermin/src/otlp/provider.rs
@@ -469,11 +469,14 @@ pub async fn init_provider(
 pub async fn init_internal_tracing(
     log_level: Level,
     span_fmt: SpanFmt,
+    log_color: bool,
     stdout: Option<StdoutExportOptions>,
     otlp: Option<OtlpExportOptions>,
 ) -> Result<(), OtlpError> {
     let provider = init_provider(stdout, otlp).await?;
-    let mut fmt_layer = Layer::new().with_span_events(FmtSpan::from(span_fmt));
+    let mut fmt_layer = Layer::new()
+        .with_span_events(FmtSpan::from(span_fmt))
+        .with_ansi(log_color);
 
     match log_level {
         Level::DEBUG => fmt_layer = fmt_layer.with_file(true).with_line_number(true),
@@ -489,7 +492,7 @@ pub async fn init_internal_tracing(
             // Format {
             //     format: Full,
             //     timer: SystemTime,
-            //     ansi: None, // conditionally set based on environment, handled by tracing-subscriber
+            //     ansi: set explicitly via with_ansi() based on log_color configuration
             //     display_timestamp: true,
             //     display_target: true,
             //     display_level: true,

--- a/mermin/src/otlp/trace.rs
+++ b/mermin/src/otlp/trace.rs
@@ -5,6 +5,8 @@ use opentelemetry::trace::{SpanKind, Tracer, TracerProvider};
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing::trace;
 
+use crate::metrics::export::{inc_spans_exported, observe_export_latency};
+
 pub struct TraceExporterAdapter {
     provider: SdkTracerProvider,
 }
@@ -43,15 +45,15 @@ pub trait Traceable {
     /// This is the core method where the implementing type is responsible for mapping
     /// its internal fields to the key-value attributes of an OpenTelemetry `Span`.
     ///
-    /// # Arguments
-    /// * `span` - An `opentelemetry_sdk::trace::Span` instance that has already been
+    /// ### Arguments
+    /// - `span` - An `opentelemetry_sdk::trace::Span` instance that has already been
     ///   configured with its start time, end time, and name based on the other
     ///   methods in this trait.
     ///
-    /// # Returns
+    /// ### Returns
     /// The same `Span` instance, now enriched with the record's specific attributes.
     ///
-    /// # Important
+    /// ### Important
     /// For performance reasons within the export pipeline, this method is designed to
     /// be called **only once** per record. The implementation should be efficient and
     /// perform all necessary attribute-setting within this single call.
@@ -66,6 +68,8 @@ pub trait TraceableExporter: Send + Sync {
 #[async_trait]
 impl TraceableExporter for TraceExporterAdapter {
     async fn export(&self, traceable: TraceableRecord) {
+        let start = std::time::Instant::now();
+
         let tracer = self.provider.tracer("mermin");
         let name = if let Some(name) = traceable.name() {
             name
@@ -75,12 +79,17 @@ impl TraceableExporter for TraceExporterAdapter {
 
         let mut span = tracer
             .span_builder(name.clone())
-            //TODO: Once SOURCE & DESTINATION are span kind are available, use them here
+            // TODO: Once SOURCE & DESTINATION are span kind are available, use them here
             .with_kind(SpanKind::Internal)
             .with_start_time(traceable.start_time())
             .start(&tracer);
         span = traceable.record(span);
         opentelemetry::trace::Span::end_with_timestamp(&mut span, traceable.end_time());
+
+        // Metrics: Span exported successfully
+        inc_spans_exported(1);
+        observe_export_latency(start.elapsed());
+
         trace!(
             event.name = "span.exported",
             span.name = %name,

--- a/mermin/src/runtime/conf.rs
+++ b/mermin/src/runtime/conf.rs
@@ -65,6 +65,7 @@ pub struct Conf {
     pub config_path: Option<std::path::PathBuf>,
     #[serde(with = "level")]
     pub log_level: Level,
+    pub log_color: bool,
     pub auto_reload: bool,
     #[serde(with = "duration")]
     pub shutdown_timeout: Duration,
@@ -95,6 +96,7 @@ impl Default for Conf {
         Self {
             config_path: None,
             log_level: Level::INFO,
+            log_color: false,
             auto_reload: false,
             shutdown_timeout: defaults::shutdown_timeout(),
             packet_channel_capacity: defaults::packet_channel_capacity(),
@@ -937,6 +939,10 @@ mod tests {
                 crate::runtime::opts::SpanFmt::Full
             ),
             "default internal span_fmt should be Full"
+        );
+        assert!(
+            !cfg.log_color,
+            "default log_color should be false (colors disabled)"
         );
         assert!(
             cfg.internal.traces.stdout.is_none(),

--- a/mermin/src/span.rs
+++ b/mermin/src/span.rs
@@ -1,4 +1,5 @@
 pub mod community_id;
+pub mod ebpf_guard;
 pub mod flow;
 pub mod opts;
 pub mod producer;

--- a/mermin/src/span/ebpf_guard.rs
+++ b/mermin/src/span/ebpf_guard.rs
@@ -1,0 +1,149 @@
+//! RAII guard for eBPF flow map entries to ensure cleanup on error paths.
+//!
+//! This module provides `EbpfFlowGuard`, a guard that automatically removes
+//! entries from the eBPF `FLOW_STATS_MAP` when dropped, unless explicitly
+//! marked as "kept" (managed by flow_store).
+//!
+//! ## Problem
+//!
+//! Multiple error paths in flow creation can leave orphaned entries in the
+//! eBPF map:
+//! - Ring buffer full → entry created but userspace never notified
+//! - Flow creation errors → error logged but map not cleaned up
+//! - Task cancellation/panic → cleanup code never reached
+//!
+//! ## Solution
+//!
+//! The guard uses RAII (Resource Acquisition Is Initialization) to ensure
+//! cleanup happens on ALL code paths, including:
+//! - Early returns from errors
+//! - Panics
+//! - Task cancellation
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! async fn process_new_flow(&self, event: FlowEvent) -> Result<(), Error> {
+//!     // Guard ensures cleanup on ANY error path
+//!     let guard = EbpfFlowGuard::new(
+//!         event.flow_key,
+//!         self.flow_stats_map.clone(),
+//!     );
+//!
+//!     // ... process flow, may return early on error ...
+//!
+//!     // Success - flow now managed by flow_store, disable auto-cleanup
+//!     guard.keep();
+//!     Ok(())
+//! }
+//! ```
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use aya::maps::HashMap as EbpfHashMap;
+use mermin_common::FlowKey;
+use tokio::sync::Mutex;
+use tracing::warn;
+
+use crate::metrics::flow::inc_flows_expired;
+
+/// RAII guard for eBPF flow map entries.
+///
+/// Automatically removes entries from `FLOW_STATS_MAP` when dropped,
+/// unless explicitly marked as "kept" via [`keep()`](Self::keep).
+///
+/// This prevents orphaned entries when errors occur during flow creation.
+pub struct EbpfFlowGuard {
+    key: FlowKey,
+    map: Arc<Mutex<EbpfHashMap<aya::maps::MapData, FlowKey, mermin_common::FlowStats>>>,
+    should_keep: Arc<AtomicBool>,
+}
+
+impl EbpfFlowGuard {
+    /// Create a new guard for an eBPF flow entry.
+    ///
+    /// The entry will be automatically removed from the map when the guard
+    /// is dropped, unless [`keep()`](Self::keep) is called first.
+    ///
+    /// ### Arguments
+    ///
+    /// - `key` - Flow key identifying the entry in the eBPF map
+    /// - `map` - Shared reference to the eBPF `FLOW_STATS_MAP`
+    pub fn new(
+        key: FlowKey,
+        map: Arc<Mutex<EbpfHashMap<aya::maps::MapData, FlowKey, mermin_common::FlowStats>>>,
+    ) -> Self {
+        Self {
+            key,
+            map,
+            should_keep: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Mark the entry as "kept" - disables automatic cleanup.
+    ///
+    /// Call this when the flow has been successfully created and is now
+    /// managed by the `flow_store`. The eBPF map entry will be cleaned up
+    /// by the timeout task instead.
+    pub fn keep(&self) {
+        self.should_keep.store(true, Ordering::Release);
+    }
+}
+
+impl Drop for EbpfFlowGuard {
+    fn drop(&mut self) {
+        if !self.should_keep.load(Ordering::Acquire) {
+            // Entry was not marked as "kept", so clean it up
+            // Spawn a background task to avoid blocking the drop (async not allowed in Drop)
+            let key = self.key;
+            let map = Arc::clone(&self.map);
+
+            tokio::spawn(async move {
+                let mut map_guard = map.lock().await;
+                if let Err(e) = map_guard.remove(&key) {
+                    warn!(
+                        event.name = "ebpf_guard.cleanup_failed",
+                        flow.key = ?key,
+                        error.message = %e,
+                        "failed to remove orphaned eBPF entry via guard cleanup"
+                    );
+                } else {
+                    warn!(
+                        event.name = "ebpf_guard.cleanup_success",
+                        flow.key = ?key,
+                        "removed orphaned eBPF entry via guard cleanup (error occurred during flow creation)"
+                    );
+
+                    // Metrics: Flow expired via guard cleanup (error path)
+                    inc_flows_expired("unknown", "guard_cleanup");
+                }
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: Full integration tests require eBPF maps, which can't be instantiated in unit tests.
+    // The guard behavior is tested via integration tests in the parent module.
+
+    #[test]
+    fn test_should_keep_default_false() {
+        // Verify the default state is "don't keep" (will cleanup)
+        let should_keep = Arc::new(AtomicBool::new(false));
+        assert!(!should_keep.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_keep_sets_flag() {
+        // Verify keep() sets the flag correctly
+        let should_keep = Arc::new(AtomicBool::new(false));
+        should_keep.store(true, Ordering::Release);
+        assert!(should_keep.load(Ordering::Acquire));
+    }
+}


### PR DESCRIPTION
## Changes

Implement comprehensive observability infrastructure with Prometheus-compatible metrics exposed via HTTP endpoint at /metrics.

Metrics categories:
- eBPF resources: map utilization, ring buffer drops, orphan cleanup counts
- Flow lifecycle: creation/expiry rates, active flows, duration histograms
- Export performance: success/error rates, batch sizes, latency tracking
- Interface statistics: packet/byte counters per interface and direction

Stability improvements:
- Add EbpfFlowGuard RAII wrapper for automatic eBPF map cleanup on error paths
- Implement orphan scanner task as safety net for stale eBPF entries
- Fix race condition in timeout task where flow_store removal could leave orphaned eBPF entries
- Extract flow_key_to_ip_addrs as reusable utility function

Configuration:
- Add metrics.enabled, metrics.listen_address, metrics.port settings
- Add log_color option for controlling ANSI color output in logs

Dependencies added:
- prometheus: Core metrics library and exporters
- axum: HTTP server framework for metrics endpoint
- tower-http: HTTP middleware for tracing

The metrics server starts automatically on configured port (default: 10250) when metrics.enabled=true, providing real-time operational visibility into Mermin's performance and resource utilization.

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Running it in my local kubernetes cluster

## Proof it works

```
# HELP mermin_ebpf_orphans_cleaned_total Total number of orphaned eBPF map entries cleaned up
# TYPE mermin_ebpf_orphans_cleaned_total counter
mermin_ebpf_orphans_cleaned_total 0
# HELP mermin_ebpf_ring_buffer_drops_total Total number of ring buffer events dropped due to buffer full
# TYPE mermin_ebpf_ring_buffer_drops_total counter
mermin_ebpf_ring_buffer_drops_total 0
# HELP mermin_ebpf_userspace_flows Current number of flows tracked in userspace
# TYPE mermin_ebpf_userspace_flows gauge
mermin_ebpf_userspace_flows 0
# HELP mermin_mermin_export_batch_size Number of spans per export batch
# TYPE mermin_mermin_export_batch_size histogram
mermin_mermin_export_batch_size_bucket{le="1"} 0
mermin_mermin_export_batch_size_bucket{le="10"} 0
mermin_mermin_export_batch_size_bucket{le="50"} 0
mermin_mermin_export_batch_size_bucket{le="100"} 0
mermin_mermin_export_batch_size_bucket{le="250"} 0
mermin_mermin_export_batch_size_bucket{le="500"} 0
mermin_mermin_export_batch_size_bucket{le="1000"} 0
mermin_mermin_export_batch_size_bucket{le="+Inf"} 0
mermin_mermin_export_batch_size_sum 0
mermin_mermin_export_batch_size_count 0
# HELP mermin_mermin_export_latency_seconds Latency of span export operations
# TYPE mermin_mermin_export_latency_seconds histogram
mermin_mermin_export_latency_seconds_bucket{le="0.001"} 202
mermin_mermin_export_latency_seconds_bucket{le="0.005"} 203
mermin_mermin_export_latency_seconds_bucket{le="0.01"} 203
mermin_mermin_export_latency_seconds_bucket{le="0.05"} 203
mermin_mermin_export_latency_seconds_bucket{le="0.1"} 203
mermin_mermin_export_latency_seconds_bucket{le="0.5"} 203
mermin_mermin_export_latency_seconds_bucket{le="1"} 203
mermin_mermin_export_latency_seconds_bucket{le="5"} 203
mermin_mermin_export_latency_seconds_bucket{le="+Inf"} 203
mermin_mermin_export_latency_seconds_sum 0.015118547000000001
mermin_mermin_export_latency_seconds_count 203
# HELP mermin_mermin_flow_duration_seconds Duration of flows from first to last packet
# TYPE mermin_mermin_flow_duration_seconds histogram
mermin_mermin_flow_duration_seconds_bucket{le="1"} 141
mermin_mermin_flow_duration_seconds_bucket{le="5"} 145
mermin_mermin_flow_duration_seconds_bucket{le="10"} 150
mermin_mermin_flow_duration_seconds_bucket{le="30"} 153
mermin_mermin_flow_duration_seconds_bucket{le="60"} 157
mermin_mermin_flow_duration_seconds_bucket{le="120"} 157
mermin_mermin_flow_duration_seconds_bucket{le="300"} 157
mermin_mermin_flow_duration_seconds_bucket{le="600"} 157
mermin_mermin_flow_duration_seconds_bucket{le="1800"} 157
mermin_mermin_flow_duration_seconds_bucket{le="+Inf"} 157
mermin_mermin_flow_duration_seconds_sum 243.0882535690001
mermin_mermin_flow_duration_seconds_count 157
# HELP mermin_mermin_flows_active Current number of active flows
# TYPE mermin_mermin_flows_active gauge
mermin_mermin_flows_active{interface="veth152c9210"} 41
mermin_mermin_flows_active{interface="veth6e48628e"} 7
mermin_mermin_flows_active{interface="veth6e86c225"} 0
mermin_mermin_flows_active{interface="veth8f82184c"} 29
mermin_mermin_flows_active{interface="vethe05f37b5"} 1
# HELP mermin_mermin_flows_created_total Total number of flows created
# TYPE mermin_mermin_flows_created_total counter
mermin_mermin_flows_created_total{interface="veth152c9210"} 84
mermin_mermin_flows_created_total{interface="veth6e48628e"} 62
mermin_mermin_flows_created_total{interface="veth6e86c225"} 17
mermin_mermin_flows_created_total{interface="veth8f82184c"} 69
mermin_mermin_flows_created_total{interface="vethe05f37b5"} 3
# HELP mermin_mermin_flows_expired_total Total number of flows expired
# TYPE mermin_mermin_flows_expired_total counter
mermin_mermin_flows_expired_total{reason="timeout"} 157
# HELP mermin_mermin_tc_programs_attached_total Total number of TC programs attached
# TYPE mermin_mermin_tc_programs_attached_total counter
mermin_mermin_tc_programs_attached_total{direction="egress",interface="ip6tnl0"} 1
mermin_mermin_tc_programs_attached_total{direction="egress",interface="tunl0"} 1
mermin_mermin_tc_programs_attached_total{direction="egress",interface="veth152c9210"} 1
mermin_mermin_tc_programs_attached_total{direction="egress",interface="veth6e48628e"} 1
mermin_mermin_tc_programs_attached_total{direction="egress",interface="veth6e86c225"} 1
mermin_mermin_tc_programs_attached_total{direction="egress",interface="veth8f82184c"} 1
mermin_mermin_tc_programs_attached_total{direction="egress",interface="vethe05f37b5"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="ip6tnl0"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="tunl0"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="veth152c9210"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="veth6e48628e"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="veth6e86c225"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="veth8f82184c"} 1
mermin_mermin_tc_programs_attached_total{direction="ingress",interface="vethe05f37b5"} 1
# HELP mermin_mermin_tc_programs_detached_total Total number of TC programs detached
# TYPE mermin_mermin_tc_programs_detached_total counter
mermin_mermin_tc_programs_detached_total{direction="egress",interface="veth6e86c225"} 1
mermin_mermin_tc_programs_detached_total{direction="ingress",interface="veth6e86c225"} 1
# HELP mermin_spans_exported_total Total number of flow spans successfully exported
# TYPE mermin_spans_exported_total counter
mermin_spans_exported_total 203
```

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass
