### PR TITLE
refactor(metrics): rename export pipeline stage label

### DIFF
--- a/docs/configuration/export-otlp.md
+++ b/docs/configuration/export-otlp.md
@@ -635,7 +635,7 @@ export "traces" {
 - `mermin_export_flow_spans_total{exporter="otlp",status="ok"}` - OTLP export success rate
 - `mermin_export_flow_spans_total{exporter="otlp",status="error"}` - OTLP export errors
 - `mermin_channel_entries{channel="producer_output"}` / `mermin_channel_capacity{channel="producer_output"}` - Channel utilization
-- `mermin_pipeline_duration_seconds{stage="k8s_export_out"}` - Export-stage latency
+- `mermin_pipeline_duration_seconds{stage="export_out"}` - Export-stage latency
 - `mermin_channel_sends_total{channel="decorator_output",status="error"}` - Channel send failures (indicates dropped spans)
 
 See the [Application Metrics](../observability/app-metrics.md) guide for complete Prometheus query examples.

--- a/mermin/src/main.rs
+++ b/mermin/src/main.rs
@@ -907,7 +907,7 @@ async fn run(cli: Cli) -> Result<()> {
             let export_result = tokio::time::timeout(Duration::from_secs(EXPORT_TIMEOUT_SECS), exporter.export(traceable)).await;
             let export_duration = export_start.elapsed();
             metrics::registry::processing_duration_seconds()
-                .with_label_values(&[ProcessingStage::K8sExportOut.as_str()])
+                .with_label_values(&[ProcessingStage::ExportOut.as_str()])
                 .observe(export_duration.as_secs_f64());
 
             if export_result.is_err() {

--- a/mermin/src/metrics/processing.rs
+++ b/mermin/src/metrics/processing.rs
@@ -19,7 +19,7 @@
 ///
 /// 1. **FlowProducerOut**: Flow producer processing from ringbuffer (fast, typically microseconds to milliseconds)
 /// 2. **K8sDecoratorOut**: Kubernetes decoration and enrichment (medium, typically milliseconds)
-/// 3. **K8sExportOut**: Export to OTLP/stdout (slow, can be seconds)
+/// 3. **ExportOut**: Export to OTLP/stdout (slow, can be seconds)
 ///
 /// # Examples
 ///
@@ -71,7 +71,7 @@ pub enum ProcessingStage {
     /// This stage measures the latency of exporting completed flow spans
     /// to configured exporters (OTLP or stdout). This includes serialization,
     /// network I/O (for OTLP), and any batching operations.
-    K8sExportOut,
+    ExportOut,
 }
 
 impl ProcessingStage {
@@ -79,7 +79,7 @@ impl ProcessingStage {
         match self {
             ProcessingStage::FlowProducerOut => "flow_producer_out",
             ProcessingStage::K8sDecoratorOut => "k8s_decorator_out",
-            ProcessingStage::K8sExportOut => "k8s_export_out",
+            ProcessingStage::ExportOut => "export_out",
         }
     }
 }


### PR DESCRIPTION
## Changes

Renames the `K8sExportOut` processing stage to `ExportOut` since the export stage is not specific to Kubernetes functionality - it handles all exports (OTLP, stdout) regardless of K8s decoration status.

**Files modified:**
- `mermin/src/metrics/processing.rs` - Renamed enum variant and string label
- `mermin/src/main.rs` - Updated usage of the renamed variant
- `docs/configuration/export-otlp.md` - Updated metric documentation

**Metric label change:** `k8s_export_out` → `export_out`

### Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] New feature
- [x] Breaking change
- [ ] Documentation
- [ ] Other:

## Testing

Tested locally using Colima with the Docker builder container:

## Proof it works

Compiles successfully and clippy passes with no warnings.

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

This is a minor breaking change for users who query the `mermin_pipeline_duration_seconds` metric with the old `stage="k8s_export_out"` label. Dashboards and alerts using this label will need to be updated to use `stage="export_out"`.