### PR TITLE
feat(metrics): add tiered metrics system with automatic cleanup for high-cardinality debug metrics

### DIFF
--- a/charts/mermin/config/default/config.hcl
+++ b/charts/mermin/config/default/config.hcl
@@ -67,6 +67,21 @@ metrics {
   enabled        = true
   listen_address = "0.0.0.0"
   port           = 10250
+
+  # Debug metrics configuration
+  # WARNING: Enabling debug metrics can cause significant memory growth in production
+  # Only enable for debugging purposes in development/staging environments
+  debug_metrics_enabled = false  # Set to true for per-resource metrics (interface, task, K8s resource labels)
+
+  # Time-to-live for stale metrics after resource deletion (only applies when debug_metrics_enabled = true)
+  # Examples: "5m", "300s", "1h", "0s" for immediate cleanup
+  # Recommended: "5m" handles pod restarts while preventing unbounded growth
+  stale_metric_ttl = "5m"
+
+  # Endpoints available:
+  # - /metrics          - All metrics (standard + debug if enabled)
+  # - /metrics/standard - Standard metrics only (aggregated, no high-cardinality labels)
+  # - /metrics/debug    - Debug metrics only (returns 404 if debug not enabled)
 }
 
 # Parser configuration for eBPF packet parsing

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -173,10 +173,18 @@ metrics {
   enabled = true
   listen_address = "0.0.0.0"
   port = 10250
+
+  # Debug metrics (optional) - see warning below
+  debug_metrics_enabled = false
+  stale_metric_ttl = "5m"
 }
 ```
 
-See [API and Metrics](api-metrics.md) for details.
+{% hint style="warning" %}
+**Debug Metrics Warning**: Setting `debug_metrics_enabled = true` enables high-cardinality metrics with per-resource labels. This can cause significant memory growth in production. Only enable for debugging. See [Debug Metrics Configuration](metrics-debug.md) for details.
+{% endhint %}
+
+See [API and Metrics](api-metrics.md) and [Debug Metrics](metrics-debug.md) for details.
 
 ### Parser Configuration
 

--- a/docs/semcov/spec.md
+++ b/docs/semcov/spec.md
@@ -163,55 +163,56 @@ Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 
 | Proposed Field Name                | Data Type  | Description                                                         | Notes / Decisions                          | Std OTel | Required |
 |:-----------------------------------|:-----------|:--------------------------------------------------------------------|--------------------------------------------|:---------|:---------|
-| `source.k8s.cluster.name`          | `string`   | The name of the Kubernetes cluster for the source.                  |                                            | ✓        | ○        |
+| `source.k8s.cluster.name`          | `string`   | The name of the Kubernetes cluster for the source.                  |                                            | ✓        | ~        |
 | `source.k8s.cluster.uid`           | `string`   | The uid of the Kubernetes cluster for the source.                   |                                            | ✓        | ○        |
-| `source.k8s.node.name`             | `string`   | The name of the Kubernetes Node for the source.                     |                                            | ✓        | ○        |
+| `source.k8s.node.name`             | `string`   | The name of the Kubernetes Node for the source.                     |                                            | ✓        | ~        |
 | `source.k8s.node.uid`              | `string`   | The uid of the Kubernetes Node for the source.                      |                                            | ✓        | ○        |
-| `source.k8s.namespace.name`        | `string`   | The name of the Kubernetes Namespace for the source.                |                                            | ✓        | ○        |
-| `source.k8s.pod.name`              | `string`   | The name of the Kubernetes Pod for the source.                      |                                            | ✓        | ○        |
+| `source.k8s.namespace.name`        | `string`   | The name of the Kubernetes Namespace for the source.                |                                            | ✓        | ~        |
+| `source.k8s.pod.name`              | `string`   | The name of the Kubernetes Pod for the source.                      |                                            | ✓        | ~        |
 | `source.k8s.pod.uid`               | `string`   | The uid of the Kubernetes Pod for the source.                       |                                            | ✓        | ○        |
-| `source.k8s.container.name`        | `string`   | The name of the Kubernetes Container for the source.                |                                            | ✓        | ○        |
-| `source.k8s.deployment.name`       | `string`   | The name of the Kubernetes Deployment for the source.               |                                            | ✓        | ○        |
+| `source.k8s.container.name`        | `string`   | The name of the Kubernetes Container for the source.                |                                            | ✓        | ~        |
+| `source.k8s.deployment.name`       | `string`   | The name of the Kubernetes Deployment for the source.               |                                            | ✓        | ~        |
 | `source.k8s.deployment.uid`        | `string`   | The uid of the Kubernetes Deployment for the source.                |                                            | ✓        | ○        |
-| `source.k8s.replicaset.name`       | `string`   | The name of the Kubernetes ReplicaSet for the source.               |                                            | ✓        | ○        |
+| `source.k8s.replicaset.name`       | `string`   | The name of the Kubernetes ReplicaSet for the source.               |                                            | ✓        | ~        |
 | `source.k8s.replicaset.uid`        | `string`   | The uid of the Kubernetes ReplicaSet for the source.                |                                            | ✓        | ○        |
-| `source.k8s.statefulset.name`      | `string`   | The name of the Kubernetes StatefulSet for the source.              |                                            | ✓        | ○        |
+| `source.k8s.statefulset.name`      | `string`   | The name of the Kubernetes StatefulSet for the source.              |                                            | ✓        | ~        |
 | `source.k8s.statefulset.uid`       | `string`   | The uid of the Kubernetes StatefulSet for the source.               |                                            | ✓        | ○        |
-| `source.k8s.daemonset.name`        | `string`   | The name of the Kubernetes DaemonSet for the source.                |                                            | ✓        | ○        |
+| `source.k8s.daemonset.name`        | `string`   | The name of the Kubernetes DaemonSet for the source.                |                                            | ✓        | ~        |
 | `source.k8s.daemonset.uid`         | `string`   | The uid of the Kubernetes DaemonSet for the source.                 |                                            | ✓        | ○        |
-| `source.k8s.job.name`              | `string`   | The name of the Kubernetes Job for the source.                      |                                            | ✓        | ○        |
+| `source.k8s.job.name`              | `string`   | The name of the Kubernetes Job for the source.                      |                                            | ✓        | ~        |
 | `source.k8s.job.uid`               | `string`   | The uid of the Kubernetes Job for the source.                       |                                            | ✓        | ○        |
-| `source.k8s.cronjob.name`          | `string`   | The name of the Kubernetes CronJob for the source.                  |                                            | ✓        | ○        |
+| `source.k8s.cronjob.name`          | `string`   | The name of the Kubernetes CronJob for the source.                  |                                            | ✓        | ~        |
 | `source.k8s.cronjob.uid`           | `string`   | The uid of the Kubernetes CronJob for the source.                   |                                            | ✓        | ○        |
-| `source.k8s.service.name`          | `string`   | The name of the Kubernetes Service for the source.                  |                                            | ✓        | ○        |
+| `source.k8s.service.name`          | `string`   | The name of the Kubernetes Service for the source.                  |                                            | ✓        | ~        |
 | `source.k8s.service.uid`           | `string`   | The uid of the Kubernetes Service for the source.                   |                                            | ✓        | ○        |
-| `destination.k8s.cluster.name`     | `string`   | The name of the Kubernetes cluster for the destination.             |                                            | ✓        | ○        |
+| `destination.k8s.cluster.name`     | `string`   | The name of the Kubernetes cluster for the destination.             |                                            | ✓        | ~        |
 | `destination.k8s.cluster.uid`      | `string`   | The uid of the Kubernetes cluster for the destination.              |                                            | ✓        | ○        |
-| `destination.k8s.node.name`        | `string`   | The name of the Kubernetes Node for the destination.                |                                            | ✓        | ○        |
+| `destination.k8s.node.name`        | `string`   | The name of the Kubernetes Node for the destination.                |                                            | ✓        | ~        |
 | `destination.k8s.node.uid`         | `string`   | The uid of the Kubernetes Node for the destination.                 |                                            | ✓        | ○        |
-| `destination.k8s.namespace.name`   | `string`   | The name of the Kubernetes Namespace for the destination.           |                                            | ✓        | ○        |
-| `destination.k8s.pod.name`         | `string`   | The name of the Kubernetes Pod for the destination.                 |                                            | ✓        | ○        |
+| `destination.k8s.namespace.name`   | `string`   | The name of the Kubernetes Namespace for the destination.           |                                            | ✓        | ~        |
+| `destination.k8s.pod.name`         | `string`   | The name of the Kubernetes Pod for the destination.                 |                                            | ✓        | ~        |
 | `destination.k8s.pod.uid`          | `string`   | The uid of the Kubernetes Pod for the destination.                  |                                            | ✓        | ○        |
-| `destination.k8s.container.name`   | `string`   | The name of the Kubernetes Container for the destination.           |                                            | ✓        | ○        |
-| `destination.k8s.deployment.name`  | `string`   | The name of the Kubernetes Deployment for the destination.          |                                            | ✓        | ○        |
+| `destination.k8s.container.name`   | `string`   | The name of the Kubernetes Container for the destination.           |                                            | ✓        | ~        |
+| `destination.k8s.deployment.name`  | `string`   | The name of the Kubernetes Deployment for the destination.          |                                            | ✓        | ~        |
 | `destination.k8s.deployment.uid`   | `string`   | The uid of the Kubernetes Deployment for the destination.           |                                            | ✓        | ○        |
-| `destination.k8s.replicaset.name`  | `string`   | The name of the Kubernetes ReplicaSet for the destination.          |                                            | ✓        | ○        |
+| `destination.k8s.replicaset.name`  | `string`   | The name of the Kubernetes ReplicaSet for the destination.          |                                            | ✓        | ~        |
 | `destination.k8s.replicaset.uid`   | `string`   | The uid of the Kubernetes ReplicaSet for the destination.           |                                            | ✓        | ○        |
-| `destination.k8s.statefulset.name` | `string`   | The name of the Kubernetes StatefulSet for the destination.         |                                            | ✓        | ○        |
+| `destination.k8s.statefulset.name` | `string`   | The name of the Kubernetes StatefulSet for the destination.         |                                            | ✓        | ~        |
 | `destination.k8s.statefulset.uid`  | `string`   | The uid of the Kubernetes StatefulSet for the destination.          |                                            | ✓        | ○        |
-| `destination.k8s.daemonset.name`   | `string`   | The name of the Kubernetes DaemonSet for the destination.           |                                            | ✓        | ○        |
+| `destination.k8s.daemonset.name`   | `string`   | The name of the Kubernetes DaemonSet for the destination.           |                                            | ✓        | ~        |
 | `destination.k8s.daemonset.uid`    | `string`   | The uid of the Kubernetes DaemonSet for the destination.            |                                            | ✓        | ○        |
-| `destination.k8s.job.name`         | `string`   | The name of the Kubernetes Job for the destination.                 |                                            | ✓        | ○        |
+| `destination.k8s.job.name`         | `string`   | The name of the Kubernetes Job for the destination.                 |                                            | ✓        | ~        |
 | `destination.k8s.job.uid`          | `string`   | The uid of the Kubernetes Job for the destination.                  |                                            | ✓        | ○        |
-| `destination.k8s.cronjob.name`     | `string`   | The name of the Kubernetes CronJob for the destination.             |                                            | ✓        | ○        |
+| `destination.k8s.cronjob.name`     | `string`   | The name of the Kubernetes CronJob for the destination.             |                                            | ✓        | ~        |
 | `destination.k8s.cronjob.uid`      | `string`   | The uid of the Kubernetes CronJob for the destination.              |                                            | ✓        | ○        |
-| `destination.k8s.service.name`     | `string`   | The name of the Kubernetes Service for the destination.             |                                            | ✓        | ○        |
+| `destination.k8s.service.name`     | `string`   | The name of the Kubernetes Service for the destination.             |                                            | ✓        | ~        |
 | `destination.k8s.service.uid`      | `string`   | The uid of the Kubernetes Service for the destination.              |                                            | ✓        | ○        |
 | `network.policy.ingress`           | `string[]` | A list of network policy names affecting ingress traffic.           | This could be multiple policies.           | ✓        | ○        |
 | `network.policy.egress`            | `string[]` | A list of network policy names affecting egress traffic.            | This could be multiple policies.           | ✓        | ○        |
-| `process.executable.name`          | `string`   | The name of the binary associated with the socket for this flow.    | Provides application-level identification. | ✓        | ○        |
-| `container.image.name`             | `string`   | The name of the container image (e.g., `nginx:1.21`, `app:v1.0.0`). | Provides application-level identification. | ✓        | ○        |
-| `container.name`                   | `string`   | The name of the container instance.                                 | Provides application-level identification. | ✓        | ○        |
+| `process.executable.name`          | `string`   | The name of the binary associated with the socket for this flow.    | Provides application-level identification. | ✓        | ~        |
+| `process.pid`                      | `string`   | The pid of the process associated with the socket for this flow.    | Provides application-level identification. | ✓        | ~        |
+| `container.image.name`             | `string`   | The name of the container image (e.g., `nginx:1.21`, `app:v1.0.0`). | Provides application-level identification. | ✓        | ~        |
+| `container.name`                   | `string`   | The name of the container instance.                                 | Provides application-level identification. | ✓        | ~        |
 
 ---
 

--- a/mermin/src/metrics.rs
+++ b/mermin/src/metrics.rs
@@ -1,3 +1,4 @@
+pub mod cleanup;
 pub mod ebpf;
 pub mod error;
 pub mod export;

--- a/mermin/src/metrics/cleanup.rs
+++ b/mermin/src/metrics/cleanup.rs
@@ -1,0 +1,373 @@
+//! Metric cleanup tracker for managing stale metrics with configurable TTL.
+//!
+//! This module provides infrastructure to automatically clean up metrics for deleted resources
+//! (interfaces, K8s objects, tasks) after a configurable time-to-live period.
+//!
+//! ## Problem
+//!
+//! High-cardinality debug metrics (with per-interface, per-task labels) can cause unbounded
+//! memory growth in production environments when resources are frequently created and destroyed.
+//! Prometheus doesn't automatically remove metric series even when resources no longer exist.
+//!
+//! ## Solution
+//!
+//! The [`MetricCleanupTracker`] schedules cleanup of metrics after a resource is deleted,
+//! allowing a TTL grace period for resources that might come back (e.g., pod restarts).
+//!
+//! ## Usage
+//!
+//! - Only needed when `debug_metrics_enabled = true`
+//! - TTL = 0s: Immediate cleanup when resource deleted
+//! - TTL > 0s: Cleanup after grace period expires
+//! - Cleanup runs in background task spawned by main
+
+use std::{sync::Arc, time::Duration};
+
+use dashmap::DashMap;
+use tokio::time::Instant;
+use tracing::{debug, trace};
+
+use crate::metrics::registry;
+
+/// Tracks resources and schedules cleanup of their associated metrics after TTL expires.
+///
+/// When a resource is deleted (interface removed, K8s object deleted, task completed),
+/// this tracker schedules cleanup of the metrics. If TTL > 0, metrics persist for the TTL
+/// duration to handle brief resource downtimes. If TTL = 0, cleanup is immediate.
+///
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use mermin::metrics::cleanup::MetricCleanupTracker;
+///
+/// let tracker = MetricCleanupTracker::new(Duration::from_secs(300), true);
+///
+/// tracker.mark_interface_active("eth0");
+///
+/// tracker.schedule_interface_cleanup("eth0".to_string());
+/// ```
+#[derive(Clone)]
+pub struct MetricCleanupTracker {
+    /// Tracks when each interface was scheduled for cleanup
+    interface_metrics: Arc<DashMap<String, Instant>>,
+    /// Tracks when each K8s resource was scheduled for cleanup
+    k8s_resource_metrics: Arc<DashMap<String, Instant>>,
+    /// Tracks when each task was scheduled for cleanup
+    task_metrics: Arc<DashMap<String, Instant>>,
+    /// Time-to-live for metrics after resource deletion
+    ttl: Duration,
+    /// Whether debug metrics are enabled (cleanup only needed when debug metrics are registered)
+    debug_enabled: bool,
+}
+
+impl MetricCleanupTracker {
+    /// Create a new cleanup tracker.
+    pub fn new(ttl: Duration, debug_enabled: bool) -> Self {
+        Self {
+            interface_metrics: Arc::new(DashMap::new()),
+            k8s_resource_metrics: Arc::new(DashMap::new()),
+            task_metrics: Arc::new(DashMap::new()),
+            ttl,
+            debug_enabled,
+        }
+    }
+
+    /// Mark an interface as active (removes from cleanup schedule if present).
+    ///
+    /// Call this when an interface is created or used to prevent premature cleanup.
+    ///
+    /// # Note
+    ///
+    /// The internal `debug_enabled` check provides defense-in-depth: even if callers
+    /// mistakenly call this when debug metrics are disabled, it's a safe no-op.
+    pub fn mark_interface_active(&self, iface: &str) {
+        if self.debug_enabled {
+            self.interface_metrics.remove(iface);
+        }
+    }
+
+    /// Schedule cleanup for an interface's metrics.
+    ///
+    /// If TTL = 0, cleanup happens immediately. Otherwise, cleanup is scheduled
+    /// for TTL duration from now.
+    ///
+    /// # Note
+    ///
+    /// The internal `debug_enabled` check provides defense-in-depth: even if callers
+    /// mistakenly call this when debug metrics are disabled, it's a safe no-op.
+    pub fn schedule_interface_cleanup(&self, iface: String) {
+        if !self.debug_enabled {
+            return;
+        }
+
+        if self.ttl.is_zero() {
+            registry::remove_interface_metrics(&iface);
+        } else {
+            let cleanup_time = Instant::now() + self.ttl;
+            self.interface_metrics.insert(iface, cleanup_time);
+        }
+    }
+
+    /// Mark a K8s resource as active (removes from cleanup schedule if present).
+    #[allow(dead_code)]
+    pub fn mark_k8s_resource_active(&self, resource: &str) {
+        if self.debug_enabled {
+            self.k8s_resource_metrics.remove(resource);
+        }
+    }
+
+    /// Schedule cleanup for a K8s resource's metrics.
+    pub fn schedule_k8s_cleanup(&self, resource: String) {
+        if !self.debug_enabled {
+            return;
+        }
+
+        if self.ttl.is_zero() {
+            registry::remove_k8s_resource_metrics(&resource);
+        } else {
+            let cleanup_time = Instant::now() + self.ttl;
+            self.k8s_resource_metrics.insert(resource, cleanup_time);
+        }
+    }
+
+    /// Mark a task as active (removes from cleanup schedule if present).
+    #[allow(dead_code)]
+    pub fn mark_task_active(&self, task_name: &str) {
+        if self.debug_enabled {
+            self.task_metrics.remove(task_name);
+        }
+    }
+
+    /// Schedule cleanup for a task's metrics.
+    #[allow(dead_code)]
+    pub fn schedule_task_cleanup(&self, task_name: String) {
+        if !self.debug_enabled {
+            return;
+        }
+
+        if self.ttl.is_zero() {
+            registry::remove_task_metrics(&task_name);
+        } else {
+            let cleanup_time = Instant::now() + self.ttl;
+            self.task_metrics.insert(task_name, cleanup_time);
+        }
+    }
+
+    /// Run the background cleanup loop.
+    ///
+    /// Periodically scans for expired metrics and removes them.
+    /// Should be spawned as a background task.
+    ///
+    /// The loop will exit gracefully when receiving a shutdown signal.
+    pub async fn run_cleanup_loop(self, mut shutdown_rx: tokio::sync::broadcast::Receiver<()>) {
+        if !self.debug_enabled || self.ttl.is_zero() {
+            debug!(
+                event.name = "metrics.cleanup.loop_disabled",
+                debug_enabled = self.debug_enabled,
+                ttl_seconds = self.ttl.as_secs(),
+                "metric cleanup background loop not needed"
+            );
+            return;
+        }
+
+        // Check at least every 30 seconds, or every TTL/4 (whichever is longer)
+        // This ensures we don't check too frequently for very long TTLs,
+        // while still being responsive for short TTLs.
+        let check_interval = Duration::from_secs(30.max(self.ttl.as_secs() / 4));
+
+        // Invariant: check_interval is always >= 30 seconds
+        debug_assert!(
+            check_interval >= Duration::from_secs(30),
+            "check interval should be at least 30 seconds"
+        );
+
+        loop {
+            tokio::select! {
+                _ = tokio::time::sleep(check_interval) => {
+                    // Perform cleanup sweep
+                    let now = Instant::now();
+                    let mut cleaned_interfaces = 0;
+                    let mut cleaned_k8s = 0;
+                    let mut cleaned_tasks = 0;
+
+                    self.interface_metrics.retain(|iface, &mut cleanup_time| {
+                        if now >= cleanup_time {
+                            registry::remove_interface_metrics(iface);
+                            trace!(
+                                event.name = "metrics.cleanup.interface_expired",
+                                interface = %iface,
+                                "cleaned up expired interface metrics"
+                            );
+                            cleaned_interfaces += 1;
+                            false
+                        } else {
+                            true
+                        }
+                    });
+
+                    self.k8s_resource_metrics
+                        .retain(|resource, &mut cleanup_time| {
+                            if now >= cleanup_time {
+                                registry::remove_k8s_resource_metrics(resource);
+                                trace!(
+                                    event.name = "metrics.cleanup.k8s_resource_expired",
+                                    resource = %resource,
+                                    "cleaned up expired K8s resource metrics"
+                                );
+                                cleaned_k8s += 1;
+                                false
+                            } else {
+                                true
+                            }
+                        });
+
+                    self.task_metrics.retain(|task_name, &mut cleanup_time| {
+                        if now >= cleanup_time {
+                            registry::remove_task_metrics(task_name);
+                            trace!(
+                                event.name = "metrics.cleanup.task_expired",
+                                task_name = %task_name,
+                                "cleaned up expired task metrics"
+                            );
+                            cleaned_tasks += 1;
+                            false
+                        } else {
+                            true
+                        }
+                    });
+
+                    if cleaned_interfaces > 0 || cleaned_k8s > 0 || cleaned_tasks > 0 {
+                        trace!(
+                            event.name = "metrics.cleanup.sweep_completed",
+                            cleaned_interfaces,
+                            cleaned_k8s_resources = cleaned_k8s,
+                            cleaned_tasks,
+                            pending_interfaces = self.interface_metrics.len(),
+                            pending_k8s_resources = self.k8s_resource_metrics.len(),
+                            pending_tasks = self.task_metrics.len(),
+                            "metric cleanup sweep completed"
+                        );
+                    }
+                }
+                _ = shutdown_rx.recv() => {
+                    debug!(
+                        event.name = "metrics.cleanup.shutdown",
+                        pending_interfaces = self.interface_metrics.len(),
+                        pending_k8s_resources = self.k8s_resource_metrics.len(),
+                        pending_tasks = self.task_metrics.len(),
+                        "metric cleanup loop shutting down"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::time;
+
+    use super::*;
+
+    #[test]
+    fn test_cleanup_tracker_creation() {
+        let tracker = MetricCleanupTracker::new(Duration::from_secs(300), true);
+
+        // Verify tracker starts with empty state
+        assert_eq!(tracker.interface_metrics.len(), 0);
+        assert_eq!(tracker.k8s_resource_metrics.len(), 0);
+        assert_eq!(tracker.task_metrics.len(), 0);
+        assert_eq!(tracker.ttl, Duration::from_secs(300));
+        assert!(tracker.debug_enabled);
+    }
+
+    #[test]
+    fn test_cleanup_tracker_disabled_when_debug_off() {
+        let tracker = MetricCleanupTracker::new(Duration::from_secs(300), false);
+
+        // Schedule cleanups - should be no-ops when debug is disabled
+        tracker.schedule_interface_cleanup("eth0".to_string());
+        tracker.schedule_k8s_cleanup("Pod".to_string());
+        tracker.schedule_task_cleanup("test-task".to_string());
+
+        // Verify nothing was scheduled (no-op behavior)
+        assert_eq!(tracker.interface_metrics.len(), 0);
+        assert_eq!(tracker.k8s_resource_metrics.len(), 0);
+        assert_eq!(tracker.task_metrics.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_tracker_basic_flow() {
+        // Create tracker with 1 second TTL
+        let tracker = MetricCleanupTracker::new(Duration::from_secs(1), true);
+
+        // Schedule cleanup for an interface
+        tracker.schedule_interface_cleanup("test-iface".to_string());
+        assert_eq!(tracker.interface_metrics.len(), 1);
+        assert!(tracker.interface_metrics.contains_key("test-iface"));
+
+        // Mark the same interface as active (should remove from cleanup schedule)
+        tracker.mark_interface_active("test-iface");
+        assert_eq!(tracker.interface_metrics.len(), 0);
+
+        // Schedule again
+        tracker.schedule_interface_cleanup("test-iface".to_string());
+        assert_eq!(tracker.interface_metrics.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_immediate_cleanup_with_zero_ttl() {
+        let _ = crate::metrics::registry::init_registry(true);
+
+        // Create tracker with immediate cleanup (TTL=0)
+        let tracker = MetricCleanupTracker::new(Duration::ZERO, true);
+
+        // Schedule cleanup - should happen immediately (not scheduled for later)
+        tracker.schedule_interface_cleanup("immediate-cleanup-iface".to_string());
+        tracker.schedule_k8s_cleanup("immediate-cleanup-resource".to_string());
+        tracker.schedule_task_cleanup("immediate-cleanup-task".to_string());
+
+        // Verify nothing was scheduled (cleanup happened immediately)
+        assert_eq!(tracker.interface_metrics.len(), 0);
+        assert_eq!(tracker.k8s_resource_metrics.len(), 0);
+        assert_eq!(tracker.task_metrics.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_loop_shutdown() {
+        let tracker = MetricCleanupTracker::new(Duration::from_secs(60), true);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+
+        // Spawn cleanup loop
+        let handle = tokio::spawn(async move {
+            tracker.run_cleanup_loop(shutdown_rx).await;
+        });
+
+        // Give it a moment to start
+        time::sleep(Duration::from_millis(10)).await;
+
+        // Send shutdown signal
+        let _ = shutdown_tx.send(());
+
+        // Loop should exit gracefully
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("cleanup loop should exit within 1 second")
+            .expect("cleanup loop task should not panic");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_loop_disabled_with_zero_ttl() {
+        let tracker = MetricCleanupTracker::new(Duration::ZERO, true);
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::broadcast::channel(1);
+
+        // Should return immediately without looping
+        tracker.run_cleanup_loop(shutdown_rx).await;
+
+        // If we get here, the function returned immediately (good!)
+    }
+}

--- a/mermin/src/metrics/ebpf.rs
+++ b/mermin/src/metrics/ebpf.rs
@@ -5,19 +5,11 @@ use crate::metrics::registry;
 /// Increment the orphan cleanup counter.
 ///
 /// Call this when the orphan scanner successfully removes a stale entry.
-///
-/// ### Arguments:
-///
-/// - `count` - Number of orphaned entries cleaned up
 pub fn inc_orphans_cleaned(count: u64) {
-    registry::EBPF_ORPHANS_CLEANED.inc_by(count);
+    registry::EBPF_ORPHANS_CLEANED_TOTAL.inc_by(count);
 }
 
 /// Set the current number of entries in the eBPF map.
-///
-/// ### Arguments:
-///
-/// - `entries` - Current number of entries in the flow stats map
 pub fn set_map_entries(entries: u64) {
     registry::EBPF_MAP_ENTRIES
         .with_label_values(&["flow_stats"])
@@ -26,24 +18,32 @@ pub fn set_map_entries(entries: u64) {
 
 /// Increment the TC program attached counter.
 ///
-/// ### Arguments:
-///
-/// - `interface` - Network interface name
-/// - `direction` - Traffic direction ("ingress" or "egress")
+/// Always increments the aggregated counter. If debug metrics are enabled,
+/// also increments the per-interface debug counter.
 pub fn inc_tc_programs_attached(interface: &str, direction: &str) {
-    registry::TC_PROGRAMS_ATTACHED
-        .with_label_values(&[interface, direction])
-        .inc();
+    // Always increment aggregated metric
+    registry::TC_PROGRAMS_ATTACHED_TOTAL.inc();
+
+    // Conditionally increment debug metric with labels
+    if registry::debug_enabled() {
+        registry::TC_PROGRAMS_ATTACHED_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface, direction])
+            .inc();
+    }
 }
 
 /// Increment the TC program detached counter.
 ///
-/// ### Arguments:
-///
-/// - `interface` - Network interface name
-/// - `direction` - Traffic direction ("ingress" or "egress")
+/// Always increments the aggregated counter. If debug metrics are enabled,
+/// also increments the per-interface debug counter.
 pub fn inc_tc_programs_detached(interface: &str, direction: &str) {
-    registry::TC_PROGRAMS_DETACHED
-        .with_label_values(&[interface, direction])
-        .inc();
+    // Always increment aggregated metric
+    registry::TC_PROGRAMS_DETACHED_TOTAL.inc();
+
+    // Conditionally increment debug metric with labels
+    if registry::debug_enabled() {
+        registry::TC_PROGRAMS_DETACHED_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface, direction])
+            .inc();
+    }
 }

--- a/mermin/src/metrics/export.rs
+++ b/mermin/src/metrics/export.rs
@@ -35,7 +35,7 @@ pub fn inc_export_flow_spans(status: ExportStatus) {
 
 /// Record export operation latency.
 pub fn observe_export_latency(duration: Duration) {
-    registry::EXPORT_LATENCY.observe(duration.as_secs_f64());
+    registry::EXPORT_LATENCY_SECONDS.observe(duration.as_secs_f64());
 }
 
 /// Record export batch size.

--- a/mermin/src/metrics/flow.rs
+++ b/mermin/src/metrics/flow.rs
@@ -70,27 +70,60 @@ pub fn inc_flow_events(event_type: FlowEventResult) {
 }
 
 /// Increment the flow creation counter.
+///
+/// Always increments the aggregated counter. If debug metrics are enabled,
+/// also increments the per-interface debug counter.
 pub fn inc_flows_created(interface: &str) {
-    registry::FLOWS_CREATED
-        .with_label_values(&[interface])
-        .inc();
+    // Always increment aggregated metric
+    registry::FLOWS_CREATED_TOTAL.inc();
+
+    // Conditionally increment debug metric with labels
+    if registry::debug_enabled() {
+        registry::FLOWS_CREATED_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface])
+            .inc();
+    }
 }
 
 /// Increment the active flows gauge.
 pub fn inc_flows_active(interface: &str) {
-    registry::FLOWS_ACTIVE.with_label_values(&[interface]).inc();
+    // Always increment aggregated metric
+    registry::FLOWS_ACTIVE_TOTAL.inc();
+
+    // Conditionally increment debug metric with labels
+    if registry::debug_enabled() {
+        registry::FLOWS_ACTIVE_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface])
+            .inc();
+    }
 }
 
 /// Decrement the active flows gauge.
 pub fn dec_flows_active(interface: &str) {
-    registry::FLOWS_ACTIVE.with_label_values(&[interface]).dec();
+    // Always decrement aggregated metric
+    registry::FLOWS_ACTIVE_TOTAL.dec();
+
+    // Conditionally decrement debug metric with labels
+    if registry::debug_enabled() {
+        registry::FLOWS_ACTIVE_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface])
+            .dec();
+    }
 }
 
 /// Increment the producer flow spans counter.
 pub fn inc_producer_flow_spans(interface: &str, status: FlowSpanProducerStatus) {
+    // Always increment aggregated metric (by status only, no interface label)
     registry::PRODUCER_FLOW_SPANS_TOTAL
-        .with_label_values(&[interface, status.as_ref()])
+        .with_label_values(&[status.as_ref()])
         .inc();
+
+    // Conditionally increment debug metric with labels
+    if registry::debug_enabled() {
+        registry::PRODUCER_FLOW_SPANS_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface, status.as_ref()])
+            .inc();
+    }
 }
 
 /// Increment the flow stats map access counter.
@@ -107,11 +140,17 @@ pub fn inc_flow_stats_map_access(status: FlowStatsStatus) {
 /// - If direction = Ingress: forward packets came via ingress, reverse via egress
 /// - If direction = Egress: forward packets came via egress, reverse via ingress
 pub fn inc_packets_total(interface: &str, direction: Direction, count: u64) {
-    let direction_str = match direction {
-        Direction::Ingress => "ingress",
-        Direction::Egress => "egress",
-    };
-    registry::PACKETS_TOTAL
-        .with_label_values(&[interface, direction_str])
-        .inc_by(count);
+    // Always increment aggregated metric (no interface or direction labels)
+    registry::PACKETS_TOTAL.inc_by(count);
+
+    // Conditionally increment debug metric with labels
+    if registry::debug_enabled() {
+        let direction_str = match direction {
+            Direction::Ingress => "ingress",
+            Direction::Egress => "egress",
+        };
+        registry::PACKETS_BY_INTERFACE_TOTAL
+            .with_label_values(&[interface, direction_str])
+            .inc_by(count);
+    }
 }

--- a/mermin/src/metrics/opts.rs
+++ b/mermin/src/metrics/opts.rs
@@ -1,6 +1,8 @@
-use std::net::Ipv4Addr;
+use std::{net::Ipv4Addr, time::Duration};
 
 use serde::{Deserialize, Serialize};
+
+use crate::runtime::conf::conf_serde::duration;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MetricsOptions {
@@ -10,6 +12,15 @@ pub struct MetricsOptions {
     pub listen_address: String,
     /// The port the metrics server will listen on.
     pub port: u16,
+    /// Enable debug metrics with high-cardinality labels (per-interface, per-task, etc.).
+    /// WARNING: This will significantly increase memory usage. Do not use in production unless necessary.
+    pub debug_metrics_enabled: bool,
+    /// Time-to-live for stale metrics after resource deletion.
+    /// Examples: "5m", "300s", "1h"
+    /// 0s = immediate cleanup, >0s = cleanup after TTL expires.
+    /// Only applies when debug_metrics_enabled = true.
+    #[serde(with = "duration")]
+    pub stale_metric_ttl: Duration,
 }
 
 impl Default for MetricsOptions {
@@ -18,6 +29,8 @@ impl Default for MetricsOptions {
             enabled: true,
             listen_address: Ipv4Addr::UNSPECIFIED.to_string(),
             port: 10250,
+            debug_metrics_enabled: false,
+            stale_metric_ttl: Duration::from_secs(300),
         }
     }
 }

--- a/mermin/src/metrics/userspace.rs
+++ b/mermin/src/metrics/userspace.rs
@@ -56,33 +56,33 @@ impl AsRef<str> for ChannelSendStatus {
 
 /// Increment the ring buffer packets counter.
 pub fn inc_ringbuf_packets(packet_type: PacketType, count: u64) {
-    registry::USERSPACE_RINGBUF_PACKETS
+    registry::RINGBUF_PACKETS_TOTAL
         .with_label_values(&[packet_type.as_ref()])
         .inc_by(count);
 }
 
 /// Increment the ring buffer bytes counter.
 pub fn inc_ringbuf_bytes(bytes: u64) {
-    registry::USERSPACE_RINGBUF_BYTES.inc_by(bytes);
+    registry::RINGBUF_BYTES_TOTAL.inc_by(bytes);
 }
 
 /// Set the capacity of a channel.
 pub fn set_channel_capacity(channel: ChannelName, capacity: usize) {
-    registry::USERSPACE_CHANNEL_CAPACITY
+    registry::CHANNEL_CAPACITY
         .with_label_values(&[channel.as_ref()])
         .set(capacity as i64);
 }
 
 /// Set the current size of a channel.
 pub fn set_channel_size(channel: ChannelName, size: usize) {
-    registry::USERSPACE_CHANNEL_SIZE
+    registry::CHANNEL_SIZE
         .with_label_values(&[channel.as_ref()])
         .set(size as i64);
 }
 
 /// Increment the channel send operations counter.
 pub fn inc_channel_sends(channel: ChannelName, status: ChannelSendStatus) {
-    registry::USERSPACE_CHANNEL_SENDS
+    registry::CHANNEL_SENDS
         .with_label_values(&[channel.as_ref(), status.as_ref()])
         .inc();
 }

--- a/mermin/src/runtime/conf.rs
+++ b/mermin/src/runtime/conf.rs
@@ -653,7 +653,9 @@ impl From<figment::Error> for ConfError {
     }
 }
 
+/// Serde helper modules for configuration types.
 pub mod conf_serde {
+    /// Serde helpers for tracing::Level
     pub mod level {
         use serde::{self, Deserialize, Deserializer, Serializer};
         use tracing::Level;
@@ -673,6 +675,7 @@ pub mod conf_serde {
             s.parse::<Level>().map_err(serde::de::Error::custom)
         }
 
+        /// Serde helpers for Option<Level>
         pub mod option {
             use super::*;
 
@@ -699,6 +702,7 @@ pub mod conf_serde {
         }
     }
 
+    /// Serde helpers for humantime Duration (e.g., "5m", "30s", "1h")
     pub mod duration {
         use std::time::Duration;
 
@@ -720,6 +724,7 @@ pub mod conf_serde {
         }
     }
 
+    /// Serde helpers for StdoutFmt
     pub mod stdout_fmt {
         use serde::{Deserialize, Deserializer, Serializer};
 
@@ -757,6 +762,7 @@ pub mod conf_serde {
         }
     }
 
+    /// Serde helpers for ExporterProtocol
     pub mod exporter_protocol {
         use serde::{Deserialize, Deserializer, Serializer};
 
@@ -822,7 +828,7 @@ pub struct PipelineOptions {
     /// Pollers check for record intervals and timeouts at this frequency.
     /// Lower values = more responsive but higher CPU. Higher values = less overhead.
     /// At 10K flows/sec with 100K active flows and 32 pollers: ~600 checks/sec per poller.
-    #[serde(with = "conf_serde::duration")]
+    #[serde(with = "duration")]
     pub worker_poll_interval: Duration,
 
     /// Number of dedicated threads for K8s decorator (default: 4)

--- a/mermin/src/runtime/shutdown.rs
+++ b/mermin/src/runtime/shutdown.rs
@@ -5,7 +5,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     iface::{self, types::ControllerCommand},
-    metrics::registry::{FLOWS_LOST_SHUTDOWN, FLOWS_PRESERVED_SHUTDOWN},
+    metrics::registry::{FLOWS_LOST_SHUTDOWN_TOTAL, FLOWS_PRESERVED_SHUTDOWN_TOTAL},
     runtime::task_manager::{ShutdownResult, TaskManager},
     span::{
         producer::{FlowSpanComponents, timeout_and_remove_flow},
@@ -233,7 +233,7 @@ impl ShutdownManager {
                 .await
             {
                 Ok(preserved_count) => {
-                    FLOWS_PRESERVED_SHUTDOWN.inc_by(preserved_count as u64);
+                    FLOWS_PRESERVED_SHUTDOWN_TOTAL.inc_by(preserved_count as u64);
                     info!(
                         event.name = "application.shutdown.flows_preserved",
                         count = preserved_count,
@@ -241,7 +241,7 @@ impl ShutdownManager {
                     );
                 }
                 Err(lost_count) => {
-                    FLOWS_LOST_SHUTDOWN.inc_by(lost_count as u64);
+                    FLOWS_LOST_SHUTDOWN_TOTAL.inc_by(lost_count as u64);
                     warn!(
                         event.name = "application.shutdown.flows_lost",
                         count = lost_count,

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -404,7 +404,7 @@ impl FlowSpanProducer {
                     };
 
                     while let Some(item) = flow_events.next() {
-                        let timer = metrics::registry::PROCESSING_LATENCY
+                        let _timer = metrics::registry::PROCESSING_LATENCY_SECONDS
                             .with_label_values(&["flow_ingestion"])
                             .start_timer();
 
@@ -469,8 +469,6 @@ impl FlowSpanProducer {
                             // 2. Sampling (keep 1 in N flows during overload)
                             // 3. Protocol-based priority (TCP > UDP > ICMP)
                         }
-
-                        timer.observe_duration();
                     }
 
                     guard.clear_ready();


### PR DESCRIPTION
## Changes

Implements a tiered metrics system to prevent unbounded memory growth from high-cardinality Prometheus metrics in production environments. The system splits metrics into two tiers:

- **Standard metrics** (always enabled): Aggregated counters/gauges without per-resource labels (production-safe)
- **Debug metrics** (opt-in): High-cardinality metrics with per-interface, per-task, per-resource labels (debugging only)

### Key Components

1. **Metric Cleanup Tracker** (`metrics/cleanup.rs`):
   - Automatically removes stale metric series after configurable TTL
   - Prevents memory leaks when resources (interfaces, pods, tasks) are deleted
   - Graceful shutdown support via broadcast channel
   - Defense-in-depth with no-op when debug metrics disabled

2. **Registry Enhancements** (`metrics/registry.rs`):
   - Three-registry architecture: `REGISTRY` (combined), `STANDARD_REGISTRY`, `DEBUG_REGISTRY`
   - Global `debug_enabled()` flag using `OnceLock` for thread-safe access
   - Conditional metric registration based on debug mode
   - Idempotent initialization with error on conflicting reinitialization
   - Helper macros (`register_standard!`, `register_debug!`) for clean registration

3. **Configuration** (`metrics/opts.rs`):
   - `debug_metrics_enabled` flag (default: false)
   - `stale_metric_ttl` duration (default: 300s)
   - Strong warning in docs about memory impact

4. **Integration**:
   - IfaceController tracks interface lifecycle for metric cleanup
   - K8s Attributor tracks resource deletion for metric cleanup
   - TaskManager uses aggregated + debug metrics pattern
   - Background cleanup task spawned in main with shutdown handling

### Migration Path

All metrics follow a dual-recording pattern:
```rust
// Always increment aggregated metric (no labels)
registry::FLOWS_CREATED_TOTAL.inc();

// Conditionally increment debug metric (with labels)
if registry::debug_enabled() {
    registry::FLOWS_CREATED_BY_INTERFACE_TOTAL
        .with_label_values(&[interface])
        .inc();
}
```

This ensures:
- Zero performance impact when debug metrics disabled
- Backward compatibility (aggregated metrics always available)
- Opt-in debugging capability without production risk

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change (config change, but backward compatible with defaults)
- [ ] Documentation
- [ ] Other:

## Testing

**Manual Testing**:
- Verified metric cleanup tracker with TTL=0 (immediate cleanup)
- Verified metric cleanup tracker with TTL=300s (delayed cleanup)
- Tested shutdown signal handling for cleanup loop
- Confirmed debug metrics only registered when enabled
- Validated idempotent registry initialization

**Unit Tests Added**:
- `test_cleanup_tracker_creation()` - Verifies empty initial state
- `test_cleanup_tracker_disabled_when_debug_off()` - Confirms no-op behavior
- `test_cleanup_tracker_basic_flow()` - Tests schedule/unschedule lifecycle
- `test_immediate_cleanup_with_zero_ttl()` - Edge case for TTL=0
- `test_cleanup_loop_shutdown()` - Graceful shutdown handling
- `test_cleanup_loop_disabled_with_zero_ttl()` - Loop early return

**Test Coverage**:
```bash
cargo test --package mermin cleanup
cargo test --package mermin registry::tests
```

## Proof it works

### Memory Growth Prevention

**Before** (debug metrics always on):
- Memory grows unbounded as interfaces/pods churn
- 100+ interface changes → 200+ metric series (ingress/egress)
- Never cleaned up

**After** (debug metrics opt-in with cleanup):
- Production: Only aggregated metrics (constant cardinality)
- Debug mode: Stale metrics removed after TTL
- Memory usage remains bounded

### Configuration Example

```hcl
metrics {
  enabled = true

  # Production (default) - only aggregated metrics
  debug_metrics_enabled = false

  # Development/debugging - enable per-resource metrics
  # debug_metrics_enabled = true
  # stale_metric_ttl = "5m"
}
```

### Metric Examples

**Standard (always available)**:
```
mermin_flow_spans_created_total 15234
mermin_flow_spans_active_total 42
mermin_tasks_spawned_total 8
```

**Debug (only when enabled)**:
```
mermin_flow_spans_created_by_interface_total{interface="eth0"} 8532
mermin_flow_spans_created_by_interface_total{interface="eth1"} 6702
mermin_flow_spans_active_by_interface_total{interface="eth0"} 23
mermin_tasks_spawned_by_name_total{task_name="metrics-cleanup"} 1
```

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation (inline docs, examples)
- [x] My code follows the project's style (`cargo fmt` and `cargo clippy` clean)
- [x] All tests pass
- [x] Added comprehensive unit tests for new functionality
- [x] Added examples to public APIs
- [x] Documented error conditions and edge cases

## Notes

### Review Focus Areas

1. **Macro hygiene** in `register_standard!` / `register_debug!` - using `{{ }}` for proper expression blocks
2. **Shutdown handling** in cleanup loop - uses `tokio::select!` with broadcast channel
3. **OnceLock initialization** - now returns error on conflicting reinitialization attempts
4. **Defense-in-depth** - internal `debug_enabled` checks even though callers guard

### Breaking Changes

**Configuration Schema**:
- Added `debug_metrics_enabled: bool` (default: `false`)
- Added `stale_metric_ttl: duration` (default: `"300s"`)

Both have safe defaults, so existing configs continue to work unchanged.

### Memory Impact

With `debug_metrics_enabled = true` in a cluster with:
- 50 interfaces (100 series for ingress/egress packets)
- 100 pods (100 series for K8s watcher events by resource)
- 20 tasks (100 series for task lifecycle)

Estimated: **~300 additional metric series**

The cleanup tracker ensures these are bounded by TTL, preventing unbounded growth during resource churn.

### Performance

- **Disabled (default)**: Zero overhead, only aggregated metrics
- **Enabled**: Single `AtomicBool` check per metric recording (negligible)
- **Cleanup loop**: Runs every `max(30s, TTL/4)`, minimal CPU impact