### PR TITLE
fix: Set Mermin resources requests/limits

### DIFF
--- a/charts/mermin/values.yaml
+++ b/charts/mermin/values.yaml
@@ -50,7 +50,7 @@ rbac:
   create: true
   existingClusterRoleName: ""
 
-# global common labels, applied to all ressources
+# global common labels, applied to all resources
 commonLabels: {}
 
 podAnnotations: {}
@@ -72,14 +72,14 @@ securityContext:
   runAsUser: 0
   runAsGroup: 0
 
-resources: {}
-  # TODO(mack#ENG-123|2025-09-29): Set default resources relative to the flows per second
-  # limits:
-  #   cpu: 200m
-  #   memory: 400Mi
-  # requests:
-  #   cpu:200m
-  #   memory: 400Mi
+# TODO(mack#ENG-123|2025-09-29): Set default resources relative to the flows per second
+resources:
+  limits:
+    cpu: 200m
+    memory: 220Mi
+  requests:
+    cpu: 200m
+    memory: 220Mi
 
 ports:
   - name: api


### PR DESCRIPTION
## Changes

Recent testing showed Mermin use ~150Mi in a small cluster. Although the 220Mi limit may not suit all kind of K8s clusters, it seems to be a good starting point.

Of course requests/limits should be changed for a particular use-case

Fixes #(issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Small GKE cluster

## Proof it works

<!-- Screenshots, logs, test output, or other evidence showing your changes work as expected -->

## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

<!-- Anything else reviewers should know? Areas where you'd like feedback? -->
