### PR TITLE
CI/CD Docker Hub login

### DIFF
--- a/.github/workflows/release_mermin.yml
+++ b/.github/workflows/release_mermin.yml
@@ -163,11 +163,6 @@ jobs:
           registry: us-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcr_auth.outputs.access_token }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Build docker image
         uses: elastiflow/gha-reusable/actions/docker-build-push@v0
         with:


### PR DESCRIPTION
## Changes

Removed a redundant Docker Hub login step from the `release_mermin.yml` GitHub Actions workflow. The `elastiflow/gha-reusable/actions/docker-build-push@v0` reusable action already handles Docker Hub authentication when `registry_username` and `registry_password` are provided.

Fixes #LGO-438

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Other:

## Testing

The change removes a redundant step; the expectation is that the `docker-build-push` reusable action continues to handle Docker Hub authentication as designed. The workflow should be run to confirm successful image builds and pushes to Docker Hub.

## Proof it works

The change is a removal of a redundant login step. The workflow is expected to function identically due to the reusable action's built-in login capability.

## Checklist

- [ ] I've tested my changes
- [ ] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [ ] All tests pass

## Notes

The explicit `Login to Docker Hub` step was redundant because the `elastiflow/gha-reusable/actions/docker-build-push@v0` action, used later in the workflow, already performs the necessary login when `registry_username` and `registry_password` inputs are supplied. This refactor simplifies the workflow without impacting functionality.

---
Linear Issue: [LGO-438](https://linear.app/elastiflow/issue/LGO-438/deploy-mermin-to-docker-hub)

<a href="https://cursor.com/background-agent?bcId=bc-b0b8b944-2fbc-4def-a913-3b24a1867715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0b8b944-2fbc-4def-a913-3b24a1867715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

