### PR TITLE
fix: gke deployment issues - healthchecks, metrics timeouts, and deadlock

### DIFF
--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -84,13 +84,6 @@ parser {
   parse_ipv6_dest_opts = false  # IPv6 Destination Options (disabled to reduce complexity)
 }
 
-# K8s informer configuration
-informer "k8s" {
-  kubeconfig_path         = ""
-  informers_sync_timeout  = "30s"
-  informers_resync_period = "30m"
-}
-
 discovery "instrument" {
   # Network interfaces to monitor
   #
@@ -159,6 +152,11 @@ discovery "instrument" {
 }
 
 discovery "informer" "k8s" {
+  # K8s API connection configuration
+  kubeconfig_path         = "" # Empty uses in-cluster config (default for pods)
+  informers_sync_timeout  = "30s"  # Timeout for initial cache sync (increase for large clusters)
+  informers_resync_period = "5s"  # Period between full cache resyncs
+
   /*
     Define which flow will be processed and sent to the output.
     Impacts the "In-mem K8s objects cache" build by K8s informer (https://www.plural.sh/blog/manage-kubernetes-events-informers/)

--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -99,7 +99,7 @@ startupProbe:
   initialDelaySeconds: 0
   periodSeconds: 3
   timeoutSeconds: 5
-  failureThreshold: 50
+  failureThreshold: 60
 
 tolerations:
   - effect: NoSchedule

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -198,12 +198,11 @@ discovery "instrument" {
   interfaces = ["eth*", "ens*"]
 }
 
-informer "k8s" {
-  informers_sync_timeout = "30s"
-  informers_resync_period = "30m"
-}
-
 discovery "informer" "k8s" {
+  # K8s API connection configuration
+  informers_sync_timeout = "30s"
+  informers_resync_period = "5s"
+
   selectors = [
     { kind = "Pod" },
     { kind = "Service" }

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -46,30 +46,30 @@ discovery "instrument" {
 }
 
 # Full Kubernetes metadata enrichment
-informer "k8s" {
+discovery "informer" "k8s" {
   informers_sync_timeout = "60s"
   informers_resync_period = "30m"
 
-  resources {
+  selectors = [
     # Core resources
-    pod = { enabled = true }
-    service = { enabled = true }
-    endpoint = { enabled = true }
-    endpointslice = { enabled = true }
-    node = { enabled = true }
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Endpoint" },
+    { kind = "EndpointSlice" },
+    { kind = "Node" },
 
     # Workload controllers
-    deployment = { enabled = true }
-    replicaset = { enabled = true }
-    statefulset = { enabled = true }
-    daemonset = { enabled = true }
-    job = { enabled = true }
-    cronjob = { enabled = true }
+    { kind = "Deployment" },
+    { kind = "ReplicaSet" },
+    { kind = "StatefulSet" },
+    { kind = "DaemonSet" },
+    { kind = "Job" },
+    { kind = "CronJob" },
 
     # Networking
-    networkpolicy = { enabled = true }
-    ingress = { enabled = true }
-  }
+    { kind = "NetworkPolicy" },
+    { kind = "Ingress" }
+  ]
 }
 
 # Walk owner references for workload attribution
@@ -194,12 +194,12 @@ discovery "instrument" {
 }
 
 # Basic Kubernetes enrichment
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" }
+  ]
 }
 
 # Simple owner tracking
@@ -269,15 +269,15 @@ discovery "instrument" {
   ]
 }
 
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    endpoint = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-    networkpolicy = { enabled = true }  # Cilium NetworkPolicies
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Endpoint" },
+    { kind = "Node" },
+    { kind = "Deployment" },
+    { kind = "NetworkPolicy" }  # Cilium NetworkPolicies
+  ]
 }
 
 discovery "owners" {
@@ -344,14 +344,14 @@ discovery "instrument" {
   ]
 }
 
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-    networkpolicy = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" },
+    { kind = "Deployment" },
+    { kind = "NetworkPolicy" }
+  ]
 }
 
 discovery "owners" {
@@ -418,19 +418,15 @@ discovery "instrument" {
 }
 
 # Optimize Kubernetes informer load
-informer "k8s" {
+discovery "informer" "k8s" {
   informers_resync_period = "1h"  # Reduce API server load
 
-  resources {
-    # Only essential resources
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-
-    # Disable less critical resources
-    ingress = { enabled = false }
-    networkpolicy = { enabled = false }
-  }
+  # Only watch essential resources
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" }
+  ]
 }
 
 discovery "owners" {
@@ -509,17 +505,13 @@ discovery "instrument" {
 }
 
 # Namespace filtering for security
-informer "k8s" {
-  resources {
-    namespace_selector = {
-      match_names = ["production", "staging"]  # Only specific namespaces
-    }
-
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod", namespaces = ["production", "staging"] },  # Only specific namespaces
+    { kind = "Service", namespaces = ["production", "staging"] },
+    { kind = "Node" },  # Nodes are cluster-scoped, no namespace filter
+    { kind = "Deployment", namespaces = ["production", "staging"] }
+  ]
 }
 
 discovery "owners" {
@@ -599,13 +591,13 @@ discovery "instrument" {
   interfaces = ["eth*", "cni*"]
 }
 
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" },
+    { kind = "Deployment" }
+  ]
 }
 
 discovery "owners" {
@@ -691,13 +683,13 @@ discovery "instrument" {
 }
 
 # Standard configuration for GKE
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" },
+    { kind = "Deployment" }
+  ]
 }
 
 discovery "owners" {
@@ -726,13 +718,13 @@ discovery "instrument" {
   interfaces = ["eth0"]  # EKS typically uses eth0 for pod networking
 }
 
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" },
+    { kind = "Deployment" }
+  ]
 }
 
 discovery "owners" {
@@ -761,13 +753,13 @@ discovery "instrument" {
   interfaces = ["eth0", "cni*"]  # AKS with Azure CNI or Kubenet
 }
 
-informer "k8s" {
-  resources {
-    pod = { enabled = true }
-    service = { enabled = true }
-    node = { enabled = true }
-    deployment = { enabled = true }
-  }
+discovery "informer" "k8s" {
+  selectors = [
+    { kind = "Pod" },
+    { kind = "Service" },
+    { kind = "Node" },
+    { kind = "Deployment" }
+  ]
 }
 
 discovery "owners" {

--- a/docs/configuration/kubernetes-informers.md
+++ b/docs/configuration/kubernetes-informers.md
@@ -13,13 +13,12 @@ Mermin uses Kubernetes informers to maintain an in-memory cache of cluster resou
 ## Configuration
 
 ```hcl
-informer "k8s" {
+discovery "informer" "k8s" {
+  # K8s API connection configuration
   kubeconfig_path = ""
   informers_sync_timeout = "30s"
-  informers_resync_period = "30m"
-}
+  informers_resync_period = "5s"
 
-discovery "informer" "k8s" {
   selectors = [
     { kind = "Service" },
     { kind = "Endpoint" },
@@ -49,12 +48,14 @@ Path to kubeconfig file for API server connection.
 **Examples:**
 
 ```hcl
-informer "k8s" {
+discovery "informer" "k8s" {
   # Use in-cluster config (default for pods)
   kubeconfig_path = ""
 
   # Use specific kubeconfig
   # kubeconfig_path = "/etc/mermin/kubeconfig"
+
+  # ... rest of configuration
 }
 ```
 
@@ -79,12 +80,14 @@ Timeout for initial informer synchronization.
 **Examples:**
 
 ```hcl
-informer "k8s" {
+discovery "informer" "k8s" {
   # Default
   informers_sync_timeout = "30s"
 
   # For large clusters (10,000+ pods)
   # informers_sync_timeout = "120s"
+
+  # ... rest of configuration
 }
 ```
 
@@ -103,15 +106,17 @@ Periodic full resynchronization interval.
 **Examples:**
 
 ```hcl
-informer "k8s" {
+discovery "informer" "k8s" {
   # Default
-  informers_resync_period = "30m"
+  informers_resync_period = "5s"
 
   # More frequent for critical environments
   # informers_resync_period = "15m"
 
   # Less frequent to reduce API load
   # informers_resync_period = "60m"
+
+  # ... rest of configuration
 }
 ```
 
@@ -261,15 +266,14 @@ Mermin supports watching these Kubernetes resources:
 ## Complete Configuration Example
 
 ```hcl
-# Kubernetes informer basic configuration
-informer "k8s" {
+# Kubernetes informer configuration
+discovery "informer" "k8s" {
+  # K8s API connection configuration
   kubeconfig_path = ""
   informers_sync_timeout = "30s"
-  informers_resync_period = "30m"
-}
+  informers_resync_period = "5s"
 
-# Resource selectors
-discovery "informer" "k8s" {
+  # Resource selectors
   selectors = [
     # Core resources (always recommended)
     { kind = "Service" },
@@ -336,12 +340,14 @@ Initial sync time depends on:
 **Large cluster tuning:**
 
 ```hcl
-informer "k8s" {
+discovery "informer" "k8s" {
   # Longer timeout for large clusters
   informers_sync_timeout = "120s"
 
   # Less frequent resync
-  informers_resync_period = "60m"
+  informers_resync_period = "5m"
+
+  # ... rest of configuration
 }
 ```
 

--- a/docs/deployment/kubernetes-helm.md
+++ b/docs/deployment/kubernetes-helm.md
@@ -44,16 +44,12 @@ discovery "instrument" {
   interfaces = ["eth*", "ens*"]
 }
 
-# Kubernetes informer configuration
-informer "k8s" {
-  # Sync timeout for initial load
-  informers_sync_timeout = "30s"
-  # Periodic resync interval
-  informers_resync_period = "30m"
-}
-
-# Configure which Kubernetes resources to watch
+# Configure Kubernetes informer and resources to watch
 discovery "informer" "k8s" {
+  # K8s API connection configuration
+  informers_sync_timeout = "30s"   # Sync timeout for initial load
+  informers_resync_period = "5s"  # Periodic resync interval
+
   selectors = [
     { kind = "Service" },
     { kind = "Endpoint" },

--- a/mermin/src/filter.rs
+++ b/mermin/src/filter.rs
@@ -3,4 +3,5 @@
 //! This module provides reusable filtering components (IP tables, port sets, glob matching)
 //! that can be integrated into flow processing as needed.
 
+pub mod opts;
 pub mod source;

--- a/mermin/src/filter/opts.rs
+++ b/mermin/src/filter/opts.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FilteringOptions {
+    pub address: Option<FilteringPair>,
+    pub port: Option<FilteringPair>,
+    pub transport: Option<FilteringPair>,
+    #[serde(rename = "type")]
+    pub type_: Option<FilteringPair>,
+    pub interface_name: Option<FilteringPair>,
+    pub interface_index: Option<FilteringPair>,
+    pub interface_mac: Option<FilteringPair>,
+    pub connection_state: Option<FilteringPair>,
+    pub ip_dscp_name: Option<FilteringPair>,
+    pub ip_ecn_name: Option<FilteringPair>,
+    pub ip_ttl: Option<FilteringPair>,
+    pub ip_flow_label: Option<FilteringPair>,
+    pub icmp_type_name: Option<FilteringPair>,
+    pub icmp_code_name: Option<FilteringPair>,
+    pub tcp_flags: Option<FilteringPair>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct FilteringPair {
+    #[serde(default, rename = "match")]
+    pub match_glob: String,
+    #[serde(default, rename = "not_match")]
+    pub not_match_glob: String,
+}

--- a/mermin/src/filter/source.rs
+++ b/mermin/src/filter/source.rs
@@ -16,8 +16,9 @@ use pnet::datalink::MacAddr;
 use tracing::{error, warn};
 
 use crate::{
+    filter::opts::{FilteringOptions, FilteringPair},
     ip::{Error as IpError, resolve_addrs},
-    runtime::conf::{Conf, FilteringOptions, FilteringPair},
+    runtime::conf::Conf,
     span::tcp::TcpFlags,
 };
 
@@ -472,7 +473,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::runtime::conf::{Conf, FilteringOptions, FilteringPair};
+    use crate::runtime::conf::Conf;
 
     /// Helper to create a FlowKey for testing
     fn mock_flow_key(

--- a/mermin/src/k8s/owner_relations.rs
+++ b/mermin/src/k8s/owner_relations.rs
@@ -22,7 +22,7 @@ use crate::k8s::attributor::{K8sObjectMeta, ResourceStore, WorkloadOwner};
 /// Configuration for K8s owner reference walking
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
-pub struct OwnerRelationsOptions {
+pub struct OwnerRelationsRules {
     /// Maximum depth to walk owner references
     pub max_depth: usize,
     /// Include only these owner kinds in flow metadata (case insensitive)
@@ -33,7 +33,7 @@ pub struct OwnerRelationsOptions {
     pub exclude_kinds: Vec<String>,
 }
 
-impl Default for OwnerRelationsOptions {
+impl Default for OwnerRelationsRules {
     fn default() -> Self {
         Self {
             max_depth: 5,
@@ -77,7 +77,7 @@ impl OwnerRelationsManager {
     /// // Use with defaults
     /// let manager = OwnerRelationsManager::new(OwnerRelationsOptions::default());
     /// ```
-    pub fn new(config: OwnerRelationsOptions) -> Self {
+    pub fn new(config: OwnerRelationsRules) -> Self {
         let include_kinds = config
             .include_kinds
             .iter()
@@ -346,8 +346,8 @@ mod tests {
         max_depth: usize,
         include_kinds: Vec<&str>,
         exclude_kinds: Vec<&str>,
-    ) -> OwnerRelationsOptions {
-        OwnerRelationsOptions {
+    ) -> OwnerRelationsRules {
+        OwnerRelationsRules {
             max_depth,
             include_kinds: include_kinds.iter().map(|s| s.to_string()).collect(),
             exclude_kinds: exclude_kinds.iter().map(|s| s.to_string()).collect(),
@@ -505,7 +505,7 @@ mod tests {
 
     #[test]
     fn test_default_config_values() {
-        let config = OwnerRelationsOptions::default();
+        let config = OwnerRelationsRules::default();
         assert_eq!(config.max_depth, 5, "Default max_depth should be 5");
         assert!(
             config.include_kinds.is_empty(),
@@ -698,7 +698,7 @@ mod tests {
         // This is critical: the default configuration should NOT filter out any owners
         // This test would have caught the config file bug where include_kinds=["Service"]
         // was filtering out DaemonSets
-        let config = OwnerRelationsOptions::default();
+        let config = OwnerRelationsRules::default();
         let manager = OwnerRelationsManager::new(config);
 
         // Create all supported owner types
@@ -753,7 +753,7 @@ mod tests {
         // Test that verifies the documented filtering behavior:
         // "Empty include_kinds list means include all kinds"
 
-        let config = OwnerRelationsOptions {
+        let config = OwnerRelationsRules {
             max_depth: 5,
             include_kinds: vec![], // Empty = include all
             exclude_kinds: vec![],

--- a/mermin/src/k8s/selector_relations.rs
+++ b/mermin/src/k8s/selector_relations.rs
@@ -16,13 +16,30 @@ use k8s_openapi::{
     apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement},
 };
 use kube::ResourceExt;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::{debug, trace, warn};
 
-use crate::{
-    k8s::attributor::{K8sObjectMeta, ResourceStore},
-    runtime::conf::SelectorRelationRule,
-};
+use crate::k8s::attributor::{K8sObjectMeta, ResourceStore};
+
+/// Configuration for a single selector-based resource relation rule
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SelectorRelationRule {
+    /// The kind of resource that contains the selector (e.g., "NetworkPolicy", "Service")
+    /// Case insensitive
+    pub kind: String,
+    /// The kind of resource to match against (e.g., "Pod")
+    /// Case insensitive
+    pub to: String,
+    /// JSON path to the matchLabels field in the source resource
+    /// Example: "spec.podSelector.matchLabels" or "spec.selector"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector_match_labels_field: Option<String>,
+    /// JSON path to the matchExpressions field in the source resource
+    /// Example: "spec.podSelector.matchExpressions"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selector_match_expressions_field: Option<String>,
+}
 
 /// Manages selector-based resource relations according to configuration rules.
 ///

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -215,7 +215,7 @@ async fn run() -> Result<()> {
             event.name = "config.interfaces_empty",
             "no interfaces configured, using default patterns"
         );
-        runtime::conf::InstrumentConf::default().interfaces
+        runtime::conf::InstrumentOptions::default().interfaces
     } else {
         conf.discovery.instrument.interfaces.clone()
     };

--- a/mermin/src/metrics.rs
+++ b/mermin/src/metrics.rs
@@ -2,5 +2,6 @@ pub mod ebpf;
 pub mod error;
 pub mod export;
 pub mod flow;
+pub mod opts;
 pub mod registry;
 pub mod server;

--- a/mermin/src/metrics/opts.rs
+++ b/mermin/src/metrics/opts.rs
@@ -1,0 +1,23 @@
+use std::net::Ipv4Addr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MetricsOptions {
+    /// Enable the metrics server.
+    pub enabled: bool,
+    /// The network address the metrics server will listen on.
+    pub listen_address: String,
+    /// The port the metrics server will listen on.
+    pub port: u16,
+}
+
+impl Default for MetricsOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            listen_address: Ipv4Addr::UNSPECIFIED.to_string(),
+            port: 10250,
+        }
+    }
+}

--- a/mermin/src/metrics/registry.rs
+++ b/mermin/src/metrics/registry.rs
@@ -74,6 +74,11 @@ lazy_static! {
     // Flow Lifecycle Metrics
     // ============================================================================
 
+    pub static ref FLOW_EVENTS_DROPPED_BACKPRESSURE: IntCounter = IntCounter::with_opts(
+        Opts::new("flow_events_dropped_backpressure_total", "Flow events dropped due to worker channel backpressure")
+            .namespace("mermin")
+    ).expect("failed to create flow_events_dropped_backpressure metric");
+
     /// Total number of flows created.
     pub static ref FLOWS_CREATED: IntCounterVec = IntCounterVec::new(
         Opts::new("mermin_flows_created_total", "Total number of flows created")
@@ -167,6 +172,7 @@ pub fn init_registry() -> Result<(), prometheus::Error> {
     REGISTRY.register(Box::new(TC_PROGRAMS_DETACHED.clone()))?;
 
     // Flow metrics
+    REGISTRY.register(Box::new(FLOW_EVENTS_DROPPED_BACKPRESSURE.clone()))?;
     REGISTRY.register(Box::new(FLOWS_CREATED.clone()))?;
     REGISTRY.register(Box::new(FLOWS_EXPIRED.clone()))?;
     REGISTRY.register(Box::new(FLOWS_ACTIVE.clone()))?;


### PR DESCRIPTION
## Changes

Fix three critical production issues in Kubernetes deployments:

- Implement K8s cache sync timeout to prevent indefinite startup hangs
  * Add informers_sync_timeout configuration (default: 30s)
  * Restructure K8s informer config under discovery.informer.k8s
  * Increase startup probe threshold to 180s for large clusters

- Make /metrics endpoint async to eliminate timeout errors
  * Move Prometheus registry.gather() to spawn_blocking
  * Prevent blocking async runtime with synchronous operations

- Fix critical ring buffer deadlock under high load
  * Drop events with backpressure metric instead of blocking
  * Add FLOW_EVENTS_DROPPED_BACKPRESSURE metric for monitoring
  * Prevent cascading failures when worker channels are full

- Improve TCX program restart handling
  * Leverage TCX multi-program support for pod restarts
  * Document orphan cleanup behavior (kernel GC when old pod exits)

- Update configuration structure and documentation
  * Move filtering options to dedicated modules
  * Update all examples and docs to new config structure
  * Document informer configuration options

Resolves healthcheck failures, random /metrics timeouts, and deadlocks during high traffic.

Fixes ENG-331

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation

## Testing

Local environment and still needs to be verified in GKE.

## Proof it works

<!-- Screenshots, logs, test output, or other evidence showing your changes work as expected -->

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass
