### PR TITLE
feat(metrics): add read ops metric for flow events

### DIFF
--- a/mermin/src/metrics/registry.rs
+++ b/mermin/src/metrics/registry.rs
@@ -169,7 +169,7 @@ lazy_static! {
     ).expect("failed to create ebpf_map_bytes_total metric");
 
     /// Total number of eBPF map operations.
-    /// Labels: map = "FLOW_STATS" | "LISTENING_PORTS", operation = "read" | "write" | "delete", status = "ok" | "error" | "not_found"
+    /// Labels: map = "FLOW_STATS" | "FLOW_EVENTS" | "LISTENING_PORTS", operation = "read" | "write" | "delete", status = "ok" | "error" | "not_found"
     pub static ref EBPF_MAP_OPS_TOTAL: IntCounterVec = IntCounterVec::new(
         Opts::new("map_ops_total", "Total number of eBPF map operations")
             .namespace("mermin")

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -466,6 +466,13 @@ impl FlowSpanProducer {
                         metrics::registry::EBPF_MAP_BYTES_TOTAL
                             .with_label_values(&[EbpfMapName::FlowEvents.as_str()])
                             .inc_by(flow_event.snaplen as u64);
+                        metrics::registry::EBPF_MAP_OPS_TOTAL
+                            .with_label_values(&[
+                                EbpfMapName::FlowEvents.as_str(),
+                                EbpfMapOperation::Read.as_str(),
+                                EbpfMapStatus::Ok.as_str(),
+                            ])
+                            .inc();
                         if metrics::registry::debug_enabled() {
                             metrics::registry::FLOW_EVENTS_TOTAL
                                 .with_label_values(&[FlowEventResult::Received.as_str()])


### PR DESCRIPTION
## Changes

Adds `EBPF_MAP_OPS_TOTAL` counter for read operations on the FLOW_EVENTS eBPF map. When flow events are successfully read from the map, the metric is incremented with labels `map=FLOW_EVENTS`, `operation=read`, `status=ok`.

- **registry.rs**: Updated doc comment to include `FLOW_EVENTS` in the map label values
- **producer.rs**: Instrument flow event reads with `EBPF_MAP_OPS_TOTAL` increment

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Proof it works

<img width="541" height="344" alt="Screenshot 2026-02-03 at 4 12 21 PM" src="https://github.com/user-attachments/assets/b782b414-c773-4cc3-8b95-b5f89abfa213" />


## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass