### PR TITLE
fix: pipeline stalls by isolating runtime threads and eliminating blocking operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ helm_rendered
 # IDEs
 .idea
 .vscode
+
+# Development artifacts
+/local

--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -10,9 +10,15 @@ auto_reload = false
 # Shutdown timeout
 shutdown_timeout = "5s"
 
-# Internal channel and performance related configuration options
-packet_channel_capacity = 1024
-packet_worker_count     = 2
+# Pipeline performance and channel configuration options
+pipeline {
+  ring_buffer_capacity             = 8192
+  worker_count                     = 4
+  worker_poll_interval             = "5s"
+  k8s_decorator_threads            = 12
+  flow_span_channel_multiplier     = 2.0
+  decorated_span_channel_multiplier = 4.0
+}
 
 # Internal configuration options
 internal "traces" {

--- a/charts/mermin/config/examples/config.yaml
+++ b/charts/mermin/config/examples/config.yaml
@@ -398,8 +398,13 @@ metrics:
   enabled: true
   listen_address: 0.0.0.0
   port: 10250
-packet_channel_capacity: 1024
-packet_worker_count: 2
+pipeline:
+  ring_buffer_capacity: 8192
+  worker_count: 4
+  worker_poll_interval: 5s
+  k8s_decorator_threads: 12
+  flow_span_channel_multiplier: 2.0
+  decorated_span_channel_multiplier: 4.0
 parser:
   geneve_port: 6081
   vxlan_port: 4789

--- a/charts/mermin/templates/daemonset.yaml
+++ b/charts/mermin/templates/daemonset.yaml
@@ -101,6 +101,7 @@ spec:
             - name: bpf-fs
               mountPath: /sys/fs/bpf
               readOnly: false
+              mountPropagation: HostToContainer
             {{- if .Values.config.content }}
             - name: mermin-config
               mountPath: /etc/mermin

--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -78,25 +78,25 @@ livenessProbe:
   httpGet:
     path: /livez
     port: api
-  initialDelaySeconds: 5
+  initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
-  failureThreshold: 3
+  failureThreshold: 6
 
 readinessProbe:
   httpGet:
     path: /readyz
     port: api
-  initialDelaySeconds: 5
+  initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 5
-  failureThreshold: 3
+  failureThreshold: 6
 
 startupProbe:
   httpGet:
     path: /startup
     port: api
-  initialDelaySeconds: 0
+  initialDelaySeconds: 2
   periodSeconds: 3
   timeoutSeconds: 5
   failureThreshold: 60

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -149,8 +149,11 @@ Top-level settings that affect overall behavior:
 log_level = "info"
 auto_reload = false
 shutdown_timeout = "5s"
-packet_channel_capacity = 1024
-packet_worker_count = 2
+
+pipeline {
+  ring_buffer_capacity = 8192
+  worker_count = 4
+}
 ```
 
 See [Global Options](global-options.md) for details.

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -16,8 +16,11 @@ log_level = "info"
 shutdown_timeout = "30s"
 
 # Optimized for production load
-packet_worker_count = 8
-packet_channel_capacity = 4096
+pipeline {
+  ring_buffer_capacity = 8192
+  worker_count = 8
+  k8s_decorator_threads = 12
+}
 
 # API for health checks (required for liveness/readiness probes)
 api {
@@ -399,8 +402,11 @@ Optimized for high packet rate environments (>10 Gbps).
 log_level = "warn"  # Reduce logging overhead
 
 # Maximize worker parallelism
-packet_worker_count = 16
-packet_channel_capacity = 16384
+pipeline {
+  ring_buffer_capacity = 16384
+  worker_count = 16
+  k8s_decorator_threads = 24
+}
 
 api {
   enabled = true

--- a/docs/deployment/advanced-scenarios.md
+++ b/docs/deployment/advanced-scenarios.md
@@ -218,10 +218,10 @@ export "traces" {
 
     # Adjust timeouts for HA scenarios
     timeout = "10s"
-    max_export_timeout = "30s"
+    max_export_timeout = "10s"
 
     # Increase queue for temporary outages
-    max_queue_size = 4096
+    max_queue_size = 32768
   }
 }
 ```
@@ -268,8 +268,11 @@ For environments with high network traffic (> 10,000 flows/second):
 
 ```hcl
 # Increase internal buffering
-packet_channel_capacity = 4096
-packet_worker_count = 4
+pipeline {
+  ring_buffer_capacity = 8192
+  worker_count = 8
+  k8s_decorator_threads = 12
+}
 
 # Aggressive flow expiration to limit memory
 span {
@@ -337,9 +340,12 @@ export "traces" {
 For nodes with limited memory:
 
 ```hcl
-# Reduce buffer sizes
-packet_channel_capacity = 512
-packet_worker_count = 1
+# Reduce buffer sizes for low-resource environments
+pipeline {
+  ring_buffer_capacity = 2048
+  worker_count = 1
+  k8s_decorator_threads = 2
+}
 
 # Aggressive flow expiration
 span {
@@ -463,8 +469,8 @@ Key metrics:
 
 **If you see packet drops:**
 
-1. Increase `packet_channel_capacity`
-2. Increase `packet_worker_count`
+1. Increase `pipeline.ring_buffer_capacity`
+2. Increase `pipeline.worker_count`
 3. Add more CPU resources
 4. Reduce monitored interfaces
 

--- a/docs/deployment/docker-bare-metal.md
+++ b/docs/deployment/docker-bare-metal.md
@@ -57,9 +57,11 @@ log_level = "info"
 # Shutdown timeout
 shutdown_timeout = "10s"
 
-# Internal channel configuration
-packet_channel_capacity = 1024
-packet_worker_count = 2
+# Pipeline configuration
+pipeline {
+  ring_buffer_capacity = 8192
+  worker_count = 4
+}
 
 # Network interfaces to monitor
 discovery "instrument" {

--- a/docs/deployment/examples/local/config.test.hcl
+++ b/docs/deployment/examples/local/config.test.hcl
@@ -1,8 +1,8 @@
 # Test configuration optimized for fast CI runs
 # Reduce flow export intervals for faster test feedback
 span {
-  max_record_interval = "5s"   # Export active flows every 5s (default: 60s)
-  icmp_timeout = "3s"          # ICMP flows timeout after 3s (default: 10s)
+  max_record_interval = "10s"   # Export active flows every 5s (default: 60s)
+  icmp_timeout = "5s"          # ICMP flows timeout after 3s (default: 10s)
 }
 
 # OTLP exporter configuration

--- a/docs/deployment/kubernetes-helm.md
+++ b/docs/deployment/kubernetes-helm.md
@@ -152,9 +152,9 @@ export "traces" {
     timeout = "10s"
     max_batch_size = 512
     max_batch_interval = "5s"
-    max_queue_size = 2048
+    max_queue_size = 32768
     max_concurrent_exports = 1
-    max_export_timeout = "30s"
+    max_export_timeout = "10s"
   }
 }
 

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -231,10 +231,11 @@ Mermin is designed to be efficient in production environments:
 
 ### Tunability
 
-Mermin provides extensive configuration for performance tuning:
+Mermin provides extensive configuration for performance tuning under the `pipeline` block:
 
-* `packet_channel_capacity`: Buffer size between eBPF and userspace
-* `packet_worker_count`: Number of parallel flow processors
+* `pipeline.ring_buffer_capacity`: eBPF ring buffer size between kernel and userspace
+* `pipeline.worker_count`: Number of parallel flow worker threads
+* `pipeline.k8s_decorator_threads`: Dedicated threads for Kubernetes metadata decoration
 * `span.*_timeout`: Flow expiration times affect memory usage
 * `export.otlp.max_batch_size`: Larger batches reduce network overhead
 * `export.otlp.max_queue_size`: Backpressure buffer for slow backends
@@ -313,7 +314,7 @@ If the OTLP backend is unavailable:
 
 * **Interface Unavailable**: Mermin logs a warning and continues monitoring other interfaces
 * **eBPF Load Failure**: Agent fails to start; check kernel version and eBPF support
-* **High Packet Loss**: Increase `packet_channel_capacity` or reduce monitored interfaces
+* **High Packet Loss**: Increase `pipeline.ring_buffer_capacity` or reduce monitored interfaces
 
 ## Comparison with Alternatives
 

--- a/docs/troubleshooting/export-issues.md
+++ b/docs/troubleshooting/export-issues.md
@@ -376,12 +376,12 @@ export "traces" {
 ```hcl
 export "traces" {
   otlp = {
-    max_queue_size = 8192  # Increase from default (2048)
+    max_queue_size = 65536  # Increase from default (32768)
   }
 }
 ```
 
-**Note**: Larger queues use more memory.
+**Note**: Larger queues use more memory. Default (32768) is sized for 100K flows/sec.
 
 #### 3. Network Latency
 

--- a/mermin/src/k8s/owner_relations.rs
+++ b/mermin/src/k8s/owner_relations.rs
@@ -15,7 +15,7 @@ use k8s_openapi::{
 };
 use kube::{Resource, ResourceExt};
 use serde::{Deserialize, Serialize};
-use tracing::{debug, trace, warn};
+use tracing::{trace, warn};
 
 use crate::k8s::attributor::{K8sObjectMeta, ResourceStore, WorkloadOwner};
 
@@ -183,7 +183,7 @@ impl OwnerRelationsManager {
                         next_level_owners.extend(next_owners);
                     }
                 } else {
-                    debug!(
+                    trace!(
                         event.name = "k8s.owner_ref_missing",
                         k8s.owner.name = %owner_ref.name,
                         k8s.owner.kind = %owner_ref.kind,
@@ -268,7 +268,7 @@ impl OwnerRelationsManager {
             ($store_type:ty, $variant:ident) => {{
                 let resources = store.get_by_namespace::<$store_type>(namespace);
                 let resource_count = resources.len();
-                debug!(
+                trace!(
                     event.name = "k8s.lookup_owner.store_check",
                     k8s.owner.kind = %kind,
                     k8s.namespace = %namespace,
@@ -303,7 +303,7 @@ impl OwnerRelationsManager {
             "Job" => find_in_store!(Job, Job),
             "CronJob" => find_in_store!(CronJob, CronJob),
             _ => {
-                debug!(
+                trace!(
                     event.name = "k8s.unsupported_owner_kind",
                     k8s.owner.kind = %owner_ref.kind,
                     "owner lookup for this resource kind is not implemented"

--- a/mermin/src/metrics/registry.rs
+++ b/mermin/src/metrics/registry.rs
@@ -5,8 +5,8 @@
 
 use lazy_static::lazy_static;
 use prometheus::{
-    GaugeVec, Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
-    Registry,
+    GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, Opts, Registry,
 };
 
 lazy_static! {
@@ -79,6 +79,78 @@ lazy_static! {
             .namespace("mermin")
     ).expect("failed to create flow_events_dropped_backpressure metric");
 
+    // TODO: Implement adaptive sampling in ring buffer consumer (mermin-ebpf/src/main.rs)
+    // This metric tracks intentional drops when worker channels are full to prevent complete stalls.
+    // Should be incremented when sampling logic drops events based on channel capacity.
+    // See: performance.sampling_enabled config option
+    /// Total number of flow events sampled (dropped intentionally during backpressure).
+    pub static ref FLOW_EVENTS_SAMPLED: IntCounter = IntCounter::with_opts(
+        Opts::new("flow_events_sampled_total", "Flow events sampled (dropped) during adaptive backpressure")
+            .namespace("mermin")
+    ).expect("failed to create flow_events_sampled metric");
+
+    // TODO: Implement dynamic sampling rate gauge in ring buffer consumer
+    // Should be updated when sampling logic adjusts drop rate based on channel utilization.
+    // One gauge per worker thread for granular visibility.
+    /// Current adaptive sampling rate (0.0 = no sampling, 1.0 = dropping everything).
+    pub static ref FLOW_EVENTS_SAMPLING_RATE: GaugeVec = GaugeVec::new(
+        Opts::new("flow_events_sampling_rate", "Current adaptive sampling rate")
+            .namespace("mermin"),
+        &["worker"]
+    ).expect("failed to create flow_events_sampling_rate metric");
+
+    // TODO: Add channel monitoring in pipeline (main.rs)
+    // Calculate ratio = current_len / capacity for each channel periodically.
+    // Channels: worker channels, flow_span_rx, k8s_decorated_flow_span_tx
+    // Helps identify bottlenecks and backpressure points.
+    /// Channel capacity utilization ratio (0.0-1.0).
+    pub static ref CHANNEL_CAPACITY_USED_RATIO: GaugeVec = GaugeVec::new(
+        Opts::new("channel_capacity_used_ratio", "Channel capacity utilization ratio (0.0 to 1.0)")
+            .namespace("mermin"),
+        &["channel"]
+    ).expect("failed to create channel_capacity_used_ratio metric");
+
+    // TODO: Increment when try_send() fails on any channel
+    // Add to worker dispatch, decorator send, and export send paths.
+    // Indicates when backpressure is actively blocking the pipeline.
+    /// Total number of times a channel was full (try_send failed).
+    pub static ref CHANNEL_FULL_EVENTS: IntCounterVec = IntCounterVec::new(
+        Opts::new("channel_full_events_total", "Total number of channel full events")
+            .namespace("mermin"),
+        &["channel"]
+    ).expect("failed to create channel_full_events metric");
+
+    // TODO: Add timing instrumentation to pipeline stages (main.rs)
+    // Stages: "flow_production", "k8s_decoration", "otlp_export"
+    // Wrap each stage with: let timer = PROCESSING_LATENCY.with_label_values(&["stage"]).start_timer();
+    // Critical for identifying slow stages under load.
+    /// Processing latency by pipeline stage.
+    pub static ref PROCESSING_LATENCY: HistogramVec = HistogramVec::new(
+        HistogramOpts::new("processing_latency_seconds", "Processing latency by pipeline stage")
+            .namespace("mermin")
+            .buckets(vec![0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1]),
+        &["stage"]
+    ).expect("failed to create processing_latency metric");
+
+    /// Total number of flow spans dropped due to export channel full.
+    pub static ref FLOW_SPANS_DROPPED_EXPORT_FAILURE: IntCounter = IntCounter::with_opts(
+        Opts::new("flow_spans_dropped_export_failure_total", "Flow spans dropped due to export channel full")
+            .namespace("mermin")
+    ).expect("failed to create flow_spans_dropped_export_failure metric");
+
+    /// Total number of export operations that timed out.
+    pub static ref EXPORT_TIMEOUTS: IntCounter = IntCounter::with_opts(
+        Opts::new("export_timeouts_total", "Total number of export operations that timed out")
+            .namespace("mermin")
+    ).expect("failed to create export_timeouts metric");
+
+    /// Time spent blocked waiting for export operations to complete.
+    pub static ref EXPORT_BLOCKING_TIME: Histogram = Histogram::with_opts(
+        HistogramOpts::new("export_blocking_time_seconds", "Time spent blocked waiting for export operations")
+            .namespace("mermin")
+            .buckets(vec![0.001, 0.01, 0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0])
+    ).expect("failed to create export_blocking_time metric");
+
     /// Total number of flows created.
     pub static ref FLOWS_CREATED: IntCounterVec = IntCounterVec::new(
         Opts::new("mermin_flows_created_total", "Total number of flows created")
@@ -139,6 +211,37 @@ lazy_static! {
     ).expect("failed to create export_latency metric");
 
     // ============================================================================
+    // Kubernetes Watcher Metrics
+    // ============================================================================
+
+    /// Total number of K8s resource watcher events received.
+    pub static ref K8S_WATCHER_EVENTS: IntCounterVec = IntCounterVec::new(
+        Opts::new("k8s_watcher_events_total", "Total number of K8s resource watcher events")
+            .namespace("mermin"),
+        &["resource", "event_type"]  // event_type: applied, deleted, restarted
+    ).expect("failed to create k8s_watcher_events metric");
+
+    /// Total number of K8s watcher errors.
+    pub static ref K8S_WATCHER_ERRORS: IntCounterVec = IntCounterVec::new(
+        Opts::new("k8s_watcher_errors_total", "Total number of K8s watcher errors")
+            .namespace("mermin"),
+        &["resource"]
+    ).expect("failed to create k8s_watcher_errors metric");
+
+    /// Total number of K8s IP index updates triggered.
+    pub static ref K8S_IP_INDEX_UPDATES: IntCounter = IntCounter::with_opts(
+        Opts::new("k8s_ip_index_updates_total", "Total number of K8s IP index updates")
+            .namespace("mermin")
+    ).expect("failed to create k8s_ip_index_updates metric");
+
+    /// Histogram of K8s IP index update duration.
+    pub static ref K8S_IP_INDEX_UPDATE_DURATION: Histogram = Histogram::with_opts(
+        HistogramOpts::new("k8s_ip_index_update_duration_seconds", "Duration of K8s IP index updates")
+            .namespace("mermin")
+            .buckets(vec![0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0])
+    ).expect("failed to create k8s_ip_index_update_duration metric");
+
+    // ============================================================================
     // Per-Interface Statistics
     // ============================================================================
 
@@ -173,6 +276,14 @@ pub fn init_registry() -> Result<(), prometheus::Error> {
 
     // Flow metrics
     REGISTRY.register(Box::new(FLOW_EVENTS_DROPPED_BACKPRESSURE.clone()))?;
+    REGISTRY.register(Box::new(FLOW_EVENTS_SAMPLED.clone()))?;
+    REGISTRY.register(Box::new(FLOW_EVENTS_SAMPLING_RATE.clone()))?;
+    REGISTRY.register(Box::new(CHANNEL_CAPACITY_USED_RATIO.clone()))?;
+    REGISTRY.register(Box::new(CHANNEL_FULL_EVENTS.clone()))?;
+    REGISTRY.register(Box::new(PROCESSING_LATENCY.clone()))?;
+    REGISTRY.register(Box::new(FLOW_SPANS_DROPPED_EXPORT_FAILURE.clone()))?;
+    REGISTRY.register(Box::new(EXPORT_TIMEOUTS.clone()))?;
+    REGISTRY.register(Box::new(EXPORT_BLOCKING_TIME.clone()))?;
     REGISTRY.register(Box::new(FLOWS_CREATED.clone()))?;
     REGISTRY.register(Box::new(FLOWS_EXPIRED.clone()))?;
     REGISTRY.register(Box::new(FLOWS_ACTIVE.clone()))?;
@@ -183,6 +294,12 @@ pub fn init_registry() -> Result<(), prometheus::Error> {
     REGISTRY.register(Box::new(SPANS_EXPORT_ERRORS.clone()))?;
     REGISTRY.register(Box::new(EXPORT_BATCH_SIZE.clone()))?;
     REGISTRY.register(Box::new(EXPORT_LATENCY.clone()))?;
+
+    // K8s watcher metrics
+    REGISTRY.register(Box::new(K8S_WATCHER_EVENTS.clone()))?;
+    REGISTRY.register(Box::new(K8S_WATCHER_ERRORS.clone()))?;
+    REGISTRY.register(Box::new(K8S_IP_INDEX_UPDATES.clone()))?;
+    REGISTRY.register(Box::new(K8S_IP_INDEX_UPDATE_DURATION.clone()))?;
 
     // Interface metrics
     REGISTRY.register(Box::new(PACKETS_TOTAL.clone()))?;

--- a/mermin/src/otlp/opts.rs
+++ b/mermin/src/otlp/opts.rs
@@ -402,19 +402,19 @@ pub mod defaults {
         Duration::from_secs(10)
     }
     pub fn max_batch_size() -> usize {
-        512
+        1024
     }
     pub fn max_batch_interval() -> Duration {
-        Duration::from_secs(5)
+        Duration::from_secs(2)
     }
     pub fn max_queue_size() -> usize {
-        2048
+        32768
     }
     pub fn max_concurrent_exports() -> usize {
-        1
+        4
     }
     pub fn max_export_timeout() -> Duration {
-        Duration::from_millis(30000)
+        Duration::from_secs(10)
     }
 }
 

--- a/mermin/src/otlp/provider.rs
+++ b/mermin/src/otlp/provider.rs
@@ -196,6 +196,13 @@ impl ProviderBuilder {
                     .with_max_concurrent_exports(options.max_concurrent_exports)
                     .with_max_export_timeout(options.max_export_timeout)
                     .build();
+                info!(
+                    event.name = "batch_span_processor.config",
+                    max_queue_size = options.max_queue_size,
+                    max_concurrent_exports = options.max_concurrent_exports,
+                    max_batch_size = options.max_batch_size,
+                    "configuring batch span processor for high throughput"
+                );
 
                 let processor = BatchSpanProcessor::builder(exporter, runtime::Tokio)
                     .with_batch_config(batch_config)

--- a/mermin/src/span/flow.rs
+++ b/mermin/src/span/flow.rs
@@ -1,4 +1,7 @@
-use std::{net::IpAddr, time::SystemTime};
+use std::{
+    net::IpAddr,
+    time::{Duration, SystemTime},
+};
 
 use mermin_common::TunnelType;
 use network_types::{eth::EtherType, ip::IpProto};
@@ -80,7 +83,7 @@ pub struct FlowSpan {
     pub span_kind: SpanKind,
     pub attributes: SpanAttributes,
 
-    // NEW: For eBPF map aggregation architecture
+    // eBPF map aggregation fields
     #[serde(skip)]
     pub flow_key: Option<mermin_common::FlowKey>,
     #[serde(skip)]
@@ -94,6 +97,14 @@ pub struct FlowSpan {
     #[serde(skip)]
     #[allow(dead_code)]
     pub boot_time_offset: u64,
+
+    // Timing metadata for polling architecture
+    #[serde(skip)]
+    pub last_recorded_time: SystemTime,
+    #[serde(skip)]
+    pub last_activity_time: SystemTime,
+    #[serde(skip)]
+    pub timeout_duration: Duration,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1026,6 +1037,9 @@ mod tests {
             last_recorded_reverse_packets: 0,
             last_recorded_reverse_bytes: 0,
             boot_time_offset: 0,
+            last_recorded_time: std::time::UNIX_EPOCH,
+            last_activity_time: std::time::UNIX_EPOCH,
+            timeout_duration: Duration::from_secs(0),
         };
 
         assert_eq!(
@@ -1047,6 +1061,9 @@ mod tests {
             last_recorded_reverse_packets: 0,
             last_recorded_reverse_bytes: 0,
             boot_time_offset: 0,
+            last_recorded_time: std::time::UNIX_EPOCH,
+            last_activity_time: std::time::UNIX_EPOCH,
+            timeout_duration: Duration::from_secs(0),
         };
 
         assert_eq!(
@@ -1068,6 +1085,9 @@ mod tests {
             last_recorded_reverse_packets: 0,
             last_recorded_reverse_bytes: 0,
             boot_time_offset: 0,
+            last_recorded_time: std::time::UNIX_EPOCH,
+            last_activity_time: std::time::UNIX_EPOCH,
+            timeout_duration: Duration::from_secs(0),
         };
         flow_span.attributes.network_type = EtherType::Ipv4;
         flow_span.attributes.network_transport = IpProto::Tcp;
@@ -1089,6 +1109,9 @@ mod tests {
             last_recorded_reverse_packets: 0,
             last_recorded_reverse_bytes: 0,
             boot_time_offset: 0,
+            last_recorded_time: std::time::UNIX_EPOCH,
+            last_activity_time: std::time::UNIX_EPOCH,
+            timeout_duration: Duration::from_secs(0),
         };
         flow_span.attributes.network_type = EtherType::Ipv6;
         flow_span.attributes.network_transport = IpProto::Udp;
@@ -1297,6 +1320,9 @@ mod tests {
             last_recorded_reverse_packets: 0,
             last_recorded_reverse_bytes: 0,
             boot_time_offset: 0,
+            last_recorded_time: std::time::UNIX_EPOCH,
+            last_activity_time: std::time::UNIX_EPOCH,
+            timeout_duration: Duration::from_secs(0),
         };
 
         let cloned = flow_span.clone();
@@ -1337,6 +1363,9 @@ mod tests {
             last_recorded_reverse_packets: 0,
             last_recorded_reverse_bytes: 0,
             boot_time_offset: 0,
+            last_recorded_time: std::time::UNIX_EPOCH,
+            last_activity_time: std::time::UNIX_EPOCH,
+            timeout_duration: Duration::from_secs(0),
         };
 
         let json = serde_json::to_string(&flow_span);

--- a/mermin/tests/e2e/grafana/config/mermin.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.hcl
@@ -3,8 +3,12 @@
 auto_reload = false
 
 # Pipeline configuration
-packet_channel_capacity = 1024
-packet_worker_count     = 2
+pipeline {
+  ring_buffer_capacity  = 8192
+  worker_count          = 4
+  worker_poll_interval  = "5s"
+  k8s_decorator_threads = 12
+}
 shutdown_timeout        = "5s"
 
 # API server configuration (health endpoints)


### PR DESCRIPTION
## Changes

Replace blocking send operations and shared runtime with isolated thread pools to prevent cascading failures when downstream components become slow or unavailable.

Key changes:
- Move API and metrics servers to dedicated single-threaded runtimes to ensure health checks always respond even under heavy load
- Move K8s decorator to dedicated multi-threaded pool to prevent K8s API lookups from blocking main packet processing pipeline
- Replace individual per-flow timeout tasks with hash-partitioned poller tasks that scale efficiently with flow count
- Replace blocking send() with try_send() throughout pipeline to prevent deadlocks when channels fill
- Replace K8s IP index RwLock with DashMap for better concurrent read performance
- Implement event-driven K8s watcher architecture, replacing periodic polling for real-time accuracy
- Add comprehensive pipeline metrics (processing latency, channel utilization, watcher events, export timeouts)
- Add /sys/fs/bpf writability check before TCX attachment to fail fast on permission issues
- Restructure pipeline configuration with granular tuning options (ring buffer capacity, worker count, decorator threads, channel multipliers)

This resolves production stalls where slow OTLP exports or K8s API calls would cause the entire pipeline to hang, resulting in dropped packets and missed flows.

Fixes ENG-335

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Local kind cluster with cilium CNI, OTel Microservice Platform helm chart, netobserv-flow, and opensearch.

## Proof it works

<img width="1377" height="302" alt="Screenshot 2025-11-15 at 10 08 31 PM" src="https://github.com/user-attachments/assets/0196a62f-19d8-4c79-be1a-8c103cc3ff0b" />

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

Changes need to be verified in our GKE cluster.
