### PR TITLE
fix: remove standard globs for non-string filters

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,9 +1,4 @@
 MD013:
   line_length: 240
-MD025: false
 MD033:
-  allowed_elements: [
-    "b",
-    "summary",
-    "details",
-  ]
+  allowed_elements: ["b", "summary", "details"]

--- a/docs/configuration/default/config.hcl
+++ b/docs/configuration/default/config.hcl
@@ -560,13 +560,13 @@ filter "network" {
 
 filter "flow" {
   connection_state = { match = [], not_match = [] } # States to  (e.g., ["established", "close_wait"])
-  tcp_flags        = { match = [], not_match = [] } # TCP flags (e.g., ["SYN", "ACK"])
+  tcp_flags_tags   = { match = [], not_match = [] } # TCP flags (e.g., ["SYN", "ACK"])
   ip_dscp_name     = { match = [], not_match = [] } # DSCP values (e.g., ["CS0", "AF21"])
   ip_ecn_name      = { match = [], not_match = [] } # ECN values (e.g., ["ECT0"])
   ip_ttl           = { match = [], not_match = [] } # TTL values (e.g., ["1"])
-  ipv6_flow_label  = { match = [], not_match = [] } # IPv6 flow labels (e.g., ["12345"])
+  ip_flow_label    = { match = [], not_match = [] } # IPv6 flow labels (e.g., ["12345"])
   icmp_type_name   = { match = [], not_match = [] } # ICMP types (e.g., ["echo_request"])
-  icmp_code        = { match = [], not_match = [] } # ICMP codes (e.g., ["0"])
+  icmp_code_name   = { match = [], not_match = [] } # ICMP codes (e.g., ["0"])
 }
 
 span {

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -160,15 +160,15 @@ Filter flows by address, port, transport, type, interface, and other dimensions.
 - `connection_state`
 - `ip_dscp_name`, `ip_ecn_name`, `ip_ttl`, `ip_flow_label`
 - `icmp_type_name`, `icmp_code_name`
-- `tcp_flags`
+- `tcp_flags_tags`
 
 Example:
 
 ```hcl
 filter "source" {
-  address   = { match = "10.0.0.0/8", not_match = "" }
-  port      = { match = "80,443", not_match = "" }
-  transport = { match = "tcp", not_match = "" }
+  address   = { match = ["10.0.0.0/8"] }
+  port      = { match = ["80", "443"] }
+  transport = { match = ["tcp"] }
 }
 ```
 

--- a/mermin/src/filter/opts.rs
+++ b/mermin/src/filter/opts.rs
@@ -17,13 +17,13 @@ pub struct FilteringOptions {
     pub ip_flow_label: Option<FilteringPair>,
     pub icmp_type_name: Option<FilteringPair>,
     pub icmp_code_name: Option<FilteringPair>,
-    pub tcp_flags: Option<FilteringPair>,
+    pub tcp_flags_tags: Option<FilteringPair>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FilteringPair {
     #[serde(default, rename = "match")]
-    pub match_glob: String,
+    pub match_list: Vec<String>,
     #[serde(default, rename = "not_match")]
-    pub not_match_glob: String,
+    pub not_match_list: Vec<String>,
 }

--- a/mermin/src/runtime/conf.rs
+++ b/mermin/src/runtime/conf.rs
@@ -340,62 +340,62 @@ impl Conf {
                 );
 
                 if let Some(ref address) = filter_opts.address
-                    && (!address.match_glob.is_empty() || !address.not_match_glob.is_empty())
+                    && (!address.match_list.is_empty() || !address.not_match_list.is_empty())
                 {
                     debug!(
                         event.name = "config.filter.address",
                         filter.name = %filter_name,
-                        match = %address.match_glob,
-                        not_match = %address.not_match_glob,
+                        match = ?address.match_list,
+                        not_match = ?address.not_match_list,
                         "address filter configuration"
                     );
                 }
 
                 if let Some(ref port) = filter_opts.port
-                    && (!port.match_glob.is_empty() || !port.not_match_glob.is_empty())
+                    && (!port.match_list.is_empty() || !port.not_match_list.is_empty())
                 {
                     debug!(
                         event.name = "config.filter.port",
                         filter.name = %filter_name,
-                        match = %port.match_glob,
-                        not_match = %port.not_match_glob,
+                        match = ?port.match_list,
+                        not_match = ?port.not_match_list,
                         "port filter configuration"
                     );
                 }
 
                 if let Some(ref transport) = filter_opts.transport
-                    && (!transport.match_glob.is_empty() || !transport.not_match_glob.is_empty())
+                    && (!transport.match_list.is_empty() || !transport.not_match_list.is_empty())
                 {
                     debug!(
                         event.name = "config.filter.transport",
                         filter.name = %filter_name,
-                        match = %transport.match_glob,
-                        not_match = %transport.not_match_glob,
+                        match = ?transport.match_list,
+                        not_match = ?transport.not_match_list,
                         "transport filter configuration"
                     );
                 }
 
                 if let Some(ref type_) = filter_opts.type_
-                    && (!type_.match_glob.is_empty() || !type_.not_match_glob.is_empty())
+                    && (!type_.match_list.is_empty() || !type_.not_match_list.is_empty())
                 {
                     debug!(
                         event.name = "config.filter.type",
                         filter.name = %filter_name,
-                        match = %type_.match_glob,
-                        not_match = %type_.not_match_glob,
+                        match = ?type_.match_list,
+                        not_match = ?type_.not_match_list,
                         "type filter configuration"
                     );
                 }
 
                 if let Some(ref interface_name) = filter_opts.interface_name
-                    && (!interface_name.match_glob.is_empty()
-                        || !interface_name.not_match_glob.is_empty())
+                    && (!interface_name.match_list.is_empty()
+                        || !interface_name.not_match_list.is_empty())
                 {
                     debug!(
                         event.name = "config.filter.interface_name",
                         filter.name = %filter_name,
-                        match = %interface_name.match_glob,
-                        not_match = %interface_name.not_match_glob,
+                        match = ?interface_name.match_list,
+                        not_match = ?interface_name.not_match_list,
                         "interface_name filter configuration"
                     );
                 }


### PR DESCRIPTION
## Changes

This PR significantly refactors and simplifies the flow filtering infrastructure to improve performance, configuration clarity, and runtime stability.

1.  **Strict Filtering Logic**: Removed wildcard support (`*`) for IP addresses. IPs now strictly use CIDR notation. 
2.  **Configuration Schema Update**: Changed filtering options from comma-separated strings to native lists (`Vec<String>`).
3.  **Case-Insensitive Globbing**: Standardized string-based filtering (transport, interface names, etc.) to be case-insensitive by normalizing both patterns and values to lowercase.

### Type of change

- [] Bug fix
- [x] New feature (Case-insensitive glob matching for strings)
- [x] Breaking change (Removed IP wildcards; changed CSV strings to Lists)
- [ ] Documentation
- [x] Refactor (Simplified parsing logic by removing wildcard parsers)

## Testing

- **Unit Tests**: Expanded the test suite in `filter/source.rs` to verify:
    - Strict CIDR parsing for IPv4/IPv6.
    - Discrete port matching.
    - Advanced glob matching including character classes (`[ab]`) and lists (acting as `{a,b}`).
    - Case-insensitivity for protocol and interface names.
- **Integration Testing**: Verified on-cluster that applying a `transport = ["tcp"]` filter correctly collects TCP traces while silently ignoring other protocols without log spam.

## Proof it works
<img width="631" height="565" alt="Screenshot 2026-01-30 at 12 24 27 PM" src="https://github.com/user-attachments/assets/d5b5e558-f9fa-4c2c-a55e-be8b7950fec2" />



## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

- Reviewers should note that existing HCL configurations using `match = "80,443"` must be updated to `match = ["80", "443"]`.