### PR TITLE
feat(helm): Add "extraObjects" Helm value

### DIFF
--- a/charts/mermin/templates/extraManifests.yaml
+++ b/charts/mermin/templates/extraManifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -119,3 +119,52 @@ config:
   # Define config inline:
   # content: |
   #   log_level = "info"
+
+# -- Array of extra K8s manifests to deploy (supports templating)
+extraObjects: []
+  # As a YAML object
+  # - apiVersion: secrets-store.csi.x-k8s.io/v1
+  #   kind: SecretProviderClass
+  #   metadata:
+  #     name: '{{ include "mermin.fullname" . }}'
+  #   spec:
+  #     provider: aws
+  #     parameters:
+  #       objects: |
+  #         - objectName: "argocd"
+  #           objectType: "secretsmanager"
+  #           jmesPath:
+  #               - path: "client_id"
+  #                 objectAlias: "client_id"
+  #               - path: "client_secret"
+  #                 objectAlias: "client_secret"
+  #     secretObjects:
+  #     - data:
+  #       - key: client_id
+  #         objectName: client_id
+  #       - key: client_secret
+  #         objectName: client_secret
+  #       secretName: argocd-secrets-store
+  #       type: Opaque
+  #       labels:
+  #         app.kubernetes.io/part-of: argocd
+  # # As a YAML string
+  # - |
+  #   apiVersion: monitoring.googleapis.com/v1
+  #   kind: PodMonitoring
+  #   metadata:
+  #     name: {{ include "mermin.fullname" . }}
+  #     namespace: {{ .Release.Namespace }}
+  #     labels:
+  #       {{- include "mermin.labels" . | nindent 4 }}
+  #   spec:
+  #     endpoints:
+  #     - interval: 60s
+  #       port: metrics
+  #     selector:
+  #       matchLabels:
+  #         {{- include "mermin.labels" . | nindent 4 }}
+  #     targetLabels:
+  #       metadata:
+  #       - pod
+  #       - container


### PR DESCRIPTION
## Changes

Add `extraObjects` Helm value to allow users creating extra arbitrary K8s manifests

Fixes #(issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Local Helm template render

## Proof it works

N/A

## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [ ] All tests pass

