### PR TITLE
docs: add primer and spec to sidenav

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,6 +11,11 @@
 * [Architecture](getting-started/architecture.md)
 * [Security Considerations](getting-started/security-considerations.md)
 
+## Flow Trace Specification
+
+* [Primer](semconv/primer.md)
+* [Semantic Conventions](semconv/spec.md)
+
 ## Deployment
 
 * [Deployment Overview](deployment/deployment.md)


### PR DESCRIPTION
## Changes

Adds the flow trace primer and semantic convention spec to the docs sidenav.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] Other: