### PR TITLE
feat: add configurable ebpf map sizing and adjust performance defaults

### DIFF
--- a/charts/mermin/config/examples/config.hcl
+++ b/charts/mermin/config/examples/config.hcl
@@ -12,11 +12,12 @@ shutdown_timeout = "5s"
 
 # Pipeline performance and channel configuration options
 pipeline {
-  ring_buffer_capacity             = 8192
-  worker_count                     = 4
-  worker_poll_interval             = "5s"
-  k8s_decorator_threads            = 12
-  flow_span_channel_multiplier     = 2.0
+  ebpf_max_flows                    = 100000
+  ring_buffer_capacity              = 8192
+  worker_count                      = 4
+  worker_poll_interval              = "5s"
+  k8s_decorator_threads             = 4
+  flow_span_channel_multiplier      = 2.0
   decorated_span_channel_multiplier = 4.0
 }
 

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -15,11 +15,11 @@ Optimized for reliability, security, and comprehensive observability in producti
 log_level = "info"
 shutdown_timeout = "30s"
 
-# Optimized for production load
+# Defaults are optimized for typical production workloads (1K-5K flows/sec)
 pipeline {
-  ring_buffer_capacity = 8192
-  worker_count = 8
-  k8s_decorator_threads = 12
+  ebpf_max_flows = 500000        # For high-traffic ingress (>10K flows/sec)
+  worker_count = 8               # For very busy nodes
+  k8s_decorator_threads = 12     # For very large clusters
 }
 
 # API for health checks (required for liveness/readiness probes)
@@ -396,13 +396,14 @@ export "traces" {
 
 ## High-Throughput Configuration
 
-Optimized for high packet rate environments (>10 Gbps).
+Optimized for extreme scale environments (>10 Gbps, edge/CDN deployments with >25K flows/sec).
 
 ```hcl
 log_level = "warn"  # Reduce logging overhead
 
-# Maximize worker parallelism
+# Maximize capacity and worker parallelism for extreme scale
 pipeline {
+  ebpf_max_flows = 1000000
   ring_buffer_capacity = 16384
   worker_count = 16
   k8s_decorator_threads = 24

--- a/docs/configuration/export-otlp.md
+++ b/docs/configuration/export-otlp.md
@@ -229,9 +229,9 @@ This is the internal queue capacity of OpenTelemetry's `BatchSpanProcessor`. Whe
 ```hcl
 export "traces" {
   otlp = {
-    max_queue_size = 32768  # Default (sized for 100K flows/sec)
+    max_queue_size = 32768  # Default (sized for typical enterprise workloads)
 
-    # For higher burst tolerance or very high throughput
+    # For very high throughput (>10K flows/sec) or higher burst tolerance
     # max_queue_size = 65536
 
     # For lower traffic environments
@@ -247,7 +247,7 @@ export "traces" {
 
 * Acts as buffer during temporary collector unavailability or slow exports
 * When full, `export()` calls block until space is available (with 60s timeout protection)
-* Default sized to buffer ~5 minutes at 100K flows/sec throughput
+* Default sized to buffer ~30 minutes at typical enterprise workloads (1K-5K flows/sec)
 * Monitor `mermin_export_timeouts_total` and `mermin_export_blocking_time_seconds` metrics
 
 ### `max_concurrent_exports`

--- a/docs/deployment/advanced-scenarios.md
+++ b/docs/deployment/advanced-scenarios.md
@@ -264,11 +264,12 @@ readinessProbe:
 
 ### High-Traffic Configuration
 
-For environments with high network traffic (> 10,000 flows/second):
+For environments with very high network traffic (> 10,000 flows/second), such as public ingress nodes or edge deployments:
 
 ```hcl
-# Increase internal buffering
+# Increase internal buffering and parallelism for extreme scale
 pipeline {
+  ebpf_max_flows = 500000          # Support up to 50K flows/sec
   ring_buffer_capacity = 8192
   worker_count = 8
   k8s_decorator_threads = 12

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -305,8 +305,8 @@ impl FlowSpanProducer {
         );
 
         // Spawn flow pollers (sharded by community_id hash) to replace per-flow tasks
-        // Scale with worker count but cap at 32 for high-throughput (100k flows/sec)
-        // Each poller can handle ~100K active flows efficiently
+        // Scale with worker count but cap at 32 for scalability
+        // Each poller can handle ~100K active flows efficiently (typical: 3-10K per poller)
         let num_pollers = self.worker_count.clamp(1, 32);
         let max_record_interval = self.span_opts.max_record_interval;
         let poll_interval = self.worker_poll_interval;

--- a/mermin/tests/e2e/grafana/config/mermin.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.hcl
@@ -2,12 +2,13 @@
 # Automatic configuration reloading
 auto_reload = false
 
-# Pipeline configuration
+# Pipeline configuration (using defaults optimized for typical enterprise)
 pipeline {
+  ebpf_max_flows        = 100000
   ring_buffer_capacity  = 8192
   worker_count          = 4
   worker_poll_interval  = "5s"
-  k8s_decorator_threads = 12
+  k8s_decorator_threads = 4
 }
 shutdown_timeout        = "5s"
 


### PR DESCRIPTION
## Changes

- Add pipeline.ebpf_max_flows config parameter (default: 100K flows)
- Make eBPF FLOW_STATS_MAP size configurable at runtime via loader
- Adjust k8s_decorator_threads default from 12 to 4 for typical workloads
- Update all documentation with realistic sizing guidance (1K-5K flows/sec)
- Provide scaling recommendations based on deployment type
- Update examples in docs and config files to reflect new defaults

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [x] Other: performance optimization

## Testing

Local testing on my kind cluster.

## Proof it works

<img width="480" height="296" alt="image" src="https://github.com/user-attachments/assets/e2ed7715-3812-493f-9c82-e913c23c5953" />

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass