### PR TITLE
feat: add direction-aware container attributes with port-based resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,7 +2066,6 @@ dependencies = [
  "aya-log",
  "base64 0.21.7",
  "bytesize",
- "chrono",
  "clap",
  "common-build",
  "crossbeam",
@@ -2096,7 +2095,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-sys",
  "network-types",
- "nix 0.30.1",
+ "nix",
  "num-iter",
  "num-traits",
  "opentelemetry",
@@ -2105,9 +2104,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pnet",
  "prometheus",
- "regex",
  "reqwest",
- "rtnetlink",
  "rustls",
  "rustls-native-certs 0.8.2",
  "rustls-pemfile",
@@ -2119,7 +2116,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
- "tokio-stream",
  "tonic",
  "tower-http 0.5.2",
  "tracing",
@@ -2228,47 +2224,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-proto"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
-dependencies = [
- "bytes",
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-sys",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "netlink-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
- "futures",
  "libc",
  "log",
- "tokio",
 ]
 
 [[package]]
 name = "network-types"
 version = "0.1.0"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "nix"
@@ -3088,23 +3056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtnetlink"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08fd15aa4c64c34d0b3178e45ec6dad313a9f02b193376d501668a7950264bb7"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route",
- "netlink-proto",
- "netlink-sys",
- "nix 0.29.0",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3757,7 +3708,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/docs/spec/semantic-conventions.md
+++ b/docs/spec/semantic-conventions.md
@@ -107,7 +107,7 @@ The following tables detail the proposed attributes for the flow span.
 The following symbols are used in the "Required" column to indicate [OpenTelemetry attribute requirement levels](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/):
 
 | Symbol | Requirement Level      | Description                                                      |
-| ------ | ---------------------- | ---------------------------------------------------------------- |
+|--------|------------------------|------------------------------------------------------------------|
 | ✓      | Required               | All instrumentations MUST populate the attribute                 |
 | ?      | Conditionally Required | MUST populate when the specified condition is satisfied          |
 | \~     | Recommended            | SHOULD add by default if readily available and efficient         |
@@ -118,7 +118,7 @@ The following symbols are used in the "Required" column to indicate [OpenTelemet
 > Note on Timestamps: The span's standard `start_time_unix_nano` and `end_time_unix_nano` fields are used to mark the beginning and end of the flow span's observation window. These are analogous to the `flowStart*` and `flowEnd*` fields in IPFIX records and are not duplicated as attributes.
 
 | Proposed Field Name     | Data Type | Description                                                                               | Notes / Decisions                                                                                                                                        | Std OTel | Required   |
-| ----------------------- | --------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ---------- |
+|-------------------------|-----------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------|------------|
 | `flow.community_id`     | `string`  | The Community ID hash of the flow's five-tuple.                                           | A common way to identify a network flow across different monitoring points.                                                                              |          | ✓          |
 | `flow.direction`        | `string`  | The inferred direction of the flow from the observer's perspective.                       | One of: `forward`, `reverse`, or `unknown`. Mirrors IPFIX biflow concepts. See [Flow Direction](semantic-conventions.md#flow-direction) for details.     |          | ✓          |
 | `flow.connection.state` | `string`  | The state of the connection (e.g., TCP state) at the time the flow was generated.         | For TCP, this would be one of the standard states like `established`, `time_wait`, etc. Similar to network.connection.state but from a flow perspective. |          | ? TCP only |
@@ -127,7 +127,7 @@ The following symbols are used in the "Required" column to indicate [OpenTelemet
 ### L2-L4 Attributes
 
 | Proposed Field Name           | Data Type  | Description                                                                             | Notes / Decisions                                                      | Std OTel | Required          |
-| ----------------------------- | ---------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------- | ----------------- |
+|-------------------------------|------------|-----------------------------------------------------------------------------------------|------------------------------------------------------------------------|----------|-------------------|
 | `source.address`              | `string`   | Source IP address.                                                                      |                                                                        | ✓        | ✓                 |
 | `source.port`                 | `long`     | Source port number.                                                                     |                                                                        | ✓        | ✓                 |
 | `destination.address`         | `string`   | Destination IP address.                                                                 |                                                                        | ✓        | ✓                 |
@@ -169,7 +169,7 @@ The following symbols are used in the "Required" column to indicate [OpenTelemet
 ### Flow Metrics
 
 | Proposed Field Name          | Data Type | Description                                                               | Notes / Decisions                                        | Std OTel | Required |
-| ---------------------------- | --------- | ------------------------------------------------------------------------- | -------------------------------------------------------- | -------- | -------- |
+|------------------------------|-----------|---------------------------------------------------------------------------|----------------------------------------------------------|----------|----------|
 | `flow.bytes.delta`           | `long`    | Number of bytes observed in the last measurement interval for the flow.   |                                                          |          | ✓        |
 | `flow.bytes.total`           | `long`    | Total number of bytes observed for this flow since its start.             | The term `bytes` is preferred over `octets` for clarity. |          | \~       |
 | `flow.packets.delta`         | `long`    | Number of packets observed in the last measurement interval for the flow. |                                                          |          | ✓        |
@@ -184,7 +184,7 @@ The following symbols are used in the "Required" column to indicate [OpenTelemet
 Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 
 | Proposed Field Name          | Data Type | Description                                                                                                                    | Notes / Decisions | Std OTel | Required |
-| ---------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ | ----------------- | -------- | -------- |
+|------------------------------|-----------|--------------------------------------------------------------------------------------------------------------------------------|-------------------|----------|----------|
 | `flow.tcp.handshake.latency` | `long`    | The latency of the first part of the TCP handshake (SYN to SYN/ACK), from the **client's perspective**. (Server network delay) | Unit: `ns`.       |          | \~       |
 | `flow.tcp.svc.latency`       | `long`    | The application/service processing time, as measured on the **server side**.                                                   | Unit: `ns`.       |          | \~       |
 | `flow.tcp.svc.jitter`        | `long`    | The jitter of the application/service processing time, as measured on the **server side**.                                     | Unit: `ns`.       |          | \~       |
@@ -194,7 +194,7 @@ Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 ### Tunnel & Ip-in-Ip & IPSec Attributes
 
 | Proposed Field Name            | Data Type | Description                                                                 | Notes / Decisions                                        | Std OTel | Required           |
-| ------------------------------ | --------- | --------------------------------------------------------------------------- | -------------------------------------------------------- | -------- | ------------------ |
+|--------------------------------|-----------|-----------------------------------------------------------------------------|----------------------------------------------------------|----------|--------------------|
 | `flow.ipsec.ah.spi`            | `long`    | Security Parameters Index for AH headers.                                   | SPI from the outermost header (after a tunnel)           |          | ○                  |
 | `flow.ipsec.esp.spi`           | `long`    | Security Parameters Index for ESP headers.                                  | SPI from the outermost header (after a tunnel)           |          | ○                  |
 | `flow.ipsec.sender_index`      | `long`    | The sender index from a WireGuard header.                                   |                                                          |          | ○                  |
@@ -228,7 +228,7 @@ Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 > **Note:** These attributes use `source.k8s.*` / `destination.k8s.*` prefixes rather than standard OTel `k8s.*` attributes. See [Why `source.k8s.*` Instead of `k8s.source.*`?](semantic-conventions.md#why-sourcek8s-instead-of-k8ssource) for the rationale.
 
 | Proposed Field Name                             | Data Type | Description                                                 | Notes / Decisions | Std OTel  | Required |
-| ----------------------------------------------- | --------- | ----------------------------------------------------------- | ----------------- | --------- | -------- |
+|-------------------------------------------------|-----------|-------------------------------------------------------------|-------------------|-----------|----------|
 | `source.k8s.cluster.name`                       | `string`  | The name of the Kubernetes cluster for the source.          |                   | partially | \~       |
 | `source.k8s.cluster.uid`                        | `string`  | The UID of the Kubernetes cluster for the source.           |                   | partially | ○        |
 | `source.k8s.node.name`                          | `string`  | The name of the Kubernetes Node for the source.             |                   | partially | \~       |
@@ -238,7 +238,7 @@ Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 | `source.k8s.pod.name`                           | `string`  | The name of the Kubernetes Pod for the source.              |                   | partially | \~       |
 | `source.k8s.pod.uid`                            | `string`  | The UID of the Kubernetes Pod for the source.               |                   | partially | ○        |
 | `source.k8s.pod.annotations.<key>`              | `string`  | Dynamic annotations from the source Pod.                    | Flattened map.    | partially | ○        |
-| `source.k8s.container.name`                     | `string`  | The name of the Kubernetes Container for the source.        |                   | partially | \~       |
+| `source.k8s.container.name`                     | `string`  | The name of the Container from Pod specification.           |                   | partially | \~       |
 | `source.k8s.deployment.name`                    | `string`  | The name of the Kubernetes Deployment for the source.       |                   | partially | \~       |
 | `source.k8s.deployment.uid`                     | `string`  | The UID of the Kubernetes Deployment for the source.        |                   | partially | ○        |
 | `source.k8s.deployment.annotations.<key>`       | `string`  | Dynamic annotations from the source Deployment.             | Flattened map.    | partially | ○        |
@@ -269,7 +269,7 @@ Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 | `destination.k8s.pod.name`                      | `string`  | The name of the Kubernetes Pod for the destination.         |                   | partially | \~       |
 | `destination.k8s.pod.uid`                       | `string`  | The UID of the Kubernetes Pod for the destination.          |                   | partially | ○        |
 | `destination.k8s.pod.annotations.<key>`         | `string`  | Dynamic annotations from the destination Pod.               | Flattened map.    | partially | ○        |
-| `destination.k8s.container.name`                | `string`  | The name of the Kubernetes Container for the destination.   |                   | partially | \~       |
+| `destination.k8s.container.name`                | `string`  | The name of the Container from Pod specification.           |                   | partially | \~       |
 | `destination.k8s.deployment.name`               | `string`  | The name of the Kubernetes Deployment for the destination.  |                   | partially | \~       |
 | `destination.k8s.deployment.uid`                | `string`  | The UID of the Kubernetes Deployment for the destination.   |                   | partially | ○        |
 | `destination.k8s.deployment.annotations.<key>`  | `string`  | Dynamic annotations from the destination Deployment.        | Flattened map.    | partially | ○        |
@@ -295,18 +295,20 @@ Time-based metrics calculated for the flow, stored in nanoseconds (`ns`).
 ### Network Policy Attributes
 
 | Proposed Field Name      | Data Type  | Description                                               | Notes / Decisions                | Std OTel | Required |
-| ------------------------ | ---------- | --------------------------------------------------------- | -------------------------------- | -------- | -------- |
+|--------------------------|------------|-----------------------------------------------------------|----------------------------------|----------|----------|
 | `network.policy.ingress` | `string[]` | A list of network policy names affecting ingress traffic. | This could be multiple policies. |          | ○        |
 | `network.policy.egress`  | `string[]` | A list of network policy names affecting egress traffic.  | This could be multiple policies. |          | ○        |
 
 ### Process & Container Attributes
 
-| Proposed Field Name       | Data Type | Description                                                         | Notes / Decisions                          | Std OTel | Required |
-| ------------------------- | --------- | ------------------------------------------------------------------- | ------------------------------------------ | -------- | -------- |
-| `process.executable.name` | `string`  | The name of the binary associated with the socket for this flow.    | Provides application-level identification. | ✓        | \~       |
-| `process.pid`             | `long`    | The PID of the process associated with the socket for this flow.    | Provides application-level identification. | ✓        | \~       |
-| `container.image.name`    | `string`  | The name of the container image (e.g., `nginx:1.21`, `app:v1.0.0`). | Provides application-level identification. | ✓        | \~       |
-| `container.name`          | `string`  | The name of the container instance.                                 | Provides application-level identification. | ✓        | \~       |
+| Proposed Field Name                | Data Type | Description                                                               | Notes / Decisions                               | Std OTel | Required |
+|------------------------------------|-----------|---------------------------------------------------------------------------|-------------------------------------------------|----------|----------|
+| `process.executable.name`          | `string`  | The name of the binary associated with the socket for this flow.          | Provides application-level identification.      | ✓        | \~       |
+| `process.pid`                      | `long`    | The PID of the process associated with the socket for this flow.          | Provides application-level identification.      | ✓        | \~       |
+| `source.container.name`            | `string`  | The container runtime name for the source (e.g., from Docker/containerd). | Distinct from `source.k8s.container.name`.      | ✓        | \~       |
+| `source.container.image.name`      | `string`  | The image name of the source container (e.g., `nginx:1.21`).              | From K8s Pod spec container image.              |          | \~       |
+| `destination.container.name`       | `string`  | The container runtime name for the destination.                           | Distinct from `destination.k8s.container.name`. | ✓        | \~       |
+| `destination.container.image.name` | `string`  | The image name of the destination container (e.g., `app:v1.0.0`).         | From K8s Pod spec container image.              |          | \~       |
 
 ***
 

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -20,7 +20,6 @@ aya = { workspace = true, features = ["async_tokio"] }
 aya-log = { workspace = true }
 base64 = "0.21"
 bytesize = "1.3"
-chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { workspace = true, features = ["derive", "env", "help", "suggestions", "usage"] }
 crossbeam = "0.8"
 dashmap = "6.0"
@@ -57,9 +56,7 @@ opentelemetry-stdout = "0.31.0"
 opentelemetry_sdk = { version = "0.31.0", features = ["experimental_async_runtime", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
 pnet = "0.34"
 prometheus = "0.13"
-regex = "1"
 reqwest = {  version = "0.12.26"}
-rtnetlink = "0.18.1"
 rustls = "0.23"
 rustls-native-certs = "0.8"
 rustls-pemfile = "2.2"
@@ -76,7 +73,6 @@ tokio = { workspace = true, features = [
     "signal",
     "time"
 ] }
-tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { version = "0.14.2", features = ["transport"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = { version = "0.1.41" }

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -350,7 +350,7 @@ async fn run(cli: Cli) -> Result<()> {
         event.name = "ebpf.loaded",
         map.pin_path = %map_pin_path,
         map.schema_version = EBPF_MAP_SCHEMA_VERSION,
-        "eBPF program loaded, maps will persist with versioned pinning"
+        "ebpf program loaded, maps will persist with versioned pinning"
     );
 
     if let Err(e) = aya_log::EbpfLogger::init(&mut ebpf) {
@@ -358,7 +358,7 @@ async fn run(cli: Cli) -> Result<()> {
         warn!(
             event.name = "ebpf.logger_init_failed",
             error.message = %e,
-            "failed to initialize eBPF logger"
+            "failed to initialize ebpf logger"
         );
     }
 
@@ -423,7 +423,7 @@ async fn run(cli: Cli) -> Result<()> {
             None => {
                 error!(
                     event.name = "ebpf.unexpected_error",
-                    "no ebpf maps found in loaded program, cannot test /sys/fs/bpf writability - this is unexpected and indicates a problem with the eBPF program."
+                    "no ebpf maps found in loaded program, cannot test /sys/fs/bpf writability - this is unexpected and indicates a problem with the ebpf program."
                 );
                 false
             }
@@ -435,7 +435,7 @@ async fn run(cli: Cli) -> Result<()> {
         info!(
             event.name = "ebpf.bpf_fs_check_complete",
             bpf_fs_writable = bpf_fs_writable,
-            "checked /sys/fs/bpf writability for TCX link pinning"
+            "checked /sys/fs/bpf writability for tcx link pinning"
         );
     }
 
@@ -476,7 +476,7 @@ async fn run(cli: Cli) -> Result<()> {
     info!(
         event.name = "ebpf.maps_ready",
         schema_version = EBPF_MAP_SCHEMA_VERSION,
-        "eBPF maps ready for flow producer"
+        "ebpf maps ready for flow producer"
     );
 
     let attach_method = if use_tcx { "TCX" } else { "netlink" };
@@ -486,11 +486,11 @@ async fn run(cli: Cli) -> Result<()> {
         ebpf.attach.priority = conf.discovery.instrument.tc_priority,
         ebpf.attach.tcx_order = %conf.discovery.instrument.tcx_order,
         system.kernel.version = %kernel_version,
-        "determined TC attachment method and priority"
+        "determined tc attachment method and priority"
     );
     info!(
         event.name = "ebpf.ready_for_controller",
-        "eBPF programs ready to move to controller thread"
+        "ebpf programs ready to move to controller thread"
     );
 
     let patterns = if conf.discovery.instrument.interfaces.is_empty() {
@@ -600,7 +600,7 @@ async fn run(cli: Cli) -> Result<()> {
     info!(
         event.name = "listening_ports.scan_complete",
         total_ports = scanned_ports,
-        "populated eBPF map with existing listening ports"
+        "populated ebpf map with existing listening ports"
     );
 
     let flow_span_producer = FlowSpanProducer::new(
@@ -872,7 +872,7 @@ async fn run(cli: Cli) -> Result<()> {
 
         match shutdown_exporter_gracefully(Arc::clone(&exporter), Duration::from_secs(5)).await {
             Ok(()) => {
-                info!(event.name = "exporter.otlp_shutdown_success", "OpenTelemetry provider shut down cleanly");
+                info!(event.name = "exporter.otlp_shutdown_success", "opentelemetry provider shut down cleanly");
             }
             Err(e) => {
                 let event_name = match &e {
@@ -881,7 +881,7 @@ async fn run(cli: Cli) -> Result<()> {
                     MerminError::Internal(msg) if msg.contains("panicked") => "exporter.otlp_shutdown_panic",
                     _ => "exporter.otlp_shutdown_error",
                 };
-                warn!(event.name = event_name, error.message = %e, "OpenTelemetry provider shutdown failed");
+                warn!(event.name = event_name, error.message = %e, "opentelemetry provider shutdown failed");
             }
         }
 

--- a/mermin/src/span/flow.rs
+++ b/mermin/src/span/flow.rs
@@ -274,8 +274,14 @@ pub struct SpanAttributes {
     pub network_policies_ingress: Option<Vec<String>>,
     pub network_policies_egress: Option<Vec<String>>,
     pub process_executable_name: Option<String>,
-    pub container_image_name: Option<String>,
-    pub container_name: Option<String>,
+    /// Container runtime name for source (e.g., from Docker/containerd).
+    /// Distinct from source_k8s_container_name which comes from Pod spec.
+    pub source_container_name: Option<String>,
+    pub source_container_image_name: Option<String>,
+    /// Container runtime name for destination (e.g., from Docker/containerd).
+    /// Distinct from destination_k8s_container_name which comes from Pod spec.
+    pub destination_container_name: Option<String>,
+    pub destination_container_image_name: Option<String>,
 }
 
 impl Default for SpanAttributes {
@@ -417,8 +423,10 @@ impl Default for SpanAttributes {
             network_policies_ingress: None,
             network_policies_egress: None,
             process_executable_name: None,
-            container_image_name: None,
-            container_name: None,
+            source_container_name: None,
+            source_container_image_name: None,
+            destination_container_name: None,
+            destination_container_image_name: None,
         }
     }
 }
@@ -975,11 +983,26 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.process_executable_name {
             kvs.push(KeyValue::new("process.executable.name", value.to_owned()));
         }
-        if let Some(ref value) = self.attributes.container_image_name {
-            kvs.push(KeyValue::new("container.image.name", value.to_string()));
+        if let Some(ref value) = self.attributes.source_container_name {
+            kvs.push(KeyValue::new("source.container.name", value.to_owned()));
         }
-        if let Some(ref value) = self.attributes.container_name {
-            kvs.push(KeyValue::new("container.name", value.to_owned()));
+        if let Some(ref value) = self.attributes.source_container_image_name {
+            kvs.push(KeyValue::new(
+                "source.container.image.name",
+                value.to_owned(),
+            ));
+        }
+        if let Some(ref value) = self.attributes.destination_container_name {
+            kvs.push(KeyValue::new(
+                "destination.container.name",
+                value.to_owned(),
+            ));
+        }
+        if let Some(ref value) = self.attributes.destination_container_image_name {
+            kvs.push(KeyValue::new(
+                "destination.container.image.name",
+                value.to_owned(),
+            ));
         }
         span.set_attributes(kvs);
         span


### PR DESCRIPTION
## Changes

Adds direction-aware container attributes (`source.container.*` / `destination.container.*`) with intelligent port-based container resolution. When a Pod has multiple containers, the decorator now matches the container by its declared `containerPort` to correctly attribute traffic to the right container.

**Key changes:**
- New `resolve_container_from_pod()` function matches containers by port, falling back to first container
- Container attributes are now direction-aware: `source.container.name`, `source.container.image.name`, `destination.container.name`, `destination.container.image.name`
- Updated semantic conventions documentation to reflect the new attribute schema
- Removed unused dependencies: `chrono`, `regex`, `rtnetlink`, `tokio-stream`
- Normalized log message casing for consistency (eBPF → ebpf, OpenTelemetry → opentelemetry)

Fixes #ENG-324

### Type of change

- [x] New feature
- [x] Documentation

## Testing

- Unit tested container resolution logic with single and multi-container Pods
- Verified port-based matching correctly identifies containers exposing specific ports
- Confirmed fallback behavior when no port match exists

## Proof it works



## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

The distinction between `source.k8s.container.name` (from Pod spec metadata) and `source.container.name` (runtime container name) is now documented in the semantic conventions.
