### PR TITLE
refactor: rename ring_buffer_capacity to base_capacity

### DIFF
--- a/charts/mermin/config/default/config.hcl
+++ b/charts/mermin/config/default/config.hcl
@@ -13,7 +13,7 @@ shutdown_timeout = "5s"
 # Pipeline performance and channel configuration options
 pipeline {
   ebpf_max_flows                    = 100000
-  ring_buffer_capacity              = 8192
+  base_capacity                     = 8192
   worker_count                      = 4
   worker_poll_interval              = "5s"
   k8s_decorator_threads             = 4

--- a/charts/mermin/config/default/config.yaml
+++ b/charts/mermin/config/default/config.yaml
@@ -399,7 +399,7 @@ metrics:
   listen_address: 0.0.0.0
   port: 10250
 pipeline:
-  ring_buffer_capacity: 8192
+  base_capacity: 8192
   worker_count: 4
   worker_poll_interval: 5s
   k8s_decorator_threads: 12

--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -151,7 +151,7 @@ auto_reload = false
 shutdown_timeout = "5s"
 
 pipeline {
-  ring_buffer_capacity = 8192
+  base_capacity = 8192
   worker_count = 4
 }
 ```

--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -404,7 +404,7 @@ log_level = "warn"  # Reduce logging overhead
 # Maximize capacity and worker parallelism for extreme scale
 pipeline {
   ebpf_max_flows = 1000000
-  ring_buffer_capacity = 16384
+  base_capacity = 16384
   worker_count = 16
   k8s_decorator_threads = 24
 }

--- a/docs/configuration/pipeline.md
+++ b/docs/configuration/pipeline.md
@@ -24,17 +24,26 @@ metrics {
 }
 ```
 
-### `ring_buffer_capacity`
+### `base_capacity`
 
 **Type:** Integer **Default:** `8192`
 
-The default capacity of the `FLOW_EVENTS` ring buffer. (Refer to the [architecture](../getting-started/architecture.md#ebpf-programs) documentation for more information.) Increasing this value can help process higher flow rates.
+The base capacity for **userspace channels** between pipeline stages (workers → K8s decorator → exporter). This value is used to calculate:
+
+- **Worker queue capacity**: `base_capacity / worker_count` (default: 8192 / 4 = 2048 per worker)
+- **Flow span channel**: `base_capacity × flow_span_channel_multiplier` (default: 8192 × 2.0 = 16,384)
+- **Decorated span channel**: `base_capacity × decorated_span_channel_multiplier` (default: 8192 × 4.0 = 32,768)
+- **Flow store initial capacity**: `base_capacity × 4` (default: 8192 × 4 = 32,768)
+
+Increasing this value provides larger buffers throughout the pipeline, reducing backpressure during traffic spikes.
+
+**Note:** This does NOT control the eBPF `FLOW_EVENTS` ring buffer size, which is hardcoded at compile time (256 KB, ~1,120 events).
 
 **Example:**
 
 ```hcl
 pipeline {
-  ring_buffer_capacity = 16384  # Increase buffer for high-throughput environments
+  base_capacity = 16384  # Increase userspace buffers for high-throughput environments
 }
 ```
 

--- a/docs/deployment/advanced-scenarios.md
+++ b/docs/deployment/advanced-scenarios.md
@@ -270,7 +270,7 @@ For environments with very high network traffic (> 10,000 flows/second), such as
 # Increase internal buffering and parallelism for extreme scale
 pipeline {
   ebpf_max_flows = 500000          # Support up to 50K flows/sec
-  ring_buffer_capacity = 8192
+  base_capacity = 8192
   worker_count = 8
   k8s_decorator_threads = 12
 }
@@ -343,7 +343,7 @@ For nodes with limited memory:
 ```hcl
 # Reduce buffer sizes for low-resource environments
 pipeline {
-  ring_buffer_capacity = 2048
+  base_capacity = 2048
   worker_count = 1
   k8s_decorator_threads = 2
 }
@@ -470,7 +470,7 @@ Key metrics:
 
 **If you see packet drops:**
 
-1. Increase `pipeline.ring_buffer_capacity`
+1. Increase `pipeline.base_capacity`
 2. Increase `pipeline.worker_count`
 3. Add more CPU resources
 4. Reduce monitored interfaces

--- a/docs/deployment/docker-bare-metal.md
+++ b/docs/deployment/docker-bare-metal.md
@@ -59,7 +59,7 @@ shutdown_timeout = "10s"
 
 # Pipeline configuration
 pipeline {
-  ring_buffer_capacity = 8192
+  base_capacity = 8192
   worker_count = 4
 }
 

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -108,7 +108,7 @@ Key metrics to monitor include:
 
 - **Interface Unavailable**: Mermin logs a warning and continues monitoring other interfaces
 - **eBPF Load Failure**: Agent fails to start; check kernel version and eBPF support
-- **High Packet Loss**: Increase `pipeline.ring_buffer_capacity` or reduce monitored interfaces -->
+- **High Packet Loss**: Increase `pipeline.base_capacity` or reduce monitored interfaces -->
 ### Test eBPF Capabilities
 
 Use the `diagnose bpf` subcommand to validate eBPF support and test attach/detach operations:

--- a/mermin-ebpf/src/main.rs
+++ b/mermin-ebpf/src/main.rs
@@ -134,7 +134,11 @@ const MAX_FLOWS: u32 = 10_000_000; // Upper bound, overridden at runtime
 #[map]
 static mut FLOW_STATS: HashMap<FlowKey, FlowStats> = HashMap::with_max_entries(MAX_FLOWS, 0);
 
-// Size: 256 KB (~10K flow events before overflow)
+// Size: 256 KB (~1,120 FlowEvent entries, each 234 bytes)
+// Provides buffering for new flow bursts while worker channels absorb backpressure.
+// In normal operation, ring buffer stays nearly empty due to event-driven polling.
+// When full, new flow events are dropped (flow still tracked in FLOW_STATS, but userspace
+// won't get initial packet data for deep inspection).
 #[cfg(not(feature = "test"))]
 const RING_BUF_SIZE_BYTES: u32 = 256 * 1024;
 

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -539,9 +539,9 @@ async fn run(cli: Cli) -> Result<()> {
         "ebpf programs attached and ready to process network traffic"
     );
 
-    let flow_span_capacity = (conf.pipeline.ring_buffer_capacity as f32
-        * conf.pipeline.flow_span_channel_multiplier) as usize;
-    let decorated_span_capacity = (conf.pipeline.ring_buffer_capacity as f32
+    let flow_span_capacity =
+        (conf.pipeline.base_capacity as f32 * conf.pipeline.flow_span_channel_multiplier) as usize;
+    let decorated_span_capacity = (conf.pipeline.base_capacity as f32
         * conf.pipeline.decorated_span_channel_multiplier)
         as usize;
 
@@ -567,7 +567,7 @@ async fn run(cli: Cli) -> Result<()> {
 
     let flow_span_producer = FlowSpanProducer::new(
         conf.clone().span,
-        conf.pipeline.ring_buffer_capacity,
+        conf.pipeline.base_capacity,
         conf.pipeline.worker_count,
         Arc::clone(&iface_map),
         flow_stats_map,

--- a/mermin/src/runtime/memory.rs
+++ b/mermin/src/runtime/memory.rs
@@ -137,12 +137,12 @@ pub mod initial_capacity {
     /// - 256 entries covers small-to-medium clusters
     pub const K8S_WATCHER_CACHE: usize = 256;
 
-    /// Calculate flow tracking capacity (FlowStore, TraceIdCache) based on ring buffer size.
+    /// Calculate flow tracking capacity (FlowStore, TraceIdCache) based on pipeline base capacity.
     ///
     /// Uses a 4x multiplier (vs legacy 128x) to balance memory efficiency with performance.
     ///
     /// Calculation rationale:
-    /// - Default ring buffer: 8,192 entries
+    /// - Default base_capacity: 8,192 entries
     /// - 4x multiplier → 32,768 capacity (~13 MB)
     /// - Covers 10K flows/sec without resize
     /// - For extreme traffic (100K flows/sec), will resize to 1M naturally
@@ -153,13 +153,13 @@ pub mod initial_capacity {
     /// ```
     /// use mermin::runtime::memory::initial_capacity;
     ///
-    /// let capacity = initial_capacity::from_ring_buffer_size(8_192);
+    /// let capacity = initial_capacity::from_base_capacity(8_192);
     /// assert_eq!(capacity, 32_768);
     /// ```
-    pub const fn from_ring_buffer_size(ring_buffer_capacity: usize) -> usize {
+    pub const fn from_base_capacity(base_capacity: usize) -> usize {
         // Use 4x multiplier instead of 128x
         // Provides reasonable headroom without massive over-allocation
-        ring_buffer_capacity * 4
+        base_capacity * 4
     }
 }
 

--- a/mermin/tests/e2e/grafana/config/mermin.hcl
+++ b/mermin/tests/e2e/grafana/config/mermin.hcl
@@ -5,7 +5,7 @@ auto_reload = false
 # Pipeline configuration (using defaults optimized for typical enterprise)
 pipeline {
   ebpf_max_flows        = 100000
-  ring_buffer_capacity  = 8192
+  base_capacity          = 8192
   worker_count          = 4
   worker_poll_interval  = "5s"
   k8s_decorator_threads = 4


### PR DESCRIPTION
## Changes

Breaking change: Rename `pipeline.ring_buffer_capacity` to `pipeline.base_capacity` to eliminate confusion with the eBPF FLOW_EVENTS ring buffer. The config field controls userspace pipeline channel sizing, not the eBPF ring buffer.

- Fix misleading eBPF ring buffer comment (was "~10K", actually ~1,120 events)
- Rename config field to `base_capacity` to avoid stutter in `pipeline.base_capacity`
- Update all documentation to clarify this field sizes userspace channels:
  - Worker queues: base_capacity / worker_count
  - Flow span channel: base_capacity × flow_span_channel_multiplier
  - Decorated span channel: base_capacity × decorated_span_channel_multiplier
  - Flow store initial capacity: base_capacity × 4
- Clarify eBPF FLOW_EVENTS ring buffer is hardcoded at 256 KB (~1,120 events)
- Update all config examples (HCL, YAML) and tests

Fixes #(issue)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Other: