### PR TITLE
fix(config): filter.source.address.match/not_match should accept ip glob

### DIFF
--- a/mermin/src/filter/source.rs
+++ b/mermin/src/filter/source.rs
@@ -622,11 +622,12 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_parse_wildcards() {
         // "192.168.1.*" -> 192.168.1.0/24
-        // "10.*"       -> 10.0.0.0/8
+        // "10.*.*.*"       -> 10.0.0.0/8
         // "172.16.0.1" -> 172.16.0.1/32
-        let table = build_ip_network_table("192.168.1.*, 10.*, 172.16.0.1");
+        let table = build_ip_network_table("192.168.1.*, 10.*.*.*, 172.16.0.1");
 
         assert!(
             table


### PR DESCRIPTION
## Changes

Enables support for **bare IP addresses** and **IPv4 wildcard patterns** in the filter configuration `address` fields.

Previously, the filter configuration only accepted strict CIDR notation (e.g., `192.168.1.0/24`). This change improves usability by allowing users to:
1.  **Use single IPs:** `192.168.1.50` is now automatically converted to `192.168.1.50/32` (or `/128` for IPv6).
2.  **Use Wildcards:** `10.244.*.*` is now parsed and converted to the equivalent CIDR (`10.244.0.0/16`).

This logic is applied at initialization time, converting all formats into the internal `IpNetworkTable`, ensuring there is **no runtime performance penalty** compared to strict CIDR usage.

Fixes #ENG-355

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Other:

## Testing

Added a new unit test `test_parse_wildcards` in `src/filter/mod.rs` to verify the following scenarios:
- **Mixed Input:** Parsing a string containing CIDRs, bare IPs, and wildcards simultaneously.
- **IPv4 Wildcards:** Verifying `192.168.1.*` correctly matches IPs in that range.
- **Bare IPs:** Verifying explicit IPs match correctly.
- **IPv6 Safety:** Verifying that wildcard logic is skipped for IPv6 (to avoid ambiguity with `::`), while bare IPv6 addresses are still accepted.

## Proof it works
<img width="766" height="408" alt="Screenshot 2025-12-04 at 4 33 33 PM" src="https://github.com/user-attachments/assets/38a5ea8f-5094-45e5-b673-c58087053ebf" />
<img width="510" height="358" alt="Screenshot 2025-12-04 at 4 33 46 PM" src="https://github.com/user-attachments/assets/bf9fe318-268c-47bb-bd28-d6a174eb18c2" />


## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

- **IPv4 Wildcard Syntax:** The wildcard parser requires all 4 octets to be present or represented by a star.
    - ✅ `10.244.*.*` (valid, becomes `/16`)
    - ❌ `10.244.*` (invalid, missing octet)
- **IPv6:** Wildcards are intentionally disabled for IPv6 due to the ambiguity of the `::` compression syntax. IPv6 users should continue to use CIDR notation or bare IPs.