### PR TITLE
feat: implement basic and bearer auth for otlp exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
  "fxhash",
  "globset",
  "hcl-rs",
+ "http",
  "humantime",
  "hyper-rustls",
  "hyper-util",

--- a/docs/configuration/export-otlp.md
+++ b/docs/configuration/export-otlp.md
@@ -4,25 +4,28 @@ hidden: true
 
 # OTLP Exporter
 
-This page documents the OpenTelemetry Protocol (OTLP) exporter configuration, which controls how Mermin exports flow records to your observability backend.
+This page documents the OpenTelemetry Protocol (OTLP) exporter configuration, which controls how Mermin exports flow
+records to your observability backend.
 
 ## Overview
 
-OTLP is the standard protocol for OpenTelemetry telemetry data. Mermin exports network flows as OTLP trace spans, enabling integration with any OTLP-compatible backend including OpenTelemetry Collector, Grafana Tempo, Jaeger, and more.
+OTLP is the standard protocol for OpenTelemetry telemetry data. Mermin exports network flows as OTLP trace spans,
+enabling integration with any OTLP-compatible backend including OpenTelemetry Collector, Grafana Tempo, Jaeger, and
+more.
 
 ## Configuration
 
 ```hcl
 export "traces" {
   otlp = {
-    endpoint = "http://otel-collector:4317"
-    protocol = "grpc"
-    timeout = "10s"
-    max_batch_size = 512
-    max_batch_interval = "5s"
-    max_queue_size = 32768
+    endpoint               = "http://otel-collector:4317"
+    protocol               = "grpc"
+    timeout                = "10s"
+    max_batch_size         = 512
+    max_batch_interval     = "5s"
+    max_queue_size         = 32768
     max_concurrent_exports = 1
-    max_export_timeout = "10s"
+    max_export_timeout     = "10s"
 
     auth = {
       basic = {
@@ -33,9 +36,9 @@ export "traces" {
 
     tls = {
       insecure_skip_verify = false
-      ca_cert = "/etc/certs/ca.crt"
-      client_cert = "/etc/certs/client.crt"
-      client_key = "/etc/certs/client.key"
+      ca_cert              = "/etc/certs/ca.crt"
+      client_cert          = "/etc/certs/client.crt"
+      client_key           = "/etc/certs/client.key"
     }
   }
 }
@@ -118,7 +121,7 @@ export "traces" {
 **Protocol Comparison:**
 
 | Feature               | gRPC   | HTTP     |
-| --------------------- | ------ | -------- |
+|-----------------------|--------|----------|
 | **Performance**       | Higher | Moderate |
 | **Streaming**         | Yes    | No       |
 | **Firewall Friendly** | Less   | More     |
@@ -155,7 +158,8 @@ export "traces" {
 
 ## Batching Configuration
 
-Mermin uses OpenTelemetry's `BatchSpanProcessor` for efficient batching and export of flow spans. The processor queues spans asynchronously and exports them in batches, providing natural backpressure when the queue fills up.
+Mermin uses OpenTelemetry's `BatchSpanProcessor` for efficient batching and export of flow spans. The processor queues
+spans asynchronously and exports them in batches, providing natural backpressure when the queue fills up.
 
 ### `max_batch_size`
 
@@ -220,6 +224,7 @@ Maximum number of spans queued in the `BatchSpanProcessor` before they are expor
 **Critical for High Throughput:**
 
 This is the internal queue capacity of OpenTelemetry's `BatchSpanProcessor`. When this queue fills up:
+
 - New spans are **dropped silently** (OpenTelemetry will log a warning)
 - The queue uses `try_send` which is **non-blocking**, so your pipeline won't deadlock
 - This provides natural backpressure during export slowdowns
@@ -259,11 +264,13 @@ Maximum number of concurrent export requests to the backend.
 **Tuning for Throughput:**
 
 This setting is **critical** for high-throughput scenarios. With the defaults:
+
 - `1024 spans/batch × 100 batches/sec/worker = 102,400 flows/sec capacity`
 - Each worker needs ~40ms per export (including network + backend processing)
 - If exports take longer, increase this value
 
 **Recommendations:**
+
 - **2-4:** Good for most scenarios (default is 4)
 - **6-8:** High backend latency (>50ms per export)
 - **1:** Low-latency, high-performance backends only
@@ -370,6 +377,20 @@ env:
         key: password
 ```
 
+### Bearer Authentication
+
+```hcl
+export "traces" {
+  otlp = {
+    endpoint = "https://collector.example.com:4317"
+
+    auth = {
+      bearer = "secret_password"
+    }
+  }
+}
+```
+
 ## TLS Configuration
 
 ### TLS with System CA Certificates
@@ -399,7 +420,7 @@ export "traces" {
 
     tls = {
       insecure_skip_verify = false
-      ca_cert = "/etc/mermin/certs/ca.crt"
+      ca_cert              = "/etc/mermin/certs/ca.crt"
     }
   }
 }
@@ -433,9 +454,9 @@ export "traces" {
 
     tls = {
       insecure_skip_verify = false
-      ca_cert = "/etc/mermin/certs/ca.crt"
-      client_cert = "/etc/mermin/certs/client.crt"
-      client_key = "/etc/mermin/certs/client.key"
+      ca_cert              = "/etc/mermin/certs/ca.crt"
+      client_cert          = "/etc/mermin/certs/client.crt"
+      client_key           = "/etc/mermin/certs/client.key"
     }
   }
 }
@@ -458,7 +479,8 @@ volumeMounts:
 ### Insecure Mode (Development Only)
 
 {% hint style="danger" %}
-**Never use in production!** This disables all certificate verification and makes connections vulnerable to man-in-the-middle attacks.
+**Never use in production!** This disables all certificate verification and makes connections vulnerable to
+man-in-the-middle attacks.
 {% endhint %}
 
 ```hcl
@@ -544,7 +566,7 @@ export "traces" {
     max_queue_size = 4096
 
     # Long timeouts
-    timeout = "30s"
+    timeout            = "30s"
     max_export_timeout = "60s"
   }
 }
@@ -568,12 +590,12 @@ export "traces" {
 ```hcl
 export "traces" {
   otlp = {
-    endpoint = "http://otel-collector:4317"
-    protocol = "grpc"
-    timeout = "10s"
-    max_batch_size = 512
+    endpoint           = "http://otel-collector:4317"
+    protocol           = "grpc"
+    timeout            = "10s"
+    max_batch_size     = 512
     max_batch_interval = "5s"
-    max_queue_size = 2048
+    max_queue_size     = 2048
   }
 }
 ```
@@ -583,12 +605,12 @@ export "traces" {
 ```hcl
 export "traces" {
   otlp = {
-    endpoint = "https://collector.example.com:4317"
-    protocol = "grpc"
-    timeout = "15s"
-    max_batch_size = 512
+    endpoint           = "https://collector.example.com:4317"
+    protocol           = "grpc"
+    timeout            = "15s"
+    max_batch_size     = 512
     max_batch_interval = "5s"
-    max_queue_size = 2048
+    max_queue_size     = 2048
 
     auth = {
       basic = {
@@ -599,9 +621,9 @@ export "traces" {
 
     tls = {
       insecure_skip_verify = false
-      ca_cert = "/etc/mermin/certs/ca.crt"
-      client_cert = "/etc/mermin/certs/client.crt"
-      client_key = "/etc/mermin/certs/client.key"
+      ca_cert              = "/etc/mermin/certs/ca.crt"
+      client_cert          = "/etc/mermin/certs/client.crt"
+      client_key           = "/etc/mermin/certs/client.key"
     }
   }
 }

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -77,6 +77,7 @@ tonic = { version = "0.14.2", features = ["transport"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+http = "1.3.1"
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/mermin/src/otlp/opts.rs
+++ b/mermin/src/otlp/opts.rs
@@ -199,7 +199,7 @@ pub struct OtlpExportOptions {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AuthOptions {
     pub basic: Option<BasicAuthOptions>,
-    // TODO: Add support for bearer, api_key, oauth2, mtls, etc. - ENG-120
+    pub bearer: Option<String>, // TODO: Add support for api_key, oauth2, mtls, etc. - ENG-120
 }
 
 /// Configuration for HTTP Basic Authentication credentials.
@@ -324,7 +324,11 @@ impl AuthOptions {
             headers.insert("Authorization".to_string(), format!("Basic {credentials}"));
         }
 
-        // TODO: Add support for other auth methods like bearer, api_key, oauth2, mtls, etc. - ENG-120
+        if let Some(bearer) = &self.bearer {
+            headers.insert("Authorization".to_string(), format!("Bearer {bearer}"));
+        }
+
+        // TODO: Add support for other auth methods like api_key, oauth2, mtls, etc. - ENG-120
 
         Ok(headers)
     }


### PR DESCRIPTION
## Changes

This PR enhances the OTLP exporter configuration to support HTTP Basic Authentication and Bearer Token authentication.

Previously, the exporter could only connect to unauthenticated endpoints or rely on external sidecars. With this change, the `AuthOptions` struct is utilized within the `with_otlp_exporter` builder to generate standard `Authorization` headers.

Key changes:
- Implemented `generate_auth_headers` to handle `Basic` (base64 encoded user:pass) and `Bearer` schemes.
- Updated `with_otlp_exporter` to inject these headers into the gRPC metadata during client construction.
- Added validation for header names and values to prevent invalid configuration from panicking the runtime.

Fixes ENG-124

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

I tested these changes using the following methods:

1.  **Unit Tests**: Verified that `generate_auth_headers` correctly encodes `user:pass` into Base64 for Basic auth and correctly formats the Bearer string.
2.  **Local Integration**: Configured the OTLP exporter to point to a local OpenTelemetry Collector with an authentication extension enabled. Verified that spans were rejected without creds and accepted with valid creds.

## Proof it works

With the configuration of a bearer token for Dash0, the following log is received after a successful export:

```
│ 2025-11-26T18:04:22.125022Z DEBUG tokio-runtime-worker ThreadId(10) opentelemetry-otlp: /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-o │
│ tlp-0.31.0/src/exporter/tonic/trace.rs:79:  name="TonicTracesClient.ExportStarted"                                                                                     │
│ 2025-11-26T18:04:22.341654Z DEBUG tokio-runtime-worker ThreadId(09) opentelemetry-otlp: /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-o │
│ tlp-0.31.0/src/exporter/tonic/trace.rs:91:  name="TonicTracesClient.ExportSucceeded"  
```

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

Currently, these headers are generated once during the exporter initialization (`builder.with_metadata`). This is suitable for static credentials (like API keys or long-lived tokens).
```