### PR TITLE
chore: update flow connection state key

### DIFF
--- a/mermin/src/span/flow.rs
+++ b/mermin/src/span/flow.rs
@@ -481,7 +481,7 @@ impl Traceable for FlowSpan {
         ));
         // Record optional fields only if they have values
         if let Some(ref value) = self.attributes.flow_connection_state {
-            kvs.push(KeyValue::new("flow.connection_state", value.as_str()));
+            kvs.push(KeyValue::new("flow.connection.state", value.as_str()));
         }
         if let Some(ref value) = self.attributes.flow_end_reason {
             kvs.push(KeyValue::new("flow.end_reason", value.as_str()));


### PR DESCRIPTION
## Changes

Small change to update the flow connection state value to match the OTLP notation.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [x] Other: chore

## Testing

- Manual testing

## Proof it works

<img width="1315" height="728" alt="Screenshot 2025-12-12 at 2 36 06 PM" src="https://github.com/user-attachments/assets/091aa5d1-3d6e-4e6a-960b-cb34b822096f" />

## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

