### PR TITLE
feat: Add arbitrary env. var to mermin chart

### DIFF
--- a/charts/mermin/templates/daemonset.yaml
+++ b/charts/mermin/templates/daemonset.yaml
@@ -64,6 +64,11 @@ spec:
             {{- end }}
           {{- end }}
           env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
             - name: POD_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -74,13 +79,16 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.name
-            - name: POD_NAMESPACE
+            - name: POD_IP
               valueFrom:
                 fieldRef:
                   apiVersion: v1
-                  fieldPath: metadata.namespace
+                  fieldPath: status.podIP
             - name: MERMIN_PLATFORM
               value: "kubernetes"
+          {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:

--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -20,6 +20,21 @@ extraArgs: []
   # - "--foo"
   # - "bar"
 
+# Extra environment variables
+env: []
+  # - name: SOME_VAR
+  #   value: "SOME_VAL"
+  # - name: POD_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       apiVersion: v1
+  #       fieldPath: status.podIP
+  # - name: "SOME_VAL_FROM_CM"
+  #   valueFrom:
+  #     configMapKeyRef:
+  #       name: cm_name
+  #       key: cm_key
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Changes

Currently, there is no way to define additional env. vars. for the Mermin, it may be needed to define secrets from K8s secret.
The PR adds the ability to define arbitrary environment variables in values.

Fixes #(issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Locally with `make helm-template`

## Proof it works

N/A

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

<!-- Anything else reviewers should know? Areas where you'd like feedback? -->
