### PR TITLE
feat: add bytesize dependency and enhance ebpf ring buffer configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "camino"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2013,7 @@ dependencies = [
  "aya-build",
  "aya-log",
  "base64 0.21.7",
+ "bytesize",
  "chrono",
  "clap",
  "common-build",

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -19,6 +19,7 @@ axum = "0.7"
 aya = { workspace = true, features = ["async_tokio"] }
 aya-log = { workspace = true }
 base64 = "0.21"
+bytesize = "1.3"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { workspace = true, features = ["derive", "env", "help", "suggestions", "usage"] }
 crossbeam = "0.8"

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -332,6 +332,7 @@ async fn run(cli: Cli) -> Result<()> {
     let mut ebpf = EbpfLoader::new()
         .map_pin_path(&map_pin_path)
         .set_max_entries("FLOW_STATS", conf.pipeline.ebpf_max_flows)
+        .set_max_entries("FLOW_EVENTS", conf.pipeline.ebpf_ring_buffer_size_bytes)
         .load(aya::include_bytes_aligned!(concat!(
             env!("OUT_DIR"),
             "/mermin"


### PR DESCRIPTION
## Changes
- Added `bytesize` crate to manage byte size configurations.
- Introduced serialization and deserialization helpers for `bytesize` in the configuration module.
- Updated `PipelineOptions` to include a new field for eBPF ring buffer size, allowing for flexible configuration of buffer sizes in bytes.
- Enhanced documentation for the eBPF ring buffer size, including sizing guidelines and performance considerations.

### Type of change
- [x] New feature
- [x] Documentation
- [ ] Breaking change
- [ ] Bug fix
- [ ] Refactor
- [ ] Other: