### PR TITLE
fix: independent src and dst association blocks

### DIFF
--- a/mermin/src/k8s/decorator.rs
+++ b/mermin/src/k8s/decorator.rs
@@ -239,6 +239,7 @@ impl<'a> Decorator<'a> {
                 // Resolve and populate container information
                 if let Some((container_name, container_image)) =
                     pod.and_then(|p| resolve_pod_container_by_port(p, port))
+                    && self.should_extract("container", "name", is_source)
                 {
                     self.set_k8s_attr(flow_span, "container.name", &container_name, is_source);
                     self.set_k8s_attr(

--- a/mermin/src/runtime/conf.rs
+++ b/mermin/src/runtime/conf.rs
@@ -230,7 +230,14 @@ impl Conf {
         conf.attributes = match conf.attributes {
             None => Some(default_attributes()),
             Some(map) if map.is_empty() => None,
-            Some(map) => Some(map),
+            Some(mut user_map) => {
+                let defaults = default_attributes();
+
+                for (direction, default_inner_map) in defaults {
+                    user_map.entry(direction).or_insert(default_inner_map);
+                }
+                Some(user_map)
+            }
         };
         conf.config_path = config_path_to_store;
 


### PR DESCRIPTION
## Changes

This work in this request refactors the Kubernetes attribute association configuration to ensure that source and destination association blocks are handled separately. The changes improve the configuration system's ability to properly distinguish between source and destination flow attributes when associating them with Kubernetes objects.

### Key Changes:
- **Simplified AssociationSource structure**: Removed the redundant `name` field and consolidated the `from` field to directly contain the attribute name (e.g., "source.ip", "destination.ip")
- **Enhanced configuration merging**: Updated the configuration system to properly merge user-defined attributes with default attributes for both source and destination directions
- **Improved IP indexing**: Added duplicate prevention logic to avoid indexing the same resource multiple times for the same IP address
- **Fixed association rule processing**: Updated the logic to iterate through all direction-specific attribute configurations instead of just finding the first k8s configuration
- **Added comprehensive test coverage**: Included a new test `test_custom_association_logic()` to verify the custom association functionality works correctly

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor
- [ ] Other:

## Testing

The changes were tested using:
- **Unit tests**: Added `test_custom_association_logic()` test that verifies the association logic works correctly with custom configurations
- **Configuration validation**: Tested that the configuration merging logic properly handles both user-defined and default attribute configurations

**Environment used**: Local development environment with Rust/Cargo test framework

## Proof it works
<img width="588" height="942" alt="Screenshot 2026-02-03 at 3 56 55 PM" src="https://github.com/user-attachments/assets/c7312456-ce59-46d8-b31c-20b20427de0f" />
<img width="437" height="683" alt="Screenshot 2026-02-03 at 3 57 18 PM" src="https://github.com/user-attachments/assets/0db47158-8723-48ff-a13c-4371afc2d903" />


## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

**Key architectural improvement**: This change addresses a fundamental issue where source and destination association blocks were not being processed separately, which could lead to incorrect attribute associations in network flow analysis.

**Backward compatibility**: The changes maintain backward compatibility with existing configurations while fixing the underlying separation logic.

**Areas for reviewer attention**:
- The configuration merging logic in `runtime/conf.rs` - ensure it properly handles edge cases
- The IP indexing deduplication logic - verify it doesn't impact performance
- The test coverage - confirm it adequately covers the new functionality

**Performance considerations**: The duplicate prevention logic in `add_to_index()` adds a small overhead but prevents potential memory bloat from duplicate entries.