### PR TITLE
fix: Simplify copying sources for docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,18 @@
+*
+
+# misc
+!Cargo.lock
+!Cargo.toml
+!rust-toolchain.toml
+!rustfmt.toml
+
+# src
+!/common-build/
+!/mermin/
+!/mermin-common/
+!/mermin-ebpf/
+!/network-types/
+
+# re-ignore
+mermin/tests/
 **/target/
-mermin/tests/e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,13 +99,8 @@ RUN find . -type d | while read -r i; do mkdir -p "$i/src"; echo 'fn main() {}' 
   && find . -type d -name 'src' -not -path './target/*' -prune -exec rm -rf {} \; \
   && find . -mindepth 1 -maxdepth 1 -type d | while read -r i; do find ./target/ -type d -name "${i#./}-*" -prune -exec rm -rf {} \;; done
 
-# Copy source code
-COPY ./common-build ./common-build
-COPY ./mermin ./mermin
-COPY ./mermin-common ./mermin-common
-COPY ./mermin-ebpf ./mermin-ebpf
-COPY ./network-types ./network-types
-
+# Copy source code (heavily relies on .dockerignore)
+COPY . .
 # Build the final application, leveraging the cached dependencies
 RUN cargo build --release
 


### PR DESCRIPTION
## Changes

In order to reduce complexity it makes sense to better utilize the `.dockerignore` to exclude all and include only required dirs for the build process. It allows to reduce the context passed to the docker build process.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Other:

## Testing

Locally with `docker build`

## Proof it works

N/A

## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [ ] All tests pass

## Notes

<!-- Anything else reviewers should know? Areas where you'd like feedback? -->
