### PR TITLE
feat: add docker hub as an upload target for mermin docker images

### DIFF
--- a/.github/workflows/release_mermin.yaml
+++ b/.github/workflows/release_mermin.yaml
@@ -188,7 +188,7 @@ jobs:
           cache_from: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }}
           cache_to: type=registry,ref=us-docker.pkg.dev/pub-artifacts-j8rjbu/docker-cache/mermin-${{ matrix.target }},mode=max
           registry_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          registry_password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry_password: ${{ secrets.DOCKERHUB_API_TOKEN }}
 
   release_chart:
     name: Release Chart


### PR DESCRIPTION
## Changes

Add docker.io as a build/push target, in addition to ghcr.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

n/a

## Proof it works

This may need another secondary pr if the upload fails. There's not really a way to prove it works other than running the ci stage. The same format has been used for other projects, though.

## Checklist

- [ ] I've tested my changes
- [ ] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [ ] All tests pass
