### PR TITLE
docs: fix markdown lint issues and improve heading structure for seo

### DIFF
--- a/docs/CODE-OF-CONDUCT.md
+++ b/docs/CODE-OF-CONDUCT.md
@@ -4,11 +4,14 @@
 
 We pledge to make our community welcoming, safe, and equitable for all.
 
-We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics,
+neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status.
+The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
 
 ## Encouraged Behaviors
 
-While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior.
+We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
 
 With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
 
@@ -41,15 +44,20 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 ## Reporting an Issue
 
-Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+Tensions can occur between community members even when they are trying their best to collaborate.
+Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
 When an incident does occur, it is important to report it promptly. Please report code of conduct violations by emailing [mermin@elastiflow.com](mailto:mermin@elastiflow.com).
 
-Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner.
+They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants.
+Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality.
+In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 
 ## Addressing and Repairing Harm
 
-If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm,
+based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
 
 1) Warning
    1) Event: A violation involving a single incident or series of incidents.
@@ -57,22 +65,26 @@ If an investigation by the Community Moderators finds that this Code of Conduct 
    3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
 2) Temporarily Limited Activities
    1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
-   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident.
+      The cooldown period may be limited to particular communication channels or interactions with particular community members.
    3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
 3) Temporary Suspension
    1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
    2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
    3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
 4) Permanent Ban
-   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
-   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve,
+      or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed.
+      In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
    3) Repair: There is no possible repair in cases of this severity.
 
 This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces.
+Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Attribution
 
@@ -80,4 +92,7 @@ This Code of Conduct is adapted from the Contributor Covenant, version 3.0, perm
 
 Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).
+Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).
+Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources).
+The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
-# Overview
+# Mermin Documentation
 
-Welcome to the Mermin documentation! Mermin is a powerful, Kubernetes-native network observability tool that uses eBPF to efficiently capture network traffic and export it as **Flow Traces** via the OpenTelemetry Protocol (OTLP). It provides deep visibility into your cluster's network communications with zero application changes required.
+Welcome to the Mermin documentation! Mermin is a powerful, Kubernetes-native network observability tool that uses eBPF to efficiently capture network traffic and export it as **Flow Traces** via the OpenTelemetry Protocol (OTLP).
+It provides deep visibility into your cluster's network communications with zero application changes required.
 
 ![Mermin Overview](.gitbook/assets/mermin-overview.png)
 
@@ -10,7 +11,8 @@ Welcome to the Mermin documentation! Mermin is a powerful, Kubernetes-native net
 
 ### The Problem
 
-Your APM traces show application behavior. Your network monitoring shows IP-level statistics. But there's a gap: when a trace shows a slow network span, you have no way to correlate that with actual network flow data. When network teams see congestion, they can't map it back to specific services or pods.
+Your APM traces show application behavior. Your network monitoring shows IP-level statistics. But there's a gap: when a trace shows a slow network span, you have no way to correlate that with actual network flow data.
+When network teams see congestion, they can't map it back to specific services or pods.
 
 The MELT stack (Metrics, Events, Logs, Traces) is missing network flow data—connection-level information that bridges application performance with network reality.
 
@@ -22,14 +24,15 @@ Mermin captures network traffic using eBPF and exports it as **Flow Traces**—n
 
 Observability involves trade-offs between granularity and overhead. Flow data sits between two extremes:
 
-* **Not Raw PCAP**: Full packet capture is expensive to store and query. Mermin aggregates packets into flows—you get connection-level detail without payload overhead.
-* **Not Just Counters**: Metrics tell you bandwidth usage but miss connection context—timing, retransmissions, directionality.
+- **Not Raw PCAP**: Full packet capture is expensive to store and query. Mermin aggregates packets into flows—you get connection-level detail without payload overhead.
+- **Not Just Counters**: Metrics tell you bandwidth usage but miss connection context—timing, retransmissions, directionality.
 
 Flow data provides **granular, connection-level detail that's lightweight enough to run always-on in production.**
 
 ## What are Flow Traces?
 
-Flow Traces are OpenTelemetry trace spans that represent network flows with NetFlow-like behavior. Unlike traditional NetFlow or IPFIX, Flow Traces leverage the OpenTelemetry standard, providing bidirectional flow statistics, rich Kubernetes metadata, and native integration with modern observability platforms.
+Flow Traces are OpenTelemetry trace spans that represent network flows with NetFlow-like behavior.
+Unlike traditional NetFlow or IPFIX, Flow Traces leverage the OpenTelemetry standard, providing bidirectional flow statistics, rich Kubernetes metadata, and native integration with modern observability platforms.
 
 ## Quick Start
 
@@ -48,62 +51,63 @@ Once deployed, Mermin runs as a DaemonSet with one pod per node, automatically c
 
 ## Key Capabilities
 
-* **Auto-Instrumentation for Your Network Stack**: Just as eBPF-based APM tools auto-instrument application code, Mermin auto-instruments your network layer. Deploy once per node, get visibility into all traffic—no per-service configuration required.
-* **Kubernetes-Native Enrichment**: Flows include Pod, Service, and Deployment metadata. You see `frontend-service` → `redis-cache`, not `10.42.0.5` → `10.42.0.8`.
-* **Zero Code Changes**: eBPF captures traffic transparently—no sidecars, no application modifications, no service mesh required.
-* **Standards-Based Export**: Native OTLP output integrates with your existing observability stack (Tempo, Jaeger, Elastic, etc.).
-* **Production-Ready**: Low-overhead kernel-level capture designed for always-on operation.
-* **Comprehensive Protocol Support**: Parses and tracks TCP, UDP, ICMP traffic, with support for common tunneling protocols (VXLAN, Geneve, WireGuard).
-* **Flexible Filtering**: Configure fine-grained filters to control which network flows are captured and exported.
+- **Auto-Instrumentation for Your Network Stack**: Just as eBPF-based APM tools auto-instrument application code, Mermin auto-instruments your network layer.
+  Deploy once per node, get visibility into all traffic—no per-service configuration required.
+- **Kubernetes-Native Enrichment**: Flows include Pod, Service, and Deployment metadata. You see `frontend-service` → `redis-cache`, not `10.42.0.5` → `10.42.0.8`.
+- **Zero Code Changes**: eBPF captures traffic transparently—no sidecars, no application modifications, no service mesh required.
+- **Standards-Based Export**: Native OTLP output integrates with your existing observability stack (Tempo, Jaeger, Elastic, etc.).
+- **Production-Ready**: Low-overhead kernel-level capture designed for always-on operation.
+- **Comprehensive Protocol Support**: Parses and tracks TCP, UDP, ICMP traffic, with support for common tunneling protocols (VXLAN, Geneve, WireGuard).
+- **Flexible Filtering**: Configure fine-grained filters to control which network flows are captured and exported.
 
 ## How It Compares
 
-| Feature                | Mermin             | eBPF APM Agents      | Traditional NetFlow/IPFIX | Service Mesh (Istio/Linkerd)  | Packet Capture Tools  |
-| ---------------------- | ------------------ | -------------------- | ------------------------- | ----------------------------- | --------------------- |
-| Kubernetes Context     | ✅ Native           | ✅ Native             | ❌ None                    | ✅ Native                      | ❌ None                |
-| Application Changes    | ✅ Zero             | ✅ Zero               | ✅ Zero                    | ❌ Sidecar injection           | ✅ Zero                |
+| Feature                | Mermin             | eBPF APM Agents      | Traditional NetFlow/IPFIX | Service Mesh (Istio/Linkerd) | Packet Capture Tools  |
+|------------------------|--------------------|----------------------|---------------------------|------------------------------|-----------------------|
+| Kubernetes Context     | ✅ Native           | ✅ Native             | ❌ None                    | ✅ Native                     | ❌ None                |
+| Application Changes    | ✅ Zero             | ✅ Zero               | ✅ Zero                    | ❌ Sidecar injection          | ✅ Zero                |
 | Network Data Type      | ✅ Flow Records     | ❌ Counters only      | ✅ Flow Records            | ⚠️ Request/response           | ✅ Full packets        |
 | Connection Context     | ✅ Full details     | ❌ Aggregated metrics | ✅ Full details            | ⚠️ L7 only                    | ✅ Full packets        |
 | Performance Overhead   | ✅ Minimal (eBPF)   | ✅ Minimal (eBPF)     | ✅ Low                     | ⚠️ Moderate (sidecars)        | ❌ High (full capture) |
-| Standards-Based Export | ✅ OTLP Traces      | ⚠️ OTLP Metrics      | ⚠️ Yes (not OTel-native)  | ⚠️ Prometheus/vendor-specific | ❌ PCAP files          |
-| Bidirectional Flows    | ✅ Yes              | ❌ Separate counters  | ⚠️ Rarely                 | ⚠️ Limited                    | ❌ Packet-level only   |
+| Standards-Based Export | ✅ OTLP Traces      | ⚠️ OTLP Metrics       | ⚠️ Yes (not OTel-native)   | ⚠️ Prometheus/vendor-specific | ❌ PCAP files          |
+| Bidirectional Flows    | ✅ Yes              | ❌ Separate counters  | ⚠️ Rarely                  | ⚠️ Limited                    | ❌ Packet-level only   |
 | Deployment Complexity  | ✅ Simple DaemonSet | ✅ Simple DaemonSet   | ✅ Simple                  | ⚠️ Complex                    | ✅ Simple              |
 
 **Key Differentiators:**
 
-* **vs eBPF APM Agents**: Exports flow records (with timing, flags, directionality) as traces, not aggregated counter metrics
-* **vs NetFlow/IPFIX**: Adds Kubernetes context and uses modern OTLP standard
-* **vs Service Meshes**: No application changes, lower overhead, but L3/L4 only (not L7)
-* **vs Packet Capture**: Aggregated flows instead of raw packets, with metadata enrichment
+- **vs eBPF APM Agents**: Exports flow records (with timing, flags, directionality) as traces, not aggregated counter metrics
+- **vs NetFlow/IPFIX**: Adds Kubernetes context and uses modern OTLP standard
+- **vs Service Meshes**: No application changes, lower overhead, but L3/L4 only (not L7)
+- **vs Packet Capture**: Aggregated flows instead of raw packets, with metadata enrichment
 
 ## What You Can Expect
 
 This documentation is designed to help you successfully deploy, configure, and operate Mermin in your environment. You'll find:
 
-* [**Quick Start Guide**](getting-started/quickstart.md): Get Mermin running in minutes on a local Kubernetes cluster.
-* [**Architecture Overview**](getting-started/architecture.md): Understand how Mermin works and its data flow.
-* [**Deployment Guides**](deployment/deployment.md): Detailed instructions for various deployment scenarios (Kubernetes, cloud platforms, bare metal).
-* [**Configuration Reference**](configuration/configuration.md): Comprehensive documentation of all configuration options.
-* [**Observability Backends**](observability/backends.md): Understand how to send Flow Traces to Elastic, Grafana Tempo, Jaeger, and other OTLP-compatible platforms.
-* [**Troubleshooting**](troubleshooting/troubleshooting.md): Solutions to common issues and diagnostic approaches
-* [**Development Guides**](contributor-guide/development-workflow.md): Build, test, and contribute to Mermin
+- [**Quick Start Guide**](getting-started/quickstart.md): Get Mermin running in minutes on a local Kubernetes cluster.
+- [**Architecture Overview**](getting-started/architecture.md): Understand how Mermin works and its data flow.
+- [**Deployment Guides**](deployment/deployment.md): Detailed instructions for various deployment scenarios (Kubernetes, cloud platforms, bare metal).
+- [**Configuration Reference**](configuration/configuration.md): Comprehensive documentation of all configuration options.
+- [**Observability Backends**](observability/backends.md): Understand how to send Flow Traces to Elastic, Grafana Tempo, Jaeger, and other OTLP-compatible platforms.
+- [**Troubleshooting**](troubleshooting/troubleshooting.md): Solutions to common issues and diagnostic approaches
+- [**Development Guides**](contributor-guide/development-workflow.md): Build, test, and contribute to Mermin
 
 ## Development & Contributing
 
 For developers who want to contribute to Mermin or build it locally:
 
-* [**Contributor Guide**](contributor-guide/development-workflow.md): Complete guide for setting up your development environment
-* [**Debugging eBPF Programs**](contributor-guide/debugging-ebpf.md): Advanced eBPF program inspection and optimization techniques
-* [**Debugging Network Traffic**](contributor-guide/debugging-network.md): Live packet capture with Wireshark
+- [**Contributor Guide**](contributor-guide/development-workflow.md): Complete guide for setting up your development environment
+- [**Debugging eBPF Programs**](contributor-guide/debugging-ebpf.md): Advanced eBPF program inspection and optimization techniques
+- [**Debugging Network Traffic**](contributor-guide/debugging-network.md): Live packet capture with Wireshark
 
 ## System Requirements
 
 Mermin requires:
 
-* **Linux Kernel**: Version 5.14 or newer with eBPF support enabled
-* **Kubernetes**: Version 1.20 or newer (for Kubernetes deployments)
-* **Container Runtime**: Docker, containerd, or CRI-O
-* **Privileges**: Requires privileged mode to load eBPF programs and access network interfaces
+- **Linux Kernel**: Version 5.14 or newer with eBPF support enabled
+- **Kubernetes**: Version 1.20 or newer (for Kubernetes deployments)
+- **Container Runtime**: Docker, containerd, or CRI-O
+- **Privileges**: Requires privileged mode to load eBPF programs and access network interfaces
 
 ## Architecture at a Glance
 
@@ -119,10 +123,10 @@ Mermin operates as a DaemonSet in Kubernetes (or as a privileged container on ba
 
 If you encounter issues or have questions:
 
-* [**GitHub Issues**](https://github.com/elastiflow/mermin/issues): Report bugs or request features.
-* [**GitHub Discussions**](https://github.com/elastiflow/mermin/discussions): Ask questions and engage with the community.
-* [**Slack Channel**](https://join.slack.com/t/elastiflowcommunity/shared_invite/zt-23jpnlw9g-Q4nKOwKKOE1N2MjfA2mXpg): Live chat with us or other beta users.
-* [**Troubleshooting Guide**](troubleshooting/troubleshooting.md): Check common issues and solutions.
+- [**GitHub Issues**](https://github.com/elastiflow/mermin/issues): Report bugs or request features.
+- [**GitHub Discussions**](https://github.com/elastiflow/mermin/discussions): Ask questions and engage with the community.
+- [**Slack Channel**](https://join.slack.com/t/elastiflowcommunity/shared_invite/zt-23jpnlw9g-Q4nKOwKKOE1N2MjfA2mXpg): Live chat with us or other beta users.
+- [**Troubleshooting Guide**](troubleshooting/troubleshooting.md): Check common issues and solutions.
 
 ## Next Steps
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 ## Welcome
 
-* [Overview](README.md)
+* [Introduction](README.md)
 * [Beta Program](welcome/beta-program.md)
 
 ## Getting Started
@@ -14,17 +14,17 @@
 
 ## Observability
 
-* [Backends](observability/backends.md)
-* [Mermin Application Metrics](observability/app-metrics.md)
+* [Backend Integration](observability/backends.md)
+* [Internal Metrics](observability/app-metrics.md)
 
 ## Deployment
 
-* [Deployment Overview](deployment/deployment.md)
+* [Overview](deployment/deployment.md)
 * [Kubernetes with Helm](deployment/kubernetes-helm.md)
 * [Cloud Platforms](deployment/cloud-platforms.md)
 * [Advanced Scenarios](deployment/advanced-scenarios.md)
 * [Docker on Bare Metal](deployment/docker-bare-metal.md)
-* [Helm Examples](deployment/helm-examples/README.md)
+* [Integration Guides](deployment/helm-examples/README.md)
   * [Mermin with OpenTelemetry Collector](deployment/examples/local_otel/README.md)
   * [Mermin with NetObserv Flow and OpenSearch](deployment/examples/netobserv_os_simple_svc/README.md)
   * [Mermin with NetObserv Flow and OpenSearch in GKE with Gateway](deployment/examples/netobserv_os_simple_gke_gw/README.md)
@@ -32,23 +32,24 @@
 
 ## Configuration
 
-* [Configuration Overview](configuration/configuration.md)
-* [Configuration Examples](configuration/examples.md)
-* [OTLP Exporter](configuration/export-otlp.md)
-* [Global Options](configuration/global-options.md)
-* [API](configuration/api.md)
-* [Metrics](configuration/metrics.md)
-* [Parser Configuration](configuration/parser.md)
-* [Pipeline Configuration](configuration/pipeline.md)
-* [Network Interface Discovery](configuration/discovery-instrument.md)
-* [Kubernetes Informers](configuration/discovery-kubernetes-informer.md)
-* [Owner Relations](configuration/owner-relations.md)
-* [Selector Relations](configuration/selector-relations.md)
-* [Flow Attributes](configuration/attributes.md)
-* [Flow Filtering](configuration/filtering.md)
-* [Flow Span Producer](configuration/span.md)
-* [Stdout Exporter](configuration/export-stdout.md)
-* [Internal Tracing](configuration/internal-tracing.md)
+* [Overview](configuration/configuration.md)
+* [Examples](configuration/examples.md)
+* [Global Agent Options](configuration/global-options.md)
+* Configuration References
+  * [Network Interface Discovery](configuration/discovery-instrument.md)
+  * [Network Packet Parser](configuration/parser.md)
+  * [Flow Span Producer](configuration/span.md)
+  * [OTLP Exporter](configuration/export-otlp.md)
+  * [Stdout Exporter](configuration/export-stdout.md)
+  * [Flow Span Kubernetes Attribution](configuration/attributes.md)
+  * [Kubernetes Owner Relations](configuration/owner-relations.md)
+  * [Kubernetes Informer Discovery](configuration/discovery-kubernetes-informer.md)
+  * [Kubernetes Selector Relations](configuration/selector-relations.md)
+  * [Agent Pipeline](configuration/pipeline.md)
+  * [Agent Pipeline Filters](configuration/filtering.md)
+  * [Internal API](configuration/api.md)
+  * [Internal Prometheus Metrics](configuration/metrics.md)
+  * [Internal Tracing](configuration/internal-tracing.md)
 
 ## Troubleshooting
 
@@ -59,7 +60,7 @@
 
 ## Flow Trace Specification
 
-* [Introductory Primer](spec/introductory-primer.md)
+* [Introduction to Flow Traces](spec/introductory-primer.md)
 * [Semantic Conventions](spec/semantic-conventions.md)
 
 ## Security

--- a/docs/configuration/api.md
+++ b/docs/configuration/api.md
@@ -1,4 +1,4 @@
-# API and Metrics
+# Configure the Internal API
 
 Mermin provides HTTP endpoints for health checks and Prometheus metrics. This page documents how to configure the API server and health probes; for the Prometheus metrics server (port, endpoints, debug metrics), see [Metrics](metrics.md).
 
@@ -72,7 +72,8 @@ api {
 
 ## Metrics Server
 
-The metrics server (Prometheus scrape endpoint) is configured via the `internal "metrics"` block. Options include `enabled`, `listen_address`, `port` (default `10250`), and `debug_metrics_enabled`. See [Metrics](metrics.md) for full configuration and available endpoints.
+The metrics server (Prometheus scrape endpoint) is configured via the `internal "metrics"` block. Options include `enabled`, `listen_address`, `port` (default `10250`), and `debug_metrics_enabled`.
+See [Metrics](metrics.md) for full configuration and available endpoints.
 
 ## Health Check Endpoints
 

--- a/docs/configuration/attributes.md
+++ b/docs/configuration/attributes.md
@@ -1,4 +1,4 @@
-# Flow Attributes
+# Configure Flow Span Attribution
 
 Flow attributes define which Kubernetes metadata to extract and how to associate it with network flows.
 
@@ -72,9 +72,9 @@ extract {
 
 **Syntax:**
 
-* `[*]`: Applies to all resource kinds
-* `pod.metadata.name`: Specific to pods
-* `[*].metadata.labels`: Extract labels
+- `[*]`: Applies to all resource kinds
+- `pod.metadata.name`: Specific to pods
+- `[*].metadata.labels`: Extract labels
 
 ## Association Configuration
 
@@ -272,10 +272,10 @@ attributes "destination" "k8s" {
 
 **Strategy**: Comprehensive Kubernetes metadata enrichment without manual configuration
 
-* **Pod associations** capture container networking (IPs, ports, protocols) including both pod and host networking
-* **Service associations** cover all service types (ClusterIP, LoadBalancer, ExternalIP) with port and protocol matching
-* **Node associations** match node IP addresses for host networking scenarios
-* The default **endpoint** association is provided for compatibility; for direct EndpointSlice IP matching, use **endpointslice** (see [Other association types](#other-association-types))
+- **Pod associations** capture container networking (IPs, ports, protocols) including both pod and host networking
+- **Service associations** cover all service types (ClusterIP, LoadBalancer, ExternalIP) with port and protocol matching
+- **Node associations** match node IP addresses for host networking scenarios
+- The default **endpoint** association is provided for compatibility; for direct EndpointSlice IP matching, use **endpointslice** (see [Other association types](#other-association-types))
 
 This covers the most common Kubernetes networking patterns and provides immediate network observability upon deployment.
 
@@ -331,6 +331,6 @@ To verify the default attributes are working:
 
 ## Next Steps
 
-* [**Kubernetes Informers**](discovery-kubernetes-informer.md): Configure resource watching
-* [**Owner Relations**](owner-relations.md): Add owner metadata
-* [**Configuration Examples**](examples.md): See complete configurations
+- [**Kubernetes Informers**](discovery-kubernetes-informer.md): Configure resource watching
+- [**Owner Relations**](owner-relations.md): Add owner metadata
+- [**Configuration Examples**](examples.md): See complete configurations

--- a/docs/configuration/discovery-instrument.md
+++ b/docs/configuration/discovery-instrument.md
@@ -1,4 +1,4 @@
-# Discovery: Network Interfaces Instrumentation
+# Configure Network Interface Discovery
 
 This page explains how Mermin discovers and monitors network interfaces on the host. Interface selection is critical for determining what network traffic Mermin captures.
 
@@ -111,7 +111,7 @@ Mermin resolves patterns at startup and configuration reload:
 
 **Host interfaces:**
 
-```
+```text
 eth0, eth1, ens32, ens33, lo, docker0, cni0, cni123abc
 ```
 
@@ -125,7 +125,7 @@ discovery "instrument" {
 
 **Resolved interfaces:**
 
-```
+```text
 eth0, eth1, ens32, ens33, cni0, cni123abc
 ```
 
@@ -255,9 +255,11 @@ For most use cases, the default configuration (complete visibility with veth + t
 
 ## Dynamic Interface Discovery
 
-Mermin includes an **Interface Controller** that automatically discovers and manages network interfaces. The controller continuously watches for interface changes and synchronizes the configured patterns with active interfaces, attaching/detaching eBPF programs as interfaces are created and destroyed. This is particularly useful for ephemeral interfaces like veth pairs that come and go with pods.
+Mermin includes an **Interface Controller** that automatically discovers and manages network interfaces.
+The controller continuously watches for interface changes and synchronizes the configured patterns with active interfaces, attaching/detaching eBPF programs as interfaces are created and destroyed.
+This is particularly useful for ephemeral interfaces like veth pairs that come and go with pods.
 
-### Configuration
+### Discovery Configuration
 
 ```hcl
 discovery "instrument" {
@@ -497,26 +499,28 @@ discovery "instrument" {
 
 **Solutions:**
 
-1.  **List available interfaces:**
+1. **List available interfaces:**
 
-    ```bash
-    kubectl exec <pod> -- ip link show
-    # or on host
-    ip link show
-    ```
-2.  **Test pattern matching:**
+   ```bash
+   kubectl exec <pod> -- ip link show
+   # or on host
+   ip link show
+   ```
 
-    ```bash
-    # Check if pattern matches
-    ip link show | grep -E "^[0-9]+: eth"
-    ```
-3.  **Update configuration:**
+2. **Test pattern matching:**
 
-    ```hcl
-    discovery "instrument" {
-      interfaces = ["eth0"]  # Use exact name from ip link show
-    }
-    ```
+   ```bash
+   # Check if pattern matches
+   ip link show | grep -E "^[0-9]+: eth"
+   ```
+
+3. **Update configuration:**
+
+   ```hcl
+   discovery "instrument" {
+     interfaces = ["eth0"]  # Use exact name from ip link show
+   }
+   ```
 
 ### Interface Not Found
 
@@ -540,20 +544,22 @@ discovery "instrument" {
 
 **Solutions:**
 
-1.  **Reduce monitored interfaces:**
+1. **Reduce monitored interfaces:**
 
-    ```hcl
-    discovery "instrument" {
-      interfaces = ["eth0"]  # Monitor only primary interface
-    }
-    ```
-2.  **Remove CNI interfaces:**
+   ```hcl
+   discovery "instrument" {
+     interfaces = ["eth0"]  # Monitor only primary interface
+   }
+   ```
 
-    ```hcl
-    discovery "instrument" {
-      interfaces = ["eth*", "ens*"]  # Remove cni*, cali*, etc.
-    }
-    ```
+2. **Remove CNI interfaces:**
+
+   ```hcl
+   discovery "instrument" {
+     interfaces = ["eth*", "ens*"]  # Remove cni*, cali*, etc.
+   }
+   ```
+
 3. **Add flow filters** (see [Filtering](filtering.md))
 
 ### Flow Duplication
@@ -567,13 +573,14 @@ discovery "instrument" {
 
 **Solutions:**
 
-1.  **Monitor only physical interfaces:**
+1. **Monitor only physical interfaces:**
 
-    ```hcl
-    discovery "instrument" {
-      interfaces = ["eth*", "ens*"]  # Don't include CNI interfaces
-    }
-    ```
+   ```hcl
+   discovery "instrument" {
+     interfaces = ["eth*", "ens*"]  # Don't include CNI interfaces
+   }
+   ```
+
 2. **Deduplicate in backend:**
    * Use flow fingerprinting (Community ID)
    * Deduplicate based on 5-tuple + timestamps
@@ -588,7 +595,7 @@ kubectl logs <pod> | grep -i interface
 
 Example log output:
 
-```
+```text
 INFO Resolved interfaces interfaces=["eth0","eth1","ens32"]
 INFO eBPF programs attached interfaces=["eth0","eth1","ens32"]
 ```

--- a/docs/configuration/discovery-kubernetes-informer.md
+++ b/docs/configuration/discovery-kubernetes-informer.md
@@ -1,4 +1,4 @@
-# Discovery: Kubernetes Informer
+# Configure Kubernetes Informer Discovery
 
 This page documents how to configure Mermin's Kubernetes informers, which watch and cache Kubernetes resources for flow
 metadata enrichment.
@@ -59,9 +59,9 @@ discovery "informer" "k8s" {
 
 **When to set:**
 
-* Testing locally outside cluster
-* Using specific service account
-* Multi-cluster scenarios
+- Testing locally outside cluster
+- Using specific service account
+- Multi-cluster scenarios
 
 ### `informers_sync_timeout`
 
@@ -71,9 +71,9 @@ Timeout for initial informer synchronization.
 
 **Description:**
 
-* Maximum time to wait for informers to complete initial sync
-* Mermin won't be ready until sync completes
-* Large clusters may need longer timeout
+- Maximum time to wait for informers to complete initial sync
+- Mermin won't be ready until sync completes
+- Large clusters may need longer timeout
 
 **Examples:**
 
@@ -91,7 +91,8 @@ discovery "informer" "k8s" {
 
 ## Resource Selectors
 
-The `selectors` array determines which Kubernetes resources to watch. If `selectors` is omitted or empty, Mermin uses a default set of kinds (Service, EndpointSlice, Pod, workload controllers, NetworkPolicy, Ingress, Gateway). When you provide selectors, your entries are merged with these defaults: for each kind you list, your selector replaces the default for that kind.
+The `selectors` array determines which Kubernetes resources to watch. If `selectors` is omitted or empty, Mermin uses a default set of kinds (Service, EndpointSlice, Pod, workload controllers, NetworkPolicy, Ingress, Gateway).
+When you provide selectors, your entries are merged with these defaults: for each kind you list, your selector replaces the default for that kind.
 
 ### Selector Structure
 
@@ -184,15 +185,17 @@ discovery "informer" "k8s" {
 
 **Operators:**
 
-* `In`: Label value in list
-* `NotIn`: Label value not in list
-* `Exists`: Label key exists
-* `DoesNotExist`: Label key doesn't exist
+- `In`: Label value in list
+- `NotIn`: Label value not in list
+- `Exists`: Label key exists
+- `DoesNotExist`: Label key doesn't exist
 
 ### Excluding resources
 
-* **Exclude a kind entirely:** If you omit `selectors` or leave it empty, all default kinds are watched. When you provide `selectors`, they are merged with defaults: for each kind you specify, your selector is used; for kinds you do not specify, the default for that kind is still used. So you cannot remove a single kind from the default set—unspecified kinds remain. To limit scope, use **namespace filtering** or **label selectors** (inclusion) so that only the resources you need are watched.
-* **Namespace filter is inclusion-only:** `namespaces = ["a", "b"]` means "watch this kind only in namespaces `a` and `b`." There is no way to "exclude namespace X" for a kind; use inclusion (list the namespaces you want) instead.
+- **Exclude a kind entirely:** If you omit `selectors` or leave it empty, all default kinds are watched.
+  When you provide `selectors`, they are merged with defaults: for each kind you specify, your selector is used; for kinds you do not specify, the default for that kind is still used.
+  So you cannot remove a single kind from the default set—unspecified kinds remain. To limit scope, use **namespace filtering** or **label selectors** (inclusion) so that only the resources you need are watched.
+- **Namespace filter is inclusion-only:** `namespaces = ["a", "b"]` means "watch this kind only in namespaces `a` and `b`." There is no way to "exclude namespace X" for a kind; use inclusion (list the namespaces you want) instead.
 
 **Example:** Watch only pods in specific namespaces (inclusion) to reduce load:
 
@@ -282,30 +285,30 @@ discovery "informer" "k8s" {
 
 Memory usage scales with number of watched resources:
 
-* **Estimate:** ~1 KB per resource
-* **10,000 pods:** ~10 MB
-* **100,000 pods:** ~100 MB
+- **Estimate:** ~1 KB per resource
+- **10,000 pods:** ~10 MB
+- **100,000 pods:** ~100 MB
 
 ### API Server Load
 
 Informers use Kubernetes watch API:
 
-* Initial LIST operation per resource type
-* WATCH for ongoing updates
+- Initial LIST operation per resource type
+- WATCH for ongoing updates
 
 **Reduce load:**
 
-* Use namespace filtering
-* Use label selectors
+- Use namespace filtering
+- Use label selectors
 
 ### Sync Time
 
 Initial sync time depends on:
 
-* Cluster size
-* Number of resource types
-* API server performance
-* Network latency
+- Cluster size
+- Number of resource types
+- API server performance
+- Network latency
 
 **Large cluster tuning:**
 
@@ -363,7 +366,7 @@ discovery "informer" "k8s" {
 
 ## Next Steps
 
-* [**Owner Relations**](owner-relations.md): Configure owner reference walking
-* [**Selector Relations**](selector-relations.md): Configure selector-based matching
-* [**Flow Attributes**](attributes.md): Configure metadata extraction
-* [**Troubleshooting**](../troubleshooting/troubleshooting.md): Debug missing metadata
+- [**Owner Relations**](owner-relations.md): Configure owner reference walking
+- [**Selector Relations**](selector-relations.md): Configure selector-based matching
+- [**Flow Attributes**](attributes.md): Configure metadata extraction
+- [**Troubleshooting**](../troubleshooting/troubleshooting.md): Debug missing metadata

--- a/docs/configuration/export-otlp.md
+++ b/docs/configuration/export-otlp.md
@@ -1,4 +1,4 @@
-# OTLP Exporter
+# Configure the OTLP Exporter
 
 This page documents the OpenTelemetry Protocol (OTLP) exporter configuration, which controls how Mermin exports flow
 records to your observability backend.
@@ -50,10 +50,10 @@ OTLP collector endpoint URL.
 
 **Format:**
 
-* `http://hostname:port` for unencrypted gRPC
-* `https://hostname:port` for TLS-encrypted gRPC
-* Port 4317 is standard for gRPC
-* Port 4318 is standard for HTTP
+- `http://hostname:port` for unencrypted gRPC
+- `https://hostname:port` for TLS-encrypted gRPC
+- Port 4317 is standard for gRPC
+- Port 4318 is standard for HTTP
 
 **Examples:**
 
@@ -97,8 +97,8 @@ OTLP transport protocol.
 
 **Valid Values:**
 
-* `"grpc"`: gRPC protocol (recommended, default)
-* `"http_binary"`: HTTP with binary protobuf payload
+- `"grpc"`: gRPC protocol (recommended, default)
+- `"http_binary"`: HTTP with binary protobuf payload
 
 **Examples:**
 
@@ -148,9 +148,9 @@ export "traces" {
 
 **Tuning:**
 
-* **Fast networks**: 5s-10s
-* **WAN/Internet**: 15s-30s
-* **High latency**: 30s-60s
+- **Fast networks**: 5s-10s
+- **WAN/Internet**: 15s-30s
+- **High latency**: 30s-60s
 
 ## Batching Configuration
 
@@ -181,8 +181,8 @@ export "traces" {
 
 **Trade-offs:**
 
-* **Larger batches**: Better efficiency, higher latency
-* **Smaller batches**: Lower latency, more requests
+- **Larger batches**: Better efficiency, higher latency
+- **Smaller batches**: Lower latency, more requests
 
 ### `max_batch_interval`
 
@@ -208,8 +208,8 @@ export "traces" {
 
 **Behavior:**
 
-* Batch is exported when it reaches `max_batch_size` OR `max_batch_interval` (whichever comes first)
-* Prevents indefinite waiting for partial batches
+- Batch is exported when it reaches `max_batch_size` OR `max_batch_interval` (whichever comes first)
+- Prevents indefinite waiting for partial batches
 
 ### `max_queue_size`
 
@@ -246,10 +246,10 @@ export "traces" {
 
 **Queue Behavior:**
 
-* Acts as buffer during temporary collector unavailability or slow exports
-* When the queue is full, new spans are **dropped** (OpenTelemetry uses non-blocking send); export workers send batches and may block on the network call up to the configured timeout
-* Default (32768) buffers on the order of seconds at high throughput (e.g. ~6s at 5K flows/sec); increase for burst tolerance
-* Monitor `mermin_export_flow_spans_total{exporter="otlp",status="error"}` and `mermin_export_timeouts_total` for export health
+- Acts as buffer during temporary collector unavailability or slow exports
+- When the queue is full, new spans are **dropped** (OpenTelemetry uses non-blocking send); export workers send batches and may block on the network call up to the configured timeout
+- Default (32768) buffers on the order of seconds at high throughput (e.g. ~6s at 5K flows/sec); increase for burst tolerance
+- Monitor `mermin_export_flow_spans_total{exporter="otlp",status="error"}` and `mermin_export_timeouts_total` for export health
 
 ### `max_concurrent_exports`
 
@@ -638,14 +638,14 @@ export "traces" {
 - `mermin_pipeline_duration_seconds{stage="export_out"}` - Export-stage latency
 - `mermin_channel_sends_total{channel="decorator_output",status="error"}` - Channel send failures (indicates dropped spans)
 
-See the [Application Metrics](../observability/app-metrics.md) guide for complete Prometheus query examples.
+See the [Internal Metrics](../observability/app-metrics.md) guide for complete Prometheus query examples.
 
 ### Healthy Indicators
 
-* Zero or minimal export errors
-* Queue size well below max
-* Export latency < timeout
-* No channel send errors
+- Zero or minimal export errors
+- Queue size well below max
+- Export latency < timeout
+- No channel send errors
 
 ## Troubleshooting
 
@@ -696,6 +696,6 @@ See the [Application Metrics](../observability/app-metrics.md) guide for complet
 
 ## Next Steps
 
-* [**Stdout Exporter**](export-stdout.md): Configure console output for debugging
-* [**Observability Backends**](../observability/backends.md): Set up collector and connect to backends
-* [**Troubleshooting**](../troubleshooting/troubleshooting.md): Diagnose problems
+- [**Stdout Exporter**](export-stdout.md): Configure console output for debugging
+- [**Observability Backends**](../observability/backends.md): Set up collector and connect to backends
+- [**Troubleshooting**](../troubleshooting/troubleshooting.md): Diagnose problems

--- a/docs/configuration/export-stdout.md
+++ b/docs/configuration/export-stdout.md
@@ -1,4 +1,4 @@
-# Stdout Exporter
+# Configure the Stdout Exporter
 
 The stdout exporter outputs flow records directly to the console (standard output), making it ideal for development, debugging, and initial testing of Mermin.
 
@@ -61,7 +61,7 @@ export "traces" {
 
 The `text_indent` format provides structured, readable output:
 
-```
+```text
 Flow Record:
   Timestamp: 2025-10-27T15:30:45.123Z
   Duration: 15.234s

--- a/docs/configuration/filtering.md
+++ b/docs/configuration/filtering.md
@@ -1,4 +1,4 @@
-# Flow Filtering
+# Configure Agent Pipeline Filters
 
 **Block:** `filter.source`/`filter.destination`/`filter.network`/`filter.flow`
 
@@ -13,11 +13,11 @@ Mermin supports filtering flows by:
 
 A full configuration example can be found in the [Default Configuration](./default/config.hcl).
 
-# Configuration
+## Configuration
 
-## `match`/`not_match` patterns
+### `match`/`not_match` patterns
 
-**Type:** List of strings  
+**Type:** List of strings
 **Default:** `[]`
 
 Mermin uses simple match patterns:
@@ -49,12 +49,12 @@ The patterns support multiple forms
   - `close_wait`: Connection states
   - `eth*`: Interface names
 
-## `filter.source` and `filter.destination` filters
+### `filter.source` and `filter.destination` filters
 
 The filters apply to the `source`/`destination` combination of the `address` and `port` in the flow span.
 Filter is applied at the "Flow Producer" stage ([architecture](../getting-started/architecture.md#components)), which can help reduce resource usage in subsequent stages.
 
-### `address`
+#### `address`
 
 Filter by IP address.
 
@@ -73,7 +73,7 @@ Filter by IP address.
   }
   ```
 
-### `port`
+#### `port`
 
 Filter by port.
 
@@ -101,7 +101,7 @@ Filter by port.
   }
   ```
 
-### Notes
+#### Notes
 
 Result of the `filter.source`/`filter.destination` inclusion/exclusion is combined with an "AND" condition, meaning it is very easy to accidentally exclude flows you want to observe. For example:
 
@@ -158,12 +158,12 @@ Result of the `filter.source`/`filter.destination` inclusion/exclusion is combin
   ]
   ```
 
-## `filter.network` filter
+### `filter.network` filter
 
 The filter applies to various network attributes in the flow span, such as transport protocol, interface, and others.
 Filter is applied at the "Flow Producer" stage ([architecture](../getting-started/architecture.md#components)), which can help reduce resource usage in subsequent stages.
 
-### `transport`
+#### `transport`
 
 Filter by transport protocol.
 
@@ -191,7 +191,7 @@ Filter by transport protocol.
   }
   ```
 
-### `type`
+#### `type`
 
 Filter by IP version.
 
@@ -209,7 +209,7 @@ Filter by IP version.
   }
   ```
 
-### `interface_name`
+#### `interface_name`
 
 Filter by network interface name.
 
@@ -237,7 +237,7 @@ Filter by network interface name.
   }
   ```
 
-### `interface_index`
+#### `interface_index`
 
 Filter by network interface index.
 
@@ -265,7 +265,7 @@ Filter by network interface index.
   }
   ```
 
-### `interface_mac`
+#### `interface_mac`
 
 Filter by network interface MAC address.
 
@@ -283,12 +283,12 @@ Filter by network interface MAC address.
   }
   ```
 
-## `filter.flow` filters
+### `filter.flow` filters
 
 The filter applies to various flow attributes in the flow span, such as connection state, TCP flags and others.
 Filter is applied at the "Flow Producer" stage ([architecture](../getting-started/architecture.md#components)), which can help reduce resource usage in subsequent stages.
 
-### `connection_state`
+#### `connection_state`
 
 Filter by TCP connection state.
 
@@ -306,7 +306,7 @@ Filter by TCP connection state.
   }
   ```
 
-### `tcp_flags`
+#### `tcp_flags`
 
 Filter by TCP flags.
 
@@ -324,7 +324,7 @@ Filter by TCP flags.
   }
   ```
 
-### `ip_dscp_name`
+#### `ip_dscp_name`
 
 Filter flows based on the DSCP ([Differentiated Services Code Point](https://en.wikipedia.org/wiki/Differentiated_services#Configuration_guidelines)) names
 
@@ -333,7 +333,7 @@ Filter flows based on the DSCP ([Differentiated Services Code Point](https://en.
 **Examples:**
 
 - Include only low-latency data (`AF21`)
-  
+
   ```hcl
   filter "flow" {
     ip_dscp_name = { match = ["AF21"] }
@@ -341,14 +341,14 @@ Filter flows based on the DSCP ([Differentiated Services Code Point](https://en.
   ```
 
 - Exclude multimedia conferencing (`AF41`, `AF42` `AF43`)
-  
+
   ```hcl
   filter "flow" {
     ip_dscp_name = { match = ["AF4{1,2,3}"] }
   }
   ```
 
-### `ip_ecn_name`
+#### `ip_ecn_name`
 
 Filter flows based on ECN ([Explicit Congestion Notification](https://en.wikipedia.org/wiki/Explicit_congestion_notification)) values
 
@@ -357,7 +357,7 @@ Filter flows based on ECN ([Explicit Congestion Notification](https://en.wikiped
 **Examples:**
 
 - Include only ECN-capable transport (`ECT0`, `ECT1`)
-  
+
   ```hcl
   filter "flow" {
     ip_ecn_name = { match = ["ECT?"] }
@@ -365,14 +365,14 @@ Filter flows based on ECN ([Explicit Congestion Notification](https://en.wikiped
   ```
 
 - Exclude congestion encountered (`CE`)
-  
+
   ```hcl
   filter "flow" {
     ip_ecn_name = { not_match = ["CE"] }
   }
   ```
 
-### `ip_ttl`
+#### `ip_ttl`
 
 Filter flows based on the IP TTL ([Time To Live](https://en.wikipedia.org/wiki/Time_to_live)) values
 
@@ -381,7 +381,7 @@ Filter flows based on the IP TTL ([Time To Live](https://en.wikipedia.org/wiki/T
 **Examples:**
 
 - Include only packets with the TTL `1` and `64` to `128`
-  
+
   ```hcl
   filter "flow" {
     ip_ttl = { match = ["1", "64-184"] }
@@ -389,14 +389,14 @@ Filter flows based on the IP TTL ([Time To Live](https://en.wikipedia.org/wiki/T
   ```
 
 - Exclude packets with the TTL `64`
-  
+
   ```hcl
   filter "flow" {
     ip_ttl = { not_match = ["64"] }
   }
   ```
 
-### `ipv6_flow_label`
+#### `ipv6_flow_label`
 
 Filter flows based on IPv6 [flow labels](https://www.rfc-editor.org/rfc/rfc6437.html)
 
@@ -405,7 +405,7 @@ Filter flows based on IPv6 [flow labels](https://www.rfc-editor.org/rfc/rfc6437.
 **Examples:**
 
 - Include only flows with label 12345
-  
+
   ```hcl
   filter "flow" {
     ipv6_flow_label = { match = ["12345"] }
@@ -413,14 +413,14 @@ Filter flows based on IPv6 [flow labels](https://www.rfc-editor.org/rfc/rfc6437.
   ```
 
 - Exclude flows with labels in a range
-  
+
   ```hcl
   filter "flow" {
     ipv6_flow_label = { not_match = ["12345-12545"] }
   }
   ```
 
-### `icmp_type_name`
+#### `icmp_type_name`
 
 Filter flows based on [ICMP type](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml) names (converted to a [snake case](https://en.wikipedia.org/wiki/Snake_case))
 
@@ -429,7 +429,7 @@ Filter flows based on [ICMP type](https://www.iana.org/assignments/icmp-paramete
 **Examples:**
 
 - Include only echo requests
-  
+
   ```hcl
   filter "flow" {
     icmp_type_name = { match = ["echo_request"] }
@@ -437,14 +437,14 @@ Filter flows based on [ICMP type](https://www.iana.org/assignments/icmp-paramete
   ```
 
 - Exclude destination unreachable
-  
+
   ```hcl
   filter "flow" {
     icmp_type_name = { not_match = ["destination_unreachable"] }
   }
   ```
 
-### `icmp_code`
+#### `icmp_code`
 
 Filter flows based on [ICMP codes](https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml)
 
@@ -453,7 +453,7 @@ Filter flows based on [ICMP codes](https://www.iana.org/assignments/icmp-paramet
 **Examples:**
 
 - Include codes from `0` to `8` and `13`
-  
+
   ```hcl
   filter "flow" {
     icmp_code = { match = ["0-8", "13"] }
@@ -461,16 +461,16 @@ Filter flows based on [ICMP codes](https://www.iana.org/assignments/icmp-paramet
   ```
 
 - Exclude code `3`
-  
+
   ```hcl
   filter "flow" {
     icmp_code = { not_match = ["3"] }
   }
   ```
 
-# Common Filtering Scenarios
+## Common Filtering Scenarios
 
-## HTTP/HTTPS Only
+### HTTP/HTTPS Only
 
 Following configuration captures flows with HTTP/HTTPS destination.
 
@@ -496,9 +496,9 @@ Example flows:
 ]
 ```
 
-## Exclude Internal Traffic
+### Exclude Internal Traffic
 
-Following configuration captures flows originated from non-local 
+Following configuration captures flows originated from non-local
 
 ```hcl
 filter "source" {
@@ -519,7 +519,7 @@ filter "source" {
 ]
 ```
 
-## TCP Only, Established Connections
+### TCP Only, Established Connections
 
 Following configuration captures flows for established TCP connections
 
@@ -537,7 +537,7 @@ filter "flow" {
 }
 ```
 
-# Best Practices
+## Best Practices
 
 1. **Start permissive**: Begin with no filters, add as needed
 2. **Monitor impact**: Check flow reduction with metrics
@@ -545,7 +545,7 @@ filter "flow" {
 4. **Document rationale**: Comment why filters are applied
 5. **Use `match`/`not_match` carefully**: Match patterns can hide important traffic
 
-# Next Steps
+## Next Steps
 
 - [**Configuration Examples**](examples.md): See complete filter configurations
 - [**Flow Span Options**](span.md): Configure flow generation

--- a/docs/configuration/global-options.md
+++ b/docs/configuration/global-options.md
@@ -1,4 +1,4 @@
-# Global Options
+# Configure Global Agent Options
 
 Global options are top-level configuration settings that control Mermin's overall behavior. These are the only options that can be configured via CLI flags or environment variables in addition to the configuration file.
 
@@ -73,17 +73,17 @@ export MERMIN_CONFIG_AUTO_RELOAD=true
 
 **Behavior:**
 
-* File is monitored for changes using filesystem watches
-* Configuration is reloaded atomically
-* Brief pause in flow capture during reload (\~100ms)
-* Invalid configuration prevents reload (old config remains active)
-* Logs indicate successful/failed reload attempts
+- File is monitored for changes using filesystem watches
+- Configuration is reloaded atomically
+- Brief pause in flow capture during reload (\~100ms)
+- Invalid configuration prevents reload (old config remains active)
+- Logs indicate successful/failed reload attempts
 
 **Use Cases:**
 
-* Development and testing: Iterate quickly without restarts
-* Production: Update configuration without downtime
-* Debugging: Temporarily change log levels or filters
+- Development and testing: Iterate quickly without restarts
+- Production: Update configuration without downtime
+- Debugging: Temporarily change log levels or filters
 
 {% hint style="warning" %}
 Some configuration changes may require a full restart, such as changing monitored network interfaces or modifying RBAC permissions.
@@ -97,11 +97,11 @@ Sets the logging verbosity level.
 
 **Valid Values:**
 
-* `trace`: Most verbose, includes all debug information
-* `debug`: Detailed debugging information
-* `info`: General informational messages (default)
-* `warn`: Warning messages only
-* `error`: Error messages only
+- `trace`: Most verbose, includes all debug information
+- `debug`: Detailed debugging information
+- `info`: General informational messages (default)
+- `warn`: Warning messages only
+- `error`: Error messages only
 
 **HCL:**
 
@@ -123,9 +123,9 @@ export MERMIN_LOG_LEVEL=warn
 
 **Recommendations:**
 
-* **Production:** `info` or `warn` to reduce log volume
-* **Debugging:** `debug` for detailed troubleshooting
-* **Development:** `trace` for comprehensive visibility
+- **Production:** `info` or `warn` to reduce log volume
+- **Debugging:** `debug` for detailed troubleshooting
+- **Development:** `trace` for comprehensive visibility
 
 ### `shutdown_timeout`
 
@@ -148,13 +148,13 @@ shutdown_timeout = "10s"
 
 **Recommendations:**
 
-* **Production:** `10s` to ensure flows are exported
-* **Development:** `5s` (default) is usually sufficient
-* **High-throughput:** Increase to `30s` or more
+- **Production:** `10s` to ensure flows are exported
+- **Development:** `5s` (default) is usually sufficient
+- **High-throughput:** Increase to `30s` or more
 
 **Related Settings:**
 
-* `export.otlp.max_export_timeout`: Should be less than `shutdown_timeout`
+- `export.otlp.max_export_timeout`: Should be less than `shutdown_timeout`
 
 ## Monitoring Shutdown Behavior
 
@@ -186,7 +186,8 @@ Capacity for each worker thread's event queue. Determines how many raw eBPF even
 | Very High (> 100K flows/s) | 4096+             |
 
 **Signs You Need to Increase:**
-* Metrics show `mermin_flow_events_total{status="dropped_backpressure"}` increasing
+
+- Metrics show `mermin_flow_events_total{status="dropped_backpressure"}` increasing
 
 **Tuning Guidelines:**
 
@@ -198,7 +199,8 @@ Capacity for each worker thread's event queue. Determines how many raw eBPF even
 | > 100,000                  | 262144+           |
 
 **Signs You Need to Increase:**
-* High CPU usage during startup or traffic spikes (due to map resizing)
+
+- High CPU usage during startup or traffic spikes (due to map resizing)
 
 ### `worker_count`
 
@@ -209,10 +211,10 @@ Number of parallel worker threads processing packets and generating flow spans. 
 
 **Behavior:**
 
-* Each worker processes packets independently
-* More workers = more parallelism = higher throughput
-* More workers = more CPU usage
-* Workers share the flow table (synchronized)
+- Each worker processes packets independently
+- More workers = more parallelism = higher throughput
+- More workers = more CPU usage
+- Workers share the flow table (synchronized)
 
 **Tuning Guidelines:**
 
@@ -225,10 +227,10 @@ Number of parallel worker threads processing packets and generating flow spans. 
 
 **Optimal Worker Count:**
 
-* Start with CPU count / 2
-* Monitor CPU usage with metrics
-* Increase if CPU is underutilized and packet drops occur
-* Decrease if CPU is overutilized
+- Start with CPU count / 2
+- Monitor CPU usage with metrics
+- Increase if CPU is underutilized and packet drops occur
+- Decrease if CPU is overutilized
 
 **Relationship with CPU Resources:**
 
@@ -248,49 +250,50 @@ resources:
 
 Interval at which flow pollers check for flow records and timeouts. Pollers iterate through active flows to:
 
-* Generate periodic flow records (based on `max_record_interval` in `span` config)
-* Detect and remove idle flows (based on protocol-specific timeouts in `span` config)
+- Generate periodic flow records (based on `max_record_interval` in `span` config)
+- Detect and remove idle flows (based on protocol-specific timeouts in `span` config)
 
 **Behavior:**
 
-* Lower values = more responsive timeout detection and flow recording
-* Higher values = less CPU overhead
-* At typical enterprise scale (10K flows/sec with 100K active flows and 32 pollers): ~600 flow checks/sec per poller
-* Modern CPUs handle flow checking very efficiently (microseconds per check)
+- Lower values = more responsive timeout detection and flow recording
+- Higher values = less CPU overhead
+- At typical enterprise scale (10K flows/sec with 100K active flows and 32 pollers): ~600 flow checks/sec per poller
+- Modern CPUs handle flow checking very efficiently (microseconds per check)
 
 **Tuning Guidelines:**
 
-| Traffic Pattern | Recommended Interval | Rationale |
-|-----------------|---------------------|-----------|
-| Short-lived flows (ICMP) | 3-5s | Fast timeout detection |
-| Mixed traffic | 5s (default) | Balance responsiveness and overhead |
-| Long-lived flows (TCP) | 10s | Lower overhead, slower timeouts |
-| Memory constrained | 3-5s | More frequent cleanup |
+| Traffic Pattern          | Recommended Interval | Rationale                           |
+|--------------------------|----------------------|-------------------------------------|
+| Short-lived flows (ICMP) | 3-5s                 | Fast timeout detection              |
+| Mixed traffic            | 5s (default)         | Balance responsiveness and overhead |
+| Long-lived flows (TCP)   | 10s                  | Lower overhead, slower timeouts     |
+| Memory constrained       | 3-5s                 | More frequent cleanup               |
 
 **Trade-offs:**
 
-* **3s interval**: Most responsive, slightly higher CPU (~10K checks/sec per poller)
-* **5s interval** (default): Best balance for most workloads
-* **10s interval**: Lowest CPU, flows may linger longer before timeout
+- **3s interval**: Most responsive, slightly higher CPU (~10K checks/sec per poller)
+- **5s interval** (default): Best balance for most workloads
+- **10s interval**: Lowest CPU, flows may linger longer before timeout
 
 **Signs You Should Decrease:**
 
-* Flows lingering past their intended timeout
-* Memory usage growing steadily
-* Short-lived flow protocols (ICMP with 10s timeout)
+- Flows lingering past their intended timeout
+- Memory usage growing steadily
+- Short-lived flow protocols (ICMP with 10s timeout)
 
 **Signs You Can Increase:**
 
-* CPU constrained
-* Primarily long-lived TCP flows
-* Flow timeout accuracy not critical
+- CPU constrained
+- Primarily long-lived TCP flows
+- Flow timeout accuracy not critical
 
 ### `k8s_decorator.threads`
 
 **Type:** Integer
 **Default:** `4`
 
-Number of dedicated threads for Kubernetes metadata decoration. Running decoration on separate threads prevents K8s API lookups from blocking flow processing. Each thread handles ~8K flows/sec (~100-150μs per flow), so 4 threads provide 32K flows/sec capacity.
+Number of dedicated threads for Kubernetes metadata decoration. Running decoration on separate threads prevents K8s API lookups from blocking flow processing. Each thread handles ~8K flows/sec (~100-150μs per flow),
+so 4 threads provide 32K flows/sec capacity.
 
 **Recommendations based on typical FPS (flows per second):**
 
@@ -315,22 +318,23 @@ Explicit capacity for the flow span channel. Provides buffering between workers 
 
 **Recommendations:**
 
-* **Steady traffic**: `16384` (default)
-* **Bursty traffic**: `24576`-`32768`
-* **Low latency priority**: `12288`
+- **Steady traffic**: `16384` (default)
+- **Bursty traffic**: `24576`-`32768`
+- **Low latency priority**: `12288`
 
 #### `k8s_decorator.decorated_span_queue_capacity`
 
 **Type:** Integer
 **Default:** `32768`
 
-Explicit capacity for the decorated span (export) channel. Provides buffering between K8s decorator and OTLP exporter. This should be the largest buffer since network export is the slowest stage. With defaults (32,768 slots, ~320ms buffer at 100K/s).
+Explicit capacity for the decorated span (export) channel. Provides buffering between K8s decorator and OTLP exporter. This should be the largest buffer since network export is the slowest stage.
+With defaults (32,768 slots, ~320ms buffer at 100K/s).
 
 **Recommendations:**
 
-* **Reliable network**: `32768` (default)
-* **Unreliable network**: `49152`-`65536`
-* **Very high throughput**: `65536`-`98304`
+- **Reliable network**: `32768` (default)
+- **Unreliable network**: `49152`-`65536`
+- **Very high throughput**: `65536`-`98304`
 
 ### Monitoring Performance Configuration
 
@@ -341,18 +345,18 @@ After tuning performance settings, monitor these key metrics:
 - `mermin_channel_size` / `mermin_channel_capacity` - Channel utilization
 - `mermin_pipeline_duration_seconds` - Pipeline duration histogram
 
-See the [Application Metrics](../observability/app-metrics.md) guide for complete Prometheus query examples.
+See the [Internal Metrics](../observability/app-metrics.md) guide for complete Prometheus query examples.
 
 **Healthy indicators:**
 
-* Sampling rate = 0 (no backpressure)
-* Channel utilization < 80%
-* p95 processing latency < 10ms
-* IP index updates < 100ms
+- Sampling rate = 0 (no backpressure)
+- Channel utilization < 80%
+- p95 processing latency < 10ms
+- IP index updates < 100ms
 
 ## Next Steps
 
-* [**API**](api.md) and [**Metrics**](metrics.md): Configure health checks and monitoring
-* [**Network Interface Discovery**](discovery-instrument.md): Select which interfaces to monitor
-* [**Flow Span Options**](span.md): Configure flow generation and timeouts
-* [**Configuration Examples**](examples.md): See complete configurations
+- [**API**](api.md) and [**Metrics**](metrics.md): Configure health checks and monitoring
+- [**Network Interface Discovery**](discovery-instrument.md): Select which interfaces to monitor
+- [**Flow Span Options**](span.md): Configure flow generation and timeouts
+- [**Configuration Examples**](examples.md): See complete configurations

--- a/docs/configuration/internal-tracing.md
+++ b/docs/configuration/internal-tracing.md
@@ -1,6 +1,7 @@
-# Internal Tracing
+# Configure the Internal Tracing Exporter
 
-This page documents the `internal "traces"` configuration (config path: `internal.traces`), which controls how Mermin exports its own telemetry data for self-monitoring and debugging. Mermin accepts HCL or YAML; the examples below use HCL (see [Configuration Overview](configuration.md#file-format) for format details).
+This page documents the `internal "traces"` configuration (config path: `internal.traces`), which controls how Mermin exports its own telemetry data for self-monitoring and debugging.
+Mermin accepts HCL or YAML; the examples below use HCL (see [Configuration Overview](configuration.md#file-format) for format details).
 
 ## Overview
 
@@ -164,7 +165,7 @@ internal "traces" {
 
 ### eBPF Program Loading
 
-```
+```text
 Span: load_ebpf_program
   Start: 2025-10-27T15:30:00.000Z
   Duration: 250ms
@@ -179,7 +180,7 @@ Span: load_ebpf_program
 
 ### Flow Processing
 
-```
+```text
 Span: process_packet
   Start: 2025-10-27T15:30:01.234Z
   Duration: 0.5ms
@@ -195,7 +196,7 @@ Span: process_packet
 
 ### Kubernetes Informer Sync
 
-```
+```text
 Span: sync_k8s_informers
   Start: 2025-10-27T15:30:05.000Z
   Duration: 2.5s
@@ -297,7 +298,8 @@ This is the default and recommended for most deployments.
 
 1. Send internal traces to a different endpoint than flow traces (e.g. separate OTLP collectors)
 2. Use different collector instances for internal vs flow export
-3. Filter by span name or attributes in your backend: both internal and flow traces use `service.name="mermin"`, so distinguish them by span name (e.g. internal spans like `load_ebpf_program`, `process_packet`, `sync_k8s_informers` vs flow span names from your flow data)
+3. Filter by span name or attributes in your backend: both internal and flow traces use `service.name="mermin"`,
+   so distinguish them by span name (e.g. internal spans like `load_ebpf_program`, `process_packet`, `sync_k8s_informers` vs flow span names from your flow data)
 
 ## Best Practices
 

--- a/docs/configuration/metrics.md
+++ b/docs/configuration/metrics.md
@@ -1,4 +1,4 @@
-# Metrics
+# Configure the Internal Prometheus Metrics
 
 Mermin provides Prometheus metrics HTTP endpoints (default port `10250`). This page documents metrics configuration.
 Endpoints available:
@@ -98,7 +98,8 @@ internal "metrics" {
 
 ## Histogram Bucket Configuration
 
-Mermin provides several histogram metrics that track distributions of values (durations, batch sizes, etc.). By default, these metrics use pre-configured bucket sizes optimized for typical workloads. You can customize these bucket sizes inside a `histogram_buckets` block, with options named after the metric they configure.
+Mermin provides several histogram metrics that track distributions of values (durations, batch sizes, etc.). By default, these metrics use pre-configured bucket sizes optimized for typical workloads.
+You can customize these bucket sizes inside a `histogram_buckets` block, with options named after the metric they configure.
 
 ### `histogram_buckets` block
 
@@ -181,9 +182,9 @@ For production environments:
 2. Do not expose metrics endpoints externally
 3. Use port-forwarding for manual access: `kubectl port-forward pod/mermin-xxx 10250:10250`
 
-# Troubleshooting
+## Troubleshooting
 
-## Metrics Not Scraped by Prometheus
+### Metrics Not Scraped by Prometheus
 
 **Symptoms:** No Mermin metrics in Prometheus
 
@@ -195,7 +196,7 @@ For production environments:
 4. Test manual scrape: `curl http://pod-ip:10250/metrics`
 5. Check network policies
 
-### High Metrics Cardinality
+#### High Metrics Cardinality
 
 **Symptoms:** Too many unique metric series
 
@@ -207,4 +208,4 @@ For production environments:
 
 ## Next Steps
 
-- [**Mermin Application Metrics**](../observability/app-metrics.md): Mermin metrics documentation
+- [**Mermin Internal Metrics**](../observability/app-metrics.md): Mermin metrics documentation

--- a/docs/configuration/owner-relations.md
+++ b/docs/configuration/owner-relations.md
@@ -1,10 +1,12 @@
-# Owner Relations
+# Configure Kubernetes Owner Relations
 
-Owner relations control how Mermin walks Kubernetes owner references to enrich flows with workload controller metadata (Deployment, StatefulSet, etc.). Mermin accepts HCL or YAML for the config file; the examples below use HCL (see [Configuration Overview](configuration.md#file-format) for format details).
+Owner relations control how Mermin walks Kubernetes owner references to enrich flows with workload controller metadata (Deployment, StatefulSet, etc.).
+Mermin accepts HCL or YAML for the config file; the examples below use HCL (see [Configuration Overview](configuration.md#file-format) for format details).
 
 ## Overview
 
-Kubernetes resources have owner references forming a chain: Pod → ReplicaSet → Deployment → ... Mermin can walk this chain and attach metadata from owners to network flows. Owner relations apply when Kubernetes discovery is enabled (`discovery "informer" "k8s"`).
+Kubernetes resources have owner references forming a chain: Pod → ReplicaSet → Deployment → ... Mermin can walk this chain and attach metadata from owners to network flows.
+Owner relations apply when Kubernetes discovery is enabled (`discovery "informer" "k8s"`).
 
 ## Configuration
 

--- a/docs/configuration/parser.md
+++ b/docs/configuration/parser.md
@@ -1,4 +1,4 @@
-# Parser Configuration
+# Configure the Network Packet Parser
 
 The parser configuration controls how Mermin's eBPF programs detect and parse tunneled traffic by specifying UDP ports for VXLAN, Geneve, and WireGuard.
 
@@ -423,9 +423,9 @@ If your environment uses multiple ports for the same tunnel protocol (e.g., mult
 
 ## Next Steps
 
-* [**Configuration Overview**](configuration.md): Config file format and structure
-* [**Network Interface Discovery**](discovery-instrument.md): Configure which interfaces to monitor
-* [**Flow Filtering**](filtering.md): Filter flows based on protocols and ports
-* [**Deployment Issues**](../troubleshooting/deployment-issues.md): Troubleshoot eBPF verifier failures
-* [**Troubleshooting**](../troubleshooting/troubleshooting.md): Diagnose flow capture issues
-* [**Advanced Scenarios**](../deployment/advanced-scenarios.md): CNI-specific deployment guides
+- [**Configuration Overview**](configuration.md): Config file format and structure
+- [**Network Interface Discovery**](discovery-instrument.md): Configure which interfaces to monitor
+- [**Flow Filtering**](filtering.md): Filter flows based on protocols and ports
+- [**Deployment Issues**](../troubleshooting/deployment-issues.md): Troubleshoot eBPF verifier failures
+- [**Troubleshooting**](../troubleshooting/troubleshooting.md): Diagnose flow capture issues
+- [**Advanced Scenarios**](../deployment/advanced-scenarios.md): CNI-specific deployment guides

--- a/docs/configuration/pipeline.md
+++ b/docs/configuration/pipeline.md
@@ -1,4 +1,4 @@
-# Pipeline Configuration
+# Configure the Agent's Flow Processing Pipeline
 
 The `pipeline` block provides advanced configuration for flow processing pipeline optimization, including channel capacity tuning, worker threading, Kubernetes decoration, backpressure management, and buffer multipliers.
 
@@ -37,6 +37,7 @@ pipeline {
 The capacity of the `FLOW_STATS` eBPF map. See [eBPF Programs](../getting-started/architecture.md#ebpf-programs) in the architecture documentation for more information.
 
 **Example:**
+
 ```hcl
 pipeline {
   flow_capture {
@@ -49,15 +50,18 @@ pipeline {
 
 **Type:** Integer (entries) **Default:** `1024`
 
-The capacity of the `FLOW_EVENTS` ring buffer as number of entries. Each entry is 234 bytes (FlowEvent size), so the default 1024 entries equals ~240 KB. This buffer is used to pass new flow events from eBPF to userspace. Keep the buffer high enough to provide flow record burst tolerance.
+The capacity of the `FLOW_EVENTS` ring buffer as number of entries. Each entry is 234 bytes (FlowEvent size), so the default 1024 entries equals ~240 KB. This buffer is used to pass new flow events from eBPF to userspace.
+Keep the buffer high enough to provide flow record burst tolerance.
 
 **Sizing Guide** (based on flows per second):
+
 - **General/Mixed** (50-500 FPS): `1024` entries (~240 KB)
 - **High Traffic** (500-2K FPS): `2048` entries (~480 KB)
 - **Very High Traffic** (2K-5K FPS): `4096` entries (~960 KB)
 - **Extreme Traffic** (>5K FPS): `8192+` entries (~1.9 MB+)
 
 **Example:**
+
 ```hcl
 pipeline {
   flow_capture {
@@ -75,6 +79,7 @@ pipeline {
 The number of parallel flow worker threads. Adjust this value based on the available CPU resources.
 
 **Example:**
+
 ```hcl
 pipeline {
   flow_producer {
@@ -90,6 +95,7 @@ pipeline {
 Capacity for each worker thread's event queue. Determines how many raw eBPF events can be buffered per worker before drops occur.
 
 **Example:**
+
 ```hcl
 pipeline {
   flow_producer {
@@ -102,9 +108,11 @@ pipeline {
 
 **Type:** String (duration) **Default:** `"5s"`
 
-The polling interval for flow workers. This controls how frequently workers poll the flow data from the `FLOW_STATS` map. See [eBPF Programs](../getting-started/architecture.md#ebpf-programs) in the architecture documentation for more information. Reducing the interval may increase CPU usage.
+The polling interval for flow workers. This controls how frequently workers poll the flow data from the `FLOW_STATS` map.See [eBPF Programs](../getting-started/architecture.md#ebpf-programs) in the architecture documentation for more information.
+Reducing the interval may increase CPU usage.
 
 **Example:**
+
 ```hcl
 pipeline {
   flow_producer {
@@ -120,6 +128,7 @@ pipeline {
 Explicit capacity for the flow span channel, acting as a buffer between workers and the K8s decorator. With default settings, this provides approximately 1.6s of buffer at 10,000 flows/sec.
 
 **Example:**
+
 ```hcl
 pipeline {
   flow_producer {
@@ -137,6 +146,7 @@ pipeline {
 The number of threads dedicated to Kubernetes decoration. Increase this value for larger clusters.
 
 **Example:**
+
 ```hcl
 pipeline {
   k8s_decorator {
@@ -152,6 +162,7 @@ pipeline {
 Explicit capacity for the decorated span channel, acting as a buffer between the K8s decorator and the exporter. With default settings, this provides approximately 3.2s of buffer at 10,000 flows/sec.
 
 **Example:**
+
 ```hcl
 pipeline {
   k8s_decorator {
@@ -162,8 +173,8 @@ pipeline {
 
 ## Next Steps
 
-* [**Configuration Overview**](configuration.md): Config file format and structure
-* [**Architecture**](../getting-started/architecture.md): Data flow and eBPF programs
-* [**Span Options**](span.md): Flow timeouts and span generation
-* [**OTLP Exporter**](export-otlp.md): Export tuning and backpressure
-* [**Configuration Examples**](examples.md): Full pipeline examples (production, high-throughput)
+- [**Configuration Overview**](configuration.md): Config file format and structure
+- [**Architecture**](../getting-started/architecture.md): Data flow and eBPF programs
+- [**Span Options**](span.md): Flow timeouts and span generation
+- [**OTLP Exporter**](export-otlp.md): Export tuning and backpressure
+- [**Configuration Examples**](examples.md): Full pipeline examples (production, high-throughput)

--- a/docs/configuration/selector-relations.md
+++ b/docs/configuration/selector-relations.md
@@ -1,10 +1,11 @@
-# Selector Relations
+# Configure Kubernetes Selector Relations
 
 Selector relations enable matching Kubernetes resources based on label selectors, such as NetworkPolicy → Pod or Service → Pod associations.
 
 ## Overview
 
-Many Kubernetes resources use selectors to target other resources. Mermin can extract these selectors and find matching resources to enrich flow metadata. The resulting relations are used for flow and span enrichment; enable the corresponding associations in [Flow Attributes](attributes.md) (e.g. `networkpolicy`, `service`) to see this metadata on flows.
+Many Kubernetes resources use selectors to target other resources. Mermin can extract these selectors and find matching resources to enrich flow metadata.
+The resulting relations are used for flow and span enrichment; enable the corresponding associations in [Flow Attributes](attributes.md) (e.g. `networkpolicy`, `service`) to see this metadata on flows.
 
 ## Configuration
 
@@ -144,5 +145,5 @@ discovery "informer" "k8s" {
 
 ## Next Steps
 
-* [**Flow Attributes**](attributes.md): Configure metadata extraction and enable associations (e.g. `networkpolicy`, `service`) so selector-based metadata appears on flows
-* [**Owner Relations**](owner-relations.md): Configure owner reference walking
+- [**Flow Attributes**](attributes.md): Configure metadata extraction and enable associations (e.g. `networkpolicy`, `service`) so selector-based metadata appears on flows
+- [**Owner Relations**](owner-relations.md): Configure owner reference walking

--- a/docs/configuration/span.md
+++ b/docs/configuration/span.md
@@ -1,6 +1,7 @@
-# Flow Span Options
+# Configure the Flow Span Producer
 
-Mermin groups captured packets into bidirectional flows and exports each flow as an OpenTelemetry span. The `span` block controls when flows are closed and when they emit records, plus Community ID hashing, trace ID correlation, and hostname resolution. Add a top-level `span { }` block in your [configuration file](configuration.md); there are no CLI or environment overrides for span options.
+Mermin groups captured packets into bidirectional flows and exports each flow as an OpenTelemetry span. The `span` block controls when flows are closed and when they emit records,
+plus Community ID hashing, trace ID correlation, and hostname resolution. Add a top-level `span { }` block in your [configuration file](configuration.md); there are no CLI or environment overrides for span options.
 
 Flow semantics (how flows become OpenTelemetry spans and what attributes they carry) are in [Semantic Conventions](../spec/semantic-conventions.md) and [Attribute Reference](../spec/attribute-reference.md).
 
@@ -28,31 +29,31 @@ span {
 
 ### Timeouts and intervals
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `max_record_interval` | duration | `60s` | Maximum time an active flow can run without exporting a record. When this interval is reached, a record is emitted and the flow continues. Long-lived flows are therefore split into multiple spans. |
-| `generic_timeout` | duration | `30s` | Inactivity timeout for protocols that have no dedicated timeout: GRE, ESP, AH, and other IP protocols. After this period with no packets, the flow is closed. Flows with at least one packet are exported; flows with zero packets are dropped. |
-| `icmp_timeout` | duration | `10s` | Inactivity timeout for ICMP (e.g. ping, traceroute). |
-| `tcp_timeout` | duration | `20s` | Inactivity timeout for TCP when no FIN or RST has been seen (connection still open). |
-| `tcp_fin_timeout` | duration | `5s` | After a FIN is seen (graceful close), the flow is exported after this period so final ACKs can be included. |
-| `tcp_rst_timeout` | duration | `5s` | After an RST is seen (abrupt close), the flow is exported after this period. |
-| `udp_timeout` | duration | `60s` | Inactivity timeout for UDP. UDP is connectionless; a longer value suits sporadic traffic. |
+| Option                | Type     | Default | Description                                                                                                                                                                                                                                     |
+|-----------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `max_record_interval` | duration | `60s`   | Maximum time an active flow can run without exporting a record. When this interval is reached, a record is emitted and the flow continues. Long-lived flows are therefore split into multiple spans.                                            |
+| `generic_timeout`     | duration | `30s`   | Inactivity timeout for protocols that have no dedicated timeout: GRE, ESP, AH, and other IP protocols. After this period with no packets, the flow is closed. Flows with at least one packet are exported; flows with zero packets are dropped. |
+| `icmp_timeout`        | duration | `10s`   | Inactivity timeout for ICMP (e.g. ping, traceroute).                                                                                                                                                                                            |
+| `tcp_timeout`         | duration | `20s`   | Inactivity timeout for TCP when no FIN or RST has been seen (connection still open).                                                                                                                                                            |
+| `tcp_fin_timeout`     | duration | `5s`    | After a FIN is seen (graceful close), the flow is exported after this period so final ACKs can be included.                                                                                                                                     |
+| `tcp_rst_timeout`     | duration | `5s`    | After an RST is seen (abrupt close), the flow is exported after this period.                                                                                                                                                                    |
+| `udp_timeout`         | duration | `60s`   | Inactivity timeout for UDP. UDP is connectionless; a longer value suits sporadic traffic.                                                                                                                                                       |
 
 For TCP, the effective timeout is chosen per flow: `tcp_timeout` for established connections with no FIN/RST, `tcp_fin_timeout` once a FIN is seen, and `tcp_rst_timeout` once an RST is seen.
 
 ### Community ID and trace correlation
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `community_id_seed` | integer (uint16) | `0` | Seed for [Community ID](https://github.com/corelight/community-id-spec) hashing of the flow five-tuple. Use the same seed everywhere for correlation across agents and tools. The result is exported as `flow.community_id` ([Attribute Reference](../spec/attribute-reference.md)). |
-| `trace_id_timeout` | duration | `24h` | How long the same Community ID keeps the same trace ID. After this duration without activity, a new trace ID is used. Bounds memory while still allowing correlation across multiple flow records for the same logical flow. |
+| Option              | Type             | Default | Description                                                                                                                                                                                                                                                                          |
+|---------------------|------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `community_id_seed` | integer (uint16) | `0`     | Seed for [Community ID](https://github.com/corelight/community-id-spec) hashing of the flow five-tuple. Use the same seed everywhere for correlation across agents and tools. The result is exported as `flow.community_id` ([Attribute Reference](../spec/attribute-reference.md)). |
+| `trace_id_timeout`  | duration         | `24h`   | How long the same Community ID keeps the same trace ID. Bounds memory while still allowing correlation across flow records for the same logical flow.                                                                                                                                |
 
 ### Hostname resolution
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enable_hostname_resolution` | bool | `true` | When true, `client.address` and `server.address` may be reverse-DNS hostnames instead of IPs ([Attribute Reference](../spec/attribute-reference.md)). |
-| `hostname_resolve_timeout` | duration | `100ms` | Timeout for each reverse-DNS lookup. Results are cached. |
+| Option                       | Type     | Default | Description                                                                                                                                           |
+|------------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `enable_hostname_resolution` | bool     | `true`  | When true, `client.address` and `server.address` may be reverse-DNS hostnames instead of IPs ([Attribute Reference](../spec/attribute-reference.md)). |
+| `hostname_resolve_timeout`   | duration | `100ms` | Timeout for each reverse-DNS lookup. Results are cached.                                                                                              |
 
 ## When a flow span is exported
 
@@ -62,7 +63,9 @@ A flow span is exported when any of these is true:
 2. **Protocol timeout**: No packets for the protocol-specific timeout (generic, ICMP, TCP, or UDP). The flow is closed and removed from the flow table.
 3. **TCP close**: A FIN or RST was seen and the corresponding `tcp_fin_timeout` or `tcp_rst_timeout` has elapsed. The flow is closed and exported.
 
-Exported spans are sent to the targets configured in your export block ([OTLP export](export-otlp.md), [stdout export](export-stdout.md), etc.). Workers poll flow state on an interval defined in [pipeline](pipeline.md) (`flow_producer.flow_store_poll_interval`). The flow table is backed by the eBPF `FLOW_STATS` map and in-memory state; its capacity is set in [pipeline](pipeline.md) (`flow_capture.flow_stats_capacity`).
+Exported spans are sent to the targets configured in your export block ([OTLP export](export-otlp.md), [stdout export](export-stdout.md), etc.).
+Workers poll flow state on an interval defined in [pipeline](pipeline.md) (`flow_producer.flow_store_poll_interval`). The flow table is backed by the eBPF `FLOW_STATS` map and in-memory state;
+its capacity is set in [pipeline](pipeline.md) (`flow_capture.flow_stats_capacity`).
 
 ## Tuning
 
@@ -81,8 +84,11 @@ span {
 }
 ```
 
-For high-throughput or memory-constrained nodes, use longer or shorter timeouts accordingly. To reduce the number of flows tracked, use [flow filters](filtering.md). [Troubleshooting](../troubleshooting/troubleshooting.md) and [Pipeline](pipeline.md) cover backpressure, export tuning, and pipeline sizing.
+For high-throughput or memory-constrained nodes, use longer or shorter timeouts accordingly. To reduce the number of flows tracked,use [flow filters](filtering.md).
+[Troubleshooting](../troubleshooting/troubleshooting.md) and [Pipeline](pipeline.md) cover backpressure, export tuning, and pipeline sizing.
 
 ## Monitoring
 
-Flow and eBPF map metrics are in [Application Metrics](../observability/app-metrics.md): `mermin_flow_spans_active_total`, `mermin_flow_spans_created_total`, and `mermin_ebpf_map_size` / `mermin_ebpf_map_capacity` with `map="FLOW_STATS"`. If the flow table or memory grows without bound, lower timeouts or `max_record_interval`, or reduce tracked flows with [flow filters](filtering.md). If you need more headroom for legitimate load, increase `flow_capture.flow_stats_capacity` in [pipeline](pipeline.md).
+Flow and eBPF map metrics are in [Internal Metrics](../observability/app-metrics.md): `mermin_flow_spans_active_total`, `mermin_flow_spans_created_total`, and `mermin_ebpf_map_size` / `mermin_ebpf_map_capacity` with `map="FLOW_STATS"`.
+If the flow table or memory grows without bound, lower timeouts or `max_record_interval`, or reduce tracked flows with [flow filters](filtering.md). If you need more headroom for legitimate load,
+increase `flow_capture.flow_stats_capacity` in [pipeline](pipeline.md).

--- a/docs/contributor-guide/debugging-network.md
+++ b/docs/contributor-guide/debugging-network.md
@@ -25,9 +25,9 @@ You'll see output similar to this:
 
 | NAME         | READY | STATUS  | RESTARTS | AGE | IP          | NODE               | NOMINATED NODE | READINESS GATES |
 |--------------|-------|---------|----------|-----|-------------|--------------------|----------------|-----------------|
-| mermin-vrxd2 | 1/1   | Running | 0        | 42s | 10.244.0.11 | kind-control-plane | <none>         | <none>          |
-| mermin-8k9x7 | 1/1   | Running | 0        | 42s | 10.244.3.21 | kind-worker        | <none>         | <none>          |
-| mermin-pdsn7 | 1/1   | Running | 0        | 42s | 10.244.1.7  | kind-worker2       | <none>         | <none>          |
+| mermin-vrxd2 | 1/1   | Running | 0        | 42s | 10.244.0.11 | kind-control-plane | \<none\>       | \<none\>        |
+| mermin-8k9x7 | 1/1   | Running | 0        | 42s | 10.244.3.21 | kind-worker        | \<none\>       | \<none\>        |
+| mermin-pdsn7 | 1/1   | Running | 0        | 42s | 10.244.1.7  | kind-worker2       | \<none\>       | \<none\>        |
 
 For this example, we will capture traffic from mermin-vrxd2.
 

--- a/docs/contributor-guide/development-workflow.md
+++ b/docs/contributor-guide/development-workflow.md
@@ -30,11 +30,11 @@ Mermin supports multiple local development workflows depending on your needs:
 
 **Choosing your workflow:**
 
-1. **Bare Metal (Native)**: Requires Linux, but provides instant feedback. Run `cargo build` and execute the binary directly with `sudo`. Ideal for iterating on eBPF programs, packet parsing, and core flow logic. Cannot test Kubernetes metadata enrichment without a cluster.
-
+1. **Bare Metal (Native)**: Requires Linux, but provides instant feedback. Run `cargo build` and execute the binary directly with `sudo`. Ideal for iterating on eBPF programs, packet parsing, and core flow logic.
+   Cannot test Kubernetes metadata enrichment without a cluster.
 2. **Dockerized Build**: Use a Docker container for building to match the CI/CD environment. Useful on macOS or when you need a consistent, reproducible build environment. Slightly slower than native builds but works anywhere Docker runs.
-
-3. **Kubernetes (kind)**: Full integration testing environment. Deploy to a local Kubernetes cluster for testing Kubernetes metadata enrichment, Helm chart configurations, and complete deployment scenarios. Highest setup complexity and slowest iteration cycle, but essential for validating end-to-end functionality.
+3. **Kubernetes (kind)**: Full integration testing environment. Deploy to a local Kubernetes cluster for testing Kubernetes metadata enrichment, Helm chart configurations, and complete deployment scenarios.
+   Highest setup complexity and slowest iteration cycle, but essential for validating end-to-end functionality.
 
 ### 1. Build the `mermin` agent
 
@@ -99,7 +99,8 @@ fmtconvert -from hcl -to yaml charts/mermin/config/examples/config.hcl > local/c
 
 Running the eBPF agent requires elevated privileges. Use the `--config` flag to specify your configuration file.
 
-> **Note**: You can run without a configuration file, but the default settings disable stdout and OTLP exporting, so you won't see any flow trace output. For local development, it's recommended to use atleast a configuration file with stdout exporting enabled (see the minimal config example above).
+> **Note**: You can run without a configuration file, but the default settings disable stdout and OTLP exporting, so you won't see any flow trace output.
+> For local development, it's recommended to use at least a configuration file with stdout exporting enabled (see the minimal config example above).
 
 **Using HCL:**
 
@@ -172,7 +173,7 @@ cargo clippy --all-features -- -D warnings
   ```
 
 - Download Grafana dashboard JSON from a local Grafana instance
-  
+
   ```bash
   # From a local Grafana
   curl -s "localhost:3000/api/dashboards/uid/mermin_app" | jq '.dashboard' | jq -f hack/sanitize_grafana_dashboard.jq > docs/observability/grafana-mermin-app.json
@@ -240,7 +241,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/down
 kubectl -n kube-system patch deployment metrics-server --type='json' -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
 ```
 
-**Optionally install [Prometheus/Grafana](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) to get Mermin metrics:**  
+**Optionally install [Prometheus/Grafana](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) to get Mermin metrics:**
 Not intended for a production usage, Grafana auth is disabled (insecure).
 
 ```sh

--- a/docs/deployment/advanced-scenarios.md
+++ b/docs/deployment/advanced-scenarios.md
@@ -23,10 +23,10 @@ discovery "instrument" {
 
 **Considerations:**
 
-* Cilium's eBPF datapath is separate from Mermin's monitoring
-* Monitor physical interfaces for inter-node traffic
-* Monitor `cilium_*` for intra-node pod-to-pod traffic
-* May see duplicate flows for traffic that crosses nodes
+- Cilium's eBPF datapath is separate from Mermin's monitoring
+- Monitor physical interfaces for inter-node traffic
+- Monitor `cilium_*` for intra-node pod-to-pod traffic
+- May see duplicate flows for traffic that crosses nodes
 
 **Cilium-specific configuration:**
 
@@ -63,10 +63,10 @@ discovery "instrument" {
 
 **Considerations:**
 
-* Calico interfaces are `califxxxxxxxx` format
-* Monitor physical interfaces for most traffic
-* Add `cali*` for intra-node pod-to-pod visibility
-* Be aware of potential flow duplication
+- Calico interfaces are `califxxxxxxxx` format
+- Monitor physical interfaces for most traffic
+- Add `cali*` for intra-node pod-to-pod visibility
+- Be aware of potential flow duplication
 
 ### Flannel
 
@@ -175,7 +175,7 @@ export "traces" {
 
 Regional collectors aggregate to central collector:
 
-```
+```text
 Cluster 1 (us-west-1) ──┐
                         ├──> Regional Collector (us-west) ──┐
 Cluster 2 (us-west-2) ──┘                                   │
@@ -230,10 +230,10 @@ export "traces" {
 
 Mermin agents are resilient by design:
 
-* **DaemonSet**: Automatically restarts failed pods
-* **Node-local**: Failure of one agent doesn't affect others
-* **Stateless**: No data loss on restart (flows are regenerated)
-* **Queue-based**: Buffers flows during temporary collector outages
+- **DaemonSet**: Automatically restarts failed pods
+- **Node-local**: Failure of one agent doesn't affect others
+- **Stateless**: No data loss on restart (flows are regenerated)
+- **Queue-based**: Buffers flows during temporary collector outages
 
 Configure aggressive restart policy:
 
@@ -410,14 +410,14 @@ discovery "instrument" {
 
 **Advantages:**
 
-* No flow duplication
-* Lower resource usage
-* Clearer network topology
+- No flow duplication
+- Lower resource usage
+- Clearer network topology
 
 **Limitations:**
 
-* Misses pod-to-pod traffic on same node
-* Misses loopback traffic
+- Misses pod-to-pod traffic on same node
+- Misses loopback traffic
 
 ### Complete Visibility (All Traffic)
 
@@ -432,14 +432,14 @@ discovery "instrument" {
 
 **Advantages:**
 
-* Complete network visibility
-* Captures all pod-to-pod traffic
+- Complete network visibility
+- Captures all pod-to-pod traffic
 
 **Limitations:**
 
-* Flow duplication for inter-node traffic
-* Higher resource usage
-* Requires deduplication in backend
+- Flow duplication for inter-node traffic
+- Higher resource usage
+- Requires deduplication in backend
 
 ### Selective Monitoring
 
@@ -476,15 +476,15 @@ podAnnotations:
   prometheus.io/path: "/metrics"
 ```
 
-See [Application Metrics](../observability/app-metrics.md) for complete metrics documentation and Prometheus query examples.
+See [Internal Metrics](../observability/app-metrics.md) for complete metrics documentation and Prometheus query examples.
 
 Key metrics to monitor:
 
-* `mermin_flow_spans_created_total` - Total flow spans created
-* `mermin_packets_total` - Total packets processed
-* `mermin_flow_events_total{status="dropped_backpressure"}` - Events dropped due to overload
-* `mermin_export_flow_spans_total{exporter_type="otlp",status="error"}` - OTLP export failures
-* `mermin_flow_spans_active_total` - Current number of active flows
+- `mermin_flow_spans_created_total` - Total flow spans created
+- `mermin_packets_total` - Total packets processed
+- `mermin_flow_events_total{status="dropped_backpressure"}` - Events dropped due to overload
+- `mermin_export_flow_spans_total{exporter_type="otlp",status="error"}` - OTLP export failures
+- `mermin_flow_spans_active_total` - Current number of active flows
 
 ### Tuning Guidelines
 
@@ -635,7 +635,7 @@ export "traces" {
 
 ## Next Steps
 
-* [**Configuration Reference**](../configuration/configuration.md): Deep dive into all configuration options
-* [**Filtering**](../configuration/filtering.md): Configure flow filters for security and performance
-* [**Observability Backends**](../observability/backends.md): Send Flow Traces to your observability backend
-* [**Troubleshooting**](../troubleshooting/troubleshooting.md): Diagnose and resolve performance issues
+- [**Configuration Reference**](../configuration/configuration.md): Deep dive into all configuration options
+- [**Filtering**](../configuration/filtering.md): Configure flow filters for security and performance
+- [**Observability Backends**](../observability/backends.md): Send Flow Traces to your observability backend
+- [**Troubleshooting**](../troubleshooting/troubleshooting.md): Diagnose and resolve performance issues

--- a/docs/deployment/cloud-platforms.md
+++ b/docs/deployment/cloud-platforms.md
@@ -8,7 +8,7 @@ This guide provides specific instructions for deploying Mermin on major cloud Ku
 
 ## Google Kubernetes Engine (GKE)
 
-### Prerequisites
+### GKE Prerequisites
 
 - `gcloud` CLI installed and configured
 - GKE cluster created (Standard or Autopilot)
@@ -191,7 +191,7 @@ Only adjust if you experience specific integration issues with Cilium or other T
 
 ## Amazon Elastic Kubernetes Service (EKS)
 
-### Prerequisites
+### EKS Prerequisites
 
 - `aws` CLI installed and configured
 - `eksctl` installed (optional but recommended)
@@ -274,7 +274,7 @@ eksctl create iamserviceaccount \
 
 ## Azure Kubernetes Service (AKS)
 
-### Prerequisites
+### AKS Prerequisites
 
 - `az` CLI installed and configured
 - AKS cluster created
@@ -475,19 +475,19 @@ az role assignment create \
 
 ## Performance and Cost Optimization
 
-### GKE
+### GKE Cost Optimization
 
 - Use **Preemptible/Spot nodes** for non-critical Mermin pods (with PodDisruptionBudget)
 - Use **node autoscaling** to match traffic patterns
 - Consider **regional clusters** for high availability
 
-### EKS
+### EKS Cost Optimization
 
 - Use **Spot instances** for cost savings (with PodDisruptionBudget)
 - Use **Cluster Autoscaler** or **Karpenter** for dynamic scaling
 - Enable **Container Insights** for monitoring
 
-### AKS
+### AKS Cost Optimization
 
 - Use **Spot node pools** for cost savings
 - Use **Cluster Autoscaler** for dynamic scaling

--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -11,11 +11,11 @@ This section provides comprehensive guidance for deploying Mermin in various env
 Mermin supports multiple deployment scenarios:
 
 | Deployment Type                                  | Use Case                  | Complexity | Production Ready |
-| ------------------------------------------------ | ------------------------- | ---------- | ---------------- |
+|--------------------------------------------------|---------------------------|------------|------------------|
 | [**Kubernetes with Helm**](kubernetes-helm.md)   | Standard K8s clusters     | Low        | ✅ Yes            |
 | [**Cloud Platforms**](cloud-platforms.md)        | GKE, EKS, AKS             | Low        | ✅ Yes            |
 | [**Advanced Scenarios**](advanced-scenarios.md)  | Custom CNI, multi-cluster | Medium     | ✅ Yes            |
-| [**Docker on Bare Metal**](docker-bare-metal.md) | Non-K8s Linux hosts       | Medium     | ⚠️ Limited       |
+| [**Docker on Bare Metal**](docker-bare-metal.md) | Non-K8s Linux hosts       | Medium     | ⚠️ Limited        |
 
 ## Architecture Considerations
 

--- a/docs/deployment/examples/netobserv_os_simple_gke_gw/README.md
+++ b/docs/deployment/examples/netobserv_os_simple_gke_gw/README.md
@@ -8,7 +8,8 @@
 
 ## Overview
 
-This example deploys Mermin and NetObserv Flow (as OTel receiver) with OpenSearch as the data platform in a GCP GKE cluster. This example is intended only for demonstration, testing, or proof-of-concept use, since OpenSearch is deployed in a single-node mode.
+This example deploys Mermin and NetObserv Flow (as OTel receiver) with OpenSearch as the data platform in a GCP GKE cluster. This example is intended only for demonstration, testing, or proof-of-concept use,
+since OpenSearch is deployed in a single-node mode.
 
 Notes on the example deployment:
 
@@ -32,7 +33,8 @@ The installation process consists of two phases:
 1. Install NetObserv with OpenSearch.
 2. Install Mermin.
 
-This installation assumes that no additional DNS controllers are running in the cluster. Therefore, it is not possible to know the IP address of the NetObserv gRPC load balancer without extra GCP actions before the NetObserv chart (dependency) is ready.
+This installation assumes that no additional DNS controllers are running in the cluster.
+Therefore, it is not possible to know the IP address of the NetObserv gRPC load balancer without extra GCP actions before the NetObserv chart (dependency) is ready.
 
 - Phase 1
   - Create values and a config files for the Mermin Umbrella chart (or use ones from the repo)
@@ -52,12 +54,14 @@ This installation assumes that no additional DNS controllers are running in the 
         --devel \
         mermin mermin/mermin-netobserv-os-stack
       ```
+
 - Phase 2:
   - Get the NetObserv Gateway (Load Balancer) IP
 
       ```sh
       kubectl get gtw netobserv-flow -o=jsonpath='{.status.addresses[0].value}'
       ```
+
   - Modify `export.traces.otlp.endpoint` in the `config.hcl` to the value from the previous step and redeploy the chart
 
       ```sh

--- a/docs/deployment/helm-examples/README.md
+++ b/docs/deployment/helm-examples/README.md
@@ -16,4 +16,3 @@ layout:
 ---
 
 # Helm Examples
-

--- a/docs/deployment/kubernetes-helm.md
+++ b/docs/deployment/kubernetes-helm.md
@@ -205,7 +205,7 @@ kubectl get pods -l app.kubernetes.io/name=mermin
 
 You should see one pod per node:
 
-```
+```text
 NAME           READY   STATUS    RESTARTS   AGE
 mermin-abc123  1/1     Running   0          2m
 mermin-def456  1/1     Running   0          2m
@@ -527,7 +527,7 @@ Common issues:
 * No matching interfaces: Check `discovery.instrument.interfaces` configuration
 * eBPF load failure: Ensure kernel version >= 4.18 with eBPF support
 * OTLP connection failure: Verify collector endpoint and network policies
-* TCX pin warnings (kernel >= 6.6): See [TCX Mode and BPF Filesystem](#tcx-mode-and-bpf-filesystem-kernel-66) for mounting `/sys/fs/bpf`
+* TCX pin warnings (kernel >= 6.6): See [TCX Mode and BPF Filesystem](../getting-started/security-considerations.md#tcx-mode-and-bpf-filesystem-kernel--66) for mounting `/sys/fs/bpf`
 
 ### High Resource Usage
 

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -110,6 +110,7 @@ The userspace Mermin agent receives packets from eBPF and aggregates them into n
 - **Community ID**: Generates standard Community ID hashes for flow correlation
 
 A [Flow Trace Span](../spec/semantic-conventions.md) includes:
+
 - Source and destination IP addresses and ports
 - Network protocol (TCP, UDP, ICMP, etc.)
 - Packet and byte counters (bidirectional)
@@ -328,7 +329,9 @@ CNI/backend flexibility and flow-level detail, enabling long-term storage and gr
 
 Now that you understand how Mermin generates Flow Traces, review the following guides to learn more and get started:
 
-1. [**Deploy to Production**](../deployment/deployment.md): Select the deployment model that best suits your needs with detailed guidance covering Kubernetes, cloud platforms, and bare metal Docker environments. Includes in-depth recommendations for resource allocation, network architecture, and security best practices.
-2. [**Configure Mermin**](../configuration/configuration.md): Customize Mermin for your environment by configuring network interface discovery, Kubernetes metadata enrichment, flow filtering, OTLP export, and other settings. Features support for auto-reload and flexible configuration precedence.
-3. [**Choose Your Backend**](../observability/backends.md): Send Flow Traces via OTLP to any compatible observability platform, including OpenTelemetry Collector, Elastic Stack, OpenSearch, Grafana Tempo, and Jaeger, or commercial platforms like Grafana Cloud and Datadog.
-4. [**Troubleshoot Issues**](../troubleshooting/troubleshooting.md): Diagnose deployment failures, eBPF errors, and traffic visibility issues using pod logs, health checks, metrics monitoring, and the `diagnose bpf` command, with organized guides for common problem categories.
+1. [**Deploy to Production**](../deployment/deployment.md): Select the deployment model that best suits your needs with detailed guidance covering Kubernetes, cloud platforms, and bare metal Docker environments.
+   Includes in-depth recommendations for resource allocation, network architecture, and security best practices.
+2. [**Configure Mermin**](../configuration/configuration.md): Customize Mermin for your environment by configuring network interface discovery, Kubernetes metadata enrichment, flow filtering, OTLP export, and other settings.
+   Features support for auto-reload and flexible configuration precedence.
+3. [**Choose Your Backend**](../observability/backends.md): Send Flow Traces via OTLP to any compatible observability platform, including OpenTelemetry Collector, Elastic Stack, OpenSearch, Grafana Tempo, and Jaeger.
+4. [**Troubleshoot Issues**](../troubleshooting/troubleshooting.md): Diagnose deployment failures, eBPF errors, and traffic visibility issues using pod logs, health checks, metrics monitoring, and the `diagnose bpf` command.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -79,7 +79,7 @@ kubectl get pods -l app.kubernetes.io/name=mermin
 
 You should see one Mermin pod per worker node, all in the `Running` state:
 
-```
+```text
 NAME           READY   STATUS    RESTARTS   AGE
 mermin-abc123  1/1     Running   0          2m
 mermin-def456  1/1     Running   0          2m
@@ -115,7 +115,7 @@ Switch back to the logs terminal, and you'll see network flow records for the tr
 
 Example flow record (stdout format):
 
-```
+```text
 Flow Record:
   Timestamp: 2025-10-27T10:30:45Z
   Source: 10.244.1.5:45678 (test-pod)

--- a/docs/observability/app-metrics.md
+++ b/docs/observability/app-metrics.md
@@ -1,6 +1,5 @@
-# Mermin Application Metrics
+# Mermin Internal Metrics
 
-- [Mermin Application Metrics](#mermin-application-metrics)
 - [Metrics Endpoint](#metrics-endpoint)
 - [Metrics Reference](#metrics-reference)
   - [eBPF Metrics (`mermin_ebpf_*`)](#ebpf-metrics-mermin_ebpf_)
@@ -14,11 +13,10 @@
   - [TaskManager Metrics (`mermin_taskmanager_*`)](#taskmanager-metrics-mermin_taskmanager_)
 - [Grafana Dashboard](#grafana-dashboard)
 
-
 This guide describes the Prometheus metrics endpoint exposed by Mermin and provides a comprehensive breakdown of all available metrics, their types, and descriptions.
 See the [metrics configuration document](../configuration/metrics.md) for more details on metrics configuration.
 
-# Metrics Endpoint
+## Metrics Endpoint
 
 Mermin exposes Prometheus metrics in the standard Prometheus text format at multiple HTTP endpoints:
 
@@ -32,7 +30,7 @@ Mermin exposes Prometheus metrics in the standard Prometheus text format at mult
 - **Standard metrics**: Always enabled, aggregated across resources, safe for production.
 - **Debug metrics**: High-cardinality labels (per-interface, per-resource), must be explicitly enabled via `metrics.debug_metrics_enabled = true`.
 
-# Metrics Reference
+## Metrics Reference
 
 All metrics follow the naming convention: `mermin_<subsystem>_<name>`.
 Metrics are categorized into logical subsystems that correspond to different components of Mermin:
@@ -45,7 +43,7 @@ Metrics are categorized into logical subsystems that correspond to different com
 - `k8s`: For Kubernetes watcher metrics
 - `taskmanager`: Internal Mermin tasks metrics
 
-## eBPF Metrics (`mermin_ebpf_*`)
+### eBPF Metrics (`mermin_ebpf_*`)
 
 This section describes metrics from the eBPF layer, responsible for capturing low-level packets. These metrics provide visibility into the status of loaded eBPF programs and the usage of eBPF maps.
 Monitoring these is crucial for ensuring that Mermin's foundational data collection mechanism functions as expected.
@@ -83,7 +81,7 @@ Monitoring these is crucial for ensuring that Mermin's foundational data collect
   *Labels*:
   - `attachment`
 
-## Network Interface Metrics (`mermin_interface_*`)
+### Network Interface Metrics (`mermin_interface_*`)
 
 These metrics provide visibility into network traffic processed by Mermin across all monitored interfaces. They are essential for understanding the overall throughput and packet rates processed by Mermin.
 
@@ -94,7 +92,7 @@ These metrics provide visibility into network traffic processed by Mermin across
   *Type*: `counter`
   *Description*: Total number of packets processed across all interfaces
 
-## Flow Metrics (`mermin_flow_*`)
+### Flow Metrics (`mermin_flow_*`)
 
 - `mermin_flow_spans_active_total`
   *Type*: `gauge`
@@ -103,7 +101,7 @@ These metrics provide visibility into network traffic processed by Mermin across
   *Type*: `counter`
   *Description*: Total number of flow spans created across all interfaces
 
-## Kubernetes Watcher Metrics (`mermin_k8s_watcher_*`)
+### Kubernetes Watcher Metrics (`mermin_k8s_watcher_*`)
 
 These metrics track events and performance of the Kubernetes resource watchers used by Mermin for metadata enrichment and resource monitoring.
 
@@ -117,7 +115,7 @@ These metrics track events and performance of the Kubernetes resource watchers u
   *Type*: `histogram`
   *Description*: Duration of K8s IP index updates
 
-## Kubernetes Decorator Metrics (`mermin_k8s_decorator_*`)
+### Kubernetes Decorator Metrics (`mermin_k8s_decorator_*`)
 
 These metrics exposes the details to the Kubernetes decorator stage.
 
@@ -127,7 +125,7 @@ These metrics exposes the details to the Kubernetes decorator stage.
   *Labels*:
   - `status`
 
-## Flow Span Export Metrics (`mermin_export_*`)
+### Flow Span Export Metrics (`mermin_export_*`)
 
 These metrics track the export of flow spans from Mermin to external systems (such as OTLP collectors), providing insight into export performance and reliability.
 
@@ -141,7 +139,7 @@ These metrics track the export of flow spans from Mermin to external systems (su
   - `exporter`
   - `status`
 
-## Channel Metrics (`mermin_channel_*`)
+### Channel Metrics (`mermin_channel_*`)
 
 These metrics offer insight into the internal channels used for data transmission.
 
@@ -162,7 +160,7 @@ These metrics offer insight into the internal channels used for data transmissio
   - `channel`
   - `status`
 
-## Pipeline Metrics (`mermin_pipeline_*`)
+### Pipeline Metrics (`mermin_pipeline_*`)
 
 These metrics offer insight into the internal pipelines used for data mutation (flow generation, decoration).
 
@@ -172,7 +170,7 @@ These metrics offer insight into the internal pipelines used for data mutation (
   *Labels*:
   - `stage`
 
-## TaskManager Metrics (`mermin_taskmanager_*`)
+### TaskManager Metrics (`mermin_taskmanager_*`)
 
 These metrics track the number and type of active background tasks managed by Mermin.
 
@@ -182,6 +180,6 @@ These metrics track the number and type of active background tasks managed by Me
   *Labels*:
   - `task`
 
-# Grafana Dashboard
+## Grafana Dashboard
 
 Grafana dashboard can be imported from the [Dashboard JSON](./grafana-mermin-app.json)

--- a/docs/observability/backends.md
+++ b/docs/observability/backends.md
@@ -2,7 +2,7 @@
 hidden: true
 ---
 
-# Backends
+# Observability Backend Integration
 
 Mermin exports Flow Traces via the **OpenTelemetry Protocol (OTLP)**, which means it works with any OTLP-enabled observability backend or collector.
 
@@ -17,10 +17,10 @@ To receive Flow Traces from Mermin, you need one of:
 
 The OpenTelemetry Collector is the most flexible option:
 
-* Receives OTLP from Mermin via gRPC or HTTP
-* Processes, batches, and transforms telemetry data
-* Exports to multiple backends simultaneously
-* Provides buffering and retry logic
+- Receives OTLP from Mermin via gRPC or HTTP
+- Processes, batches, and transforms telemetry data
+- Exports to multiple backends simultaneously
+- Provides buffering and retry logic
 
 **Example Configuration:** See [Mermin with OpenTelemetry Collector](../deployment/examples/local_otel/README.md) for a complete setup with OpenTelemetry Collector, including Mermin configuration and collector pipeline.
 
@@ -47,8 +47,8 @@ Elasticsearch with APM Server or OpenTelemetry Collector can ingest OTLP traces.
 
 **How to Connect:**
 
-* Point Mermin → OpenTelemetry Collector → Elasticsearch exporter
-* Or point Mermin → Elastic APM Server (OTLP endpoint)
+- Point Mermin → OpenTelemetry Collector → Elasticsearch exporter
+- Or point Mermin → Elastic APM Server (OTLP endpoint)
 
 **Example:** See [`docs/deployment/examples/netobserv_os_simple_svc/`](../../docs/deployment/examples/netobserv_os_simple_svc/) for OpenSearch (Elastic-compatible) deployment
 
@@ -60,8 +60,8 @@ Open-source alternative to Elasticsearch with native OTLP support via OpenTeleme
 
 **Examples:**
 
-* [`docs/deployment/examples/netobserv_os_simple_svc/`](../../docs/deployment/examples/netobserv_os_simple_svc/) - Basic OpenSearch setup
-* [`docs/deployment/examples/netobserv_os_simple_gke_gw/`](../../docs/deployment/examples/netobserv_os_simple_gke_gw/) - GKE deployment with Gateway API
+- [`docs/deployment/examples/netobserv_os_simple_svc/`](../../docs/deployment/examples/netobserv_os_simple_svc/) - Basic OpenSearch setup
+- [`docs/deployment/examples/netobserv_os_simple_gke_gw/`](../../docs/deployment/examples/netobserv_os_simple_gke_gw/) - GKE deployment with Gateway API
 
 ### Grafana Tempo
 
@@ -101,7 +101,7 @@ export "traces" {
 
 **Example:** Coming soon
 
-### Grafana Cloud, Datadog, New Relic, Honeycomb, etc.
+### Grafana Cloud, Datadog, New Relic, Honeycomb, etc
 
 Most commercial observability platforms now support OTLP ingestion.
 
@@ -131,17 +131,17 @@ Each Flow Trace is an OpenTelemetry span containing:
 
 **Span Attributes:**
 
-* Network 5-tuple: source/dest IPs, ports, protocol
-* Bidirectional counters: bytes sent/received, packets sent/received
-* TCP state: flags (SYN, FIN, RST), connection state
-* Kubernetes metadata: pod, service, deployment, namespace, labels
-* Community ID for flow correlation
+- Network 5-tuple: source/dest IPs, ports, protocol
+- Bidirectional counters: bytes sent/received, packets sent/received
+- TCP state: flags (SYN, FIN, RST), connection state
+- Kubernetes metadata: pod, service, deployment, namespace, labels
+- Community ID for flow correlation
 
 **Resource Attributes:**
 
-* Kubernetes cluster name
-* Node name
-* Mermin version
+- Kubernetes cluster name
+- Node name
+- Mermin version
 
 This standardized format allows querying Flow Traces using native backend query languages (TraceQL, KQL, Lucene, etc.).
 

--- a/docs/spec/attribute-reference.md
+++ b/docs/spec/attribute-reference.md
@@ -1,4 +1,4 @@
-# Attribute Reference
+# Flow Span Attribute Reference
 
 This document is a quick reference for all flow span attributes in Mermin. For design rationale and the full specification, see [Semantic Conventions](semantic-conventions.md).
 

--- a/docs/spec/introductory-primer.md
+++ b/docs/spec/introductory-primer.md
@@ -1,8 +1,9 @@
-# Flow Trace Primer
+# Introduction to Flow Traces
 
 ## Introduction
 
-This document is a non-normative, user-friendly introduction to the Flow Trace semantic convention. It is intended for those who want to understand the core concepts and motivation behind representing network flow data within OpenTelemetry without reading the full specification.
+This document is a non-normative, user-friendly introduction to the Flow Trace semantic convention.
+It is intended for those who want to understand the core concepts and motivation behind representing network flow data within OpenTelemetry without reading the full specification.
 
 ---
 
@@ -10,11 +11,13 @@ This document is a non-normative, user-friendly introduction to the Flow Trace s
 
 A **Flow Trace** is an OpenTelemetry trace that represents a network connection. It is composed of one or more **Flow Trace Spans**, where each span captures a measurement interval of the network conversation.
 
-Unlike traditional OpenTelemetry traces that focus on application-level requests (HTTP calls, database queries, etc.), a Flow Trace captures the network conversation itself—the bidirectional exchange of packets between two endpoints as observed by an independent monitoring point like an eBPF agent.
+Unlike traditional OpenTelemetry traces that focus on application-level requests (HTTP calls, database queries, etc.),
+a Flow Trace captures the network conversation itself—the bidirectional exchange of packets between two endpoints as observed by an independent monitoring point like an eBPF agent.
 
 ### Flow Trace vs. Flow Trace Span
 
-- **Flow Trace Span**: A single OpenTelemetry span representing one flow record—a snapshot of the network conversation during a specific observation window. When a flow is active, the agent exports periodic spans (e.g., every 60 seconds) with delta metrics for that interval.
+- **Flow Trace Span**: A single OpenTelemetry span representing one flow record—a snapshot of the network conversation during a specific observation window.
+When a flow is active, the agent exports periodic spans (e.g., every 60 seconds) with delta metrics for that interval.
 
 - **Flow Trace**: The complete collection of related Flow Trace Spans that together represent the full lifecycle of a network connection—from the first packet to the last.
 
@@ -26,7 +29,8 @@ Think of it like a long-running database connection: individual spans might repr
 
 ### The Observability Gap
 
-The modern observability stack—Metrics, Events, Logs, and Traces (MELT)—excels at application-level visibility. APM traces show you request latency, error rates, and service dependencies. Network monitoring gives you bandwidth utilization and interface statistics.
+The modern observability stack—Metrics, Events, Logs, and Traces (MELT)—excels at application-level visibility. APM traces show you request latency, error rates, and service dependencies.'
+Network monitoring gives you bandwidth utilization and interface statistics.
 
 But there's a gap between these two worlds:
 
@@ -182,6 +186,7 @@ Here is what a simple Flow Trace Span might look like in OTLP JSON format. It re
 ```
 
 Key observations:
+
 - The span represents a 60-second observation window (start to end time).
 - Bidirectional metrics show this is primarily a download: 1KB sent, 32KB received.
 - Kubernetes metadata identifies the pods by name, not just IP address.

--- a/docs/spec/semantic-conventions.md
+++ b/docs/spec/semantic-conventions.md
@@ -1,8 +1,10 @@
-# Semantic Conventions
+# Flow Trace Semantic Conventions
 
-This document proposes semantic conventions for representing network flow data as traces. The existing network conventions are primarily designed for unidirectional, client/server interactions within an instrumented application. This proposal addresses the need to represent a network flow as a complete, bidirectional conversation, typically observed by a third party (like a network device or eBPF agent).
+This document proposes semantic conventions for representing network flow data as traces. The existing network conventions are primarily designed for unidirectional, client/server interactions within an instrumented application.
+This proposal addresses the need to represent a network flow as a complete, bidirectional conversation, typically observed by a third party (like a network device or eBPF agent).
 
-The core concept of this proposal is to represent each network flow record as a single **Span**. This model elevates traces from purely application-level signals to comprehensive flow spans that capture detailed data about network traffic, creating a new standard for network observability within the OpenTelemetry ecosystem.
+The core concept of this proposal is to represent each network flow record as a single **Span**. This model elevates traces from purely application-level signals to comprehensive flow spans that capture detailed data about network traffic,
+creating a new standard for network observability within the OpenTelemetry ecosystem.
 
 ***
 
@@ -11,7 +13,8 @@ The core concept of this proposal is to represent each network flow record as a 
 Each network flow record is represented as a single OpenTelemetry **Span**. This "flow span" has the following key characteristics:
 
 * **Span Name**: To clearly distinguish flow spans from application spans, the name SHOULD follow the format `flow_<network.type>_<network.transport>`. For example, a typical TCP flow over IPv4 would be named `flow_ipv4_tcp`.
-* **Span Kind**: The Span Kind MUST be `CLIENT`, `SERVER`, or `INTERNAL`. Using `CLIENT` or `SERVER` provides crucial directional context that the generic `INTERNAL` kind lacks, eliminating the need for separate attributes like `flow.initiator: source/destination` or `flow.biflow_direction: initiator/reverseInitiator`.
+* **Span Kind**: The Span Kind MUST be `CLIENT`, `SERVER`, or `INTERNAL`. Using `CLIENT` or `SERVER` provides crucial directional context that the generic `INTERNAL` kind lacks,
+   eliminating the need for separate attributes like `flow.initiator: source/destination` or `flow.biflow_direction: initiator/reverseInitiator`.
   * `CLIENT`: Represents the perspective of the connection initiator. An agent infers this when observing an outbound connection that originates from an ephemeral (non-listening) port or through protocol-specific logic.
     * **Example (TCP)**: A host sends a packet from an ephemeral source port (e.g., 54211) to a destination service port (e.g., 443).
     * **Example (ICMP)**: A host sends an ICMP "Echo Request" packet.
@@ -42,7 +45,8 @@ The `flow.direction` attribute MUST be consistent with the Span Kind when both a
 
 **Why both Span Kind and `flow.direction`?**
 
-Span Kind is the idiomatic way to express direction in OpenTelemetry traces and enables proper trace visualization in backends. However, when the same flow data is exported as metrics (e.g., for dashboards or alerting), Span Kind is not available. The `flow.direction` attribute ensures that direction information is preserved regardless of signal type, enabling:
+Span Kind is the idiomatic way to express direction in OpenTelemetry traces and enables proper trace visualization in backends. However, when the same flow data is exported as metrics (e.g., for dashboards or alerting), Span Kind is not available.
+The `flow.direction` attribute ensures that direction information is preserved regardless of signal type, enabling:
 
 * Consistent queries across traces and metrics (e.g., "show all forward flows to this service")
 * Metric-based dashboards that distinguish inbound vs. outbound traffic
@@ -58,26 +62,36 @@ To ensure clarity, this convention uses and defines specific attribute namespace
 * **`tunnel.*`**: Describes tunneling protocols and encapsulation metadata (e.g., tunnel.type, tunnel.id). This is always the outer-most tunnel or encapsulation.
 * **`process.*` / `container.*`**: Existing OTel namespaces used to identify the host process or container associated with the flow's socket.
 
-The `flow.*` namespace is critical for creating a clear semantic distinction. It separates attributes of a flow—a dynamic conversation between two endpoints over time—from attributes of a network entity, like a physical interface, whose properties are generally static. Overloading the existing network.\* namespace with dynamic flow concepts would create ambiguity.
+The `flow.*` namespace is critical for creating a clear semantic distinction. It separates attributes of a flow—a dynamic conversation between two endpoints over time—from attributes of a network entity, like a physical interface,
+whose properties are generally static. Overloading the existing network.\* namespace with dynamic flow concepts would create ambiguity.
 
 ### Why `source.k8s.*` Instead of `k8s.source.*`?
 
 This convention uses `source.k8s.*` / `destination.k8s.*` (e.g., `source.k8s.pod.name`) rather than `k8s.source.*` / `k8s.destination.*`. This is a deliberate design choice driven by the nature of network flow data:
 
-1. **The entity being described is the flow endpoint, not Kubernetes itself.** In flow telemetry, the primary entity is the connection between two endpoints. Each endpoint has many attributes: an IP address, a port, and potentially Kubernetes metadata (pod name, namespace, etc.). Grouping all attributes of an endpoint under its directional prefix (`source.*` or `destination.*`) keeps related data together semantically. The question "what do I know about the source?" is answered by querying `source.*`, yielding address, port, and all k8s enrichment in one logical group.
-2. **Symmetry of bidirectional flows.** Unlike client/server metrics where telemetry is recorded from a single perspective, network flow observability (especially eBPF-based) captures both directions of a conversation symmetrically. There is no privileged "recording side." The `source`/`destination` prefixes establish a consistent frame of reference for the entire flow record, and all enrichment attributes naturally belong under that frame.
-3. **Consistency with networking industry conventions.** Traditional flow protocols (NetFlow, IPFIX, sFlow) and eBPF-based tools universally structure directional metadata with the direction first: `src_addr`, `dst_port`, `src_as`, `dst_geo_country`, etc. Using `source.k8s.*` aligns with these established patterns, making the schema intuitive for network engineers and reducing cognitive overhead when correlating with other flow data sources.
-4. **Query ergonomics and grouping.** Placing the directional prefix first enables efficient queries like `source.k8s.*` to retrieve all Kubernetes context for one side of the flow. If the hierarchy were inverted (`k8s.source.*`), querying "all source endpoint attributes" would require combining `source.address`, `source.port`, and `k8s.source.*`—three separate prefix patterns instead of one.
-5. **Avoiding OTel resource attribute ambiguity.** Standard OTel `k8s.*` attributes (e.g., `k8s.pod.name`) describe the resource where telemetry originates—typically the observing agent's own pod. For flow data, we need to describe _two_ remote endpoints, neither of which is necessarily the agent itself. Using `source.k8s.*` / `destination.k8s.*` clearly distinguishes flow endpoint metadata from resource-level attributes, preventing confusion about which entity is being described.
+1. **The entity being described is the flow endpoint, not Kubernetes itself.** In flow telemetry, the primary entity is the connection between two endpoints. Each endpoint has many attributes: an IP address, a port,
+and potentially Kubernetes metadata (pod name, namespace, etc.). Grouping all attributes of an endpoint under its directional prefix (`source.*` or `destination.*`) keeps related data together semantically.
+The question "what do I know about the source?" is answered by querying `source.*`, yielding address, port, and all k8s enrichment in one logical group.
+2. **Symmetry of bidirectional flows.** Unlike client/server metrics where telemetry is recorded from a single perspective, network flow observability (especially eBPF-based) captures both directions of a conversation symmetrically.
+There is no privileged "recording side." The `source`/`destination` prefixes establish a consistent frame of reference for the entire flow record, and all enrichment attributes naturally belong under that frame.
+3. **Consistency with networking industry conventions.** Traditional flow protocols (NetFlow, IPFIX, sFlow) and eBPF-based tools universally structure directional metadata with the direction first.
+   Using `source.k8s.*` aligns with these patterns, making the schema intuitive for network engineers.
+4. **Query ergonomics and grouping.** Placing the directional prefix first enables efficient queries like `source.k8s.*` to retrieve all Kubernetes context for one side of the flow. If the hierarchy were inverted (`k8s.source.*`),
+querying "all source endpoint attributes" would require combining `source.address`, `source.port`, and `k8s.source.*`—three separate prefix patterns instead of one.
+5. **Avoiding OTel resource attribute ambiguity.** Standard OTel `k8s.*` attributes (e.g., `k8s.pod.name`) describe the resource where telemetry originates—typically the observing agent's own pod. For flow data,
+we need to describe _two_ remote endpoints, neither of which is necessarily the agent itself. Using `source.k8s.*` / `destination.k8s.*` clearly distinguishes flow endpoint metadata from resource-level attributes,
+preventing confusion about which entity is being described.
 
-This pattern intentionally diverges from the OTel `client.*`/`server.*` [guidance](https://opentelemetry.io/docs/specs/semconv/general/naming/#client-and-server-metrics), which assumes telemetry recorded from a single side's perspective. For symmetric, connection-centric observability, direction-first prefixing provides clearer semantics.
+This pattern intentionally diverges from the OTel `client.*`/`server.*` [guidance](https://opentelemetry.io/docs/specs/semconv/general/naming/#client-and-server-metrics), which assumes telemetry recorded from a single side's perspective.
+For symmetric, connection-centric observability, direction-first prefixing provides clearer semantics.
 
 A simple litmus test can help:
 
-* If an attribute's value can change during the lifetime of a flow (like a byte count), it belongs in the flow.\* namespace (e.g., flow.bytes.total).
-* If an attribute's value is static for the duration of the flow (like the transport protocol), it belongs in the network.\* namespace (e.g., network.transport).
+* If an attribute's value can change during the lifetime of a flow (like a byte count), it belongs in the `flow.\*` namespace (e.g., `flow.bytes.total`).
+* If an attribute's value is static for the duration of the flow (like the transport protocol), it belongs in the `network.\*` namespace (e.g., network.transport).
 
-This separation prevents ambiguity. For instance, an attribute like network.byte\_count could be misinterpreted as the total bytes for an entire network interface, whereas flow.bytes.total clearly refers to the byte count for a specific five-tuple flow. This makes the resulting telemetry data more accurate and easier to query.
+This separation prevents ambiguity. For instance, an attribute like `network.byte_count` could be misinterpreted as the total bytes for an entire network interface,
+whereas `flow.bytes.total` clearly refers to the byte count for a specific five-tuple flow. This makes the resulting telemetry data more accurate and easier to query.
 
 ***
 

--- a/docs/troubleshooting/common-ebpf-errors.md
+++ b/docs/troubleshooting/common-ebpf-errors.md
@@ -1,12 +1,14 @@
-# Common eBPF Errors
+# Troubleshoot Common eBPF Errors
 
-eBPF programs must pass the kernel's verifier before they can run. The verifier is like a strict security guard—it checks that your program is safe, won't crash the kernel, and will eventually terminate. Understanding verifier errors can be tricky, especially since verifier behavior changes significantly between kernel versions.
+eBPF programs must pass the kernel's verifier before they can run. The verifier is like a strict security guard—it checks that your program is safe, won't crash the kernel, and will eventually terminate.
+Understanding verifier errors can be tricky, especially since verifier behavior changes significantly between kernel versions.
 
 ## What You Need to Know About the Verifier
 
 **Good news**: Verifier errors are rare, especially on modern kernels. Most Mermin deployments work out of the box without any issues.
 
-**When problems do occur**, they're typically on older kernel versions (< 5.16) that can't perform the sophisticated complexity analysis that newer kernels can. Older kernels are more conservative and may reject programs that newer kernels accept without issue.
+**When problems do occur**, they're typically on older kernel versions (< 5.16) that can't perform the sophisticated complexity analysis that newer kernels can.
+Older kernels are more conservative and may reject programs that newer kernels accept without issue.
 
 The eBPF verifier has evolved considerably over time. A program that loads perfectly on a newer kernel might fail on an older one:
 
@@ -113,7 +115,8 @@ back-edge from insn X to Y
 infinite loop detected at insn X
 ```
 
-**What's happening**: The verifier found a loop without a provable upper bound. In eBPF, every loop must have a maximum number of iterations that the verifier can determine at verification time. If the verifier can't prove your loop will eventually exit, it rejects the program.
+**What's happening**: The verifier found a loop without a provable upper bound. In eBPF, every loop must have a maximum number of iterations that the verifier can determine at verification time.
+If the verifier can't prove your loop will eventually exit, it rejects the program.
 
 This is a fundamental eBPF safety requirement—infinite loops could freeze the kernel.
 

--- a/docs/troubleshooting/deployment-issues.md
+++ b/docs/troubleshooting/deployment-issues.md
@@ -1,4 +1,4 @@
-# Deployment Issues
+# Troubleshoot Deployment Issues
 
 This guide will help you diagnose and resolve pod startup failures, eBPF loading errors, permission issues, and network interface configuration problems.
 
@@ -200,7 +200,7 @@ securityContext:
   privileged: true    # Grants all required capabilities
 ```
 
-**If you can't use privileged mode** (due to security policies), you can grant specific capabilities instead: (Refer to the [security considerations](../getting-started/security-considerations.md#privileges-required) documentation for more information.)
+**If you can't use privileged mode** (due to security policies), you can grant specific capabilities instead. Refer to the [security considerations](../getting-started/security-considerations.md#privileges-required) documentation for more information.
 
 ```yaml
 # In charts/mermin/values.yaml (capability-based approach)
@@ -334,7 +334,7 @@ This means the service account doesn't have the necessary permissions.
 
 ```bash
 kubectl get sa -n ${MERMIN_NAMESPACE}
-kubectl get clusterrole mermin -o yaml 
+kubectl get clusterrole mermin -o yaml
 kubectl get clusterrolebinding mermin
 ```
 
@@ -362,7 +362,8 @@ Different interface types show different traffic - veth interfaces capture pod-t
 
 ## Understanding TC Priority
 
-TC (Traffic Control) priority determines the order in which eBPF programs execute in the networking stack. On older kernels (< 6.6), this is managed through netlink-based TC with numeric priorities. On newer kernels (>= 6.6), TCX mode uses explicit ordering.
+TC (Traffic Control) priority determines the order in which eBPF programs execute in the networking stack. On older kernels (< 6.6), this is managed through netlink-based TC with numeric priorities.
+On newer kernels (>= 6.6), TCX mode uses explicit ordering.
 
 ### Check What Priority Mermin is Using
 
@@ -404,7 +405,8 @@ Since Mermin uses `TC_ACT_UNSPEC` (pass-through), it observes packets without mo
 2. **Alternative**: Move Mermin to a higher priority if you prefer CNI to run first (loses unfiltered view)
 
 {% hint style="warning" %}
-**Test any priority changes thoroughly!** Adjusting either Mermin's or your CNI's priority can affect network behavior differently depending on your CNI plugin. Validate in a non-production environment that flows are captured correctly and network connectivity works as expected.
+**Test any priority changes thoroughly!** Adjusting either Mermin's or your CNI's priority can affect network behavior differently depending on your CNI plugin.
+Validate in a non-production environment that flows are captured correctly and network connectivity works as expected.
 {% endhint %}
 
 **Why priority 1 matters for Mermin**:
@@ -450,7 +452,8 @@ discovery "instrument" {
 ```
 
 {% hint style="warning" %}
-**Important**: Changing from the default priority/order settings can cause issues with some CNI plugins, including missing flows or network connectivity problems. Test thoroughly in a non-production environment first and verify that flows are being captured correctly for your specific CNI.
+**Important**: Changing from the default priority/order settings can cause issues with some CNI plugins, including missing flows or network connectivity problems.
+Test thoroughly in a non-production environment first and verify that flows are being captured correctly for your specific CNI.
 {% endhint %}
 
 Not sure which kernel you're running?

--- a/docs/troubleshooting/interface-visibility-and-traffic-decapsulation.md
+++ b/docs/troubleshooting/interface-visibility-and-traffic-decapsulation.md
@@ -1,10 +1,12 @@
-# Interface Visibility and Traffic Decapsulation
+# Troubleshoot Interface Visibility and Traffic Decapsulation
 
-Not seeing the traffic you expect from Mermin? The issue is often related to *which* network interfaces you're monitoring. Different interface types show you completely different views of the same traffic, and understanding these differences is crucial for getting Mermin configured correctly.
+Not seeing the traffic you expect from Mermin? The issue is often related to *which* network interfaces you're monitoring. Different interface types show you completely different views of the same traffic,
+and understanding these differences is crucial for getting Mermin configured correctly.
 
 ## The Big Picture: What Am I Actually Seeing?
 
-Here's the key insight that explains everything: the Linux kernel automatically encapsulates and decapsulates network traffic as it moves between physical interfaces and pod namespaces. This means the same packet looks completely different depending on where you observe it.
+Here's the key insight that explains everything: the Linux kernel automatically encapsulates and decapsulates network traffic as it moves between physical interfaces and pod namespaces.
+This means the same packet looks completely different depending on where you observe it.
 
 Think of it like watching a package move through the postal system:
 
@@ -406,6 +408,7 @@ The Linux kernel does all the heavy lifting - decapsulation, decryption, and rou
 - Node routing information
 - Node IPs
 
-For most Kubernetes observability use cases, this is exactly what you want: insight into actual workload communication without getting lost in infrastructure tunneling complexity. Your applications don't know about VXLAN or WireGuard, and for monitoring application behavior, you usually don't need to either.
+For most Kubernetes observability use cases, this is exactly what you want: insight into actual workload communication without getting lost in infrastructure tunneling complexity.
+Your applications don't know about VXLAN or WireGuard, and for monitoring application behavior, you usually don't need to either.
 
 **When you do need infrastructure visibility** (troubleshooting CNI issues, debugging tunnel problems, capacity planning), add tunnel interfaces to your configuration to see both layers.

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting
+# Troubleshooting Guide for Common Issues
 
 This guide will help you diagnose and resolve common issues when deploying and operating Mermin.
 
@@ -101,7 +101,7 @@ kubectl port-forward daemonset/mermin 10250:10250 -n mermin
 curl http://localhost:10250/metrics
 ```
 
-See the [Application Metrics](../observability/app-metrics.md) guide for complete metrics documentation and Prometheus query examples.
+See the [Internal Metrics](../observability/app-metrics.md) guide for complete metrics documentation and Prometheus query examples.
 
 Key metrics to monitor include:
 

--- a/docs/welcome/beta-program.md
+++ b/docs/welcome/beta-program.md
@@ -1,10 +1,11 @@
 # Beta Program
 
-Thank you for participating in the Mermin beta program. Mermin captures network traffic passing through your Kubernetes cluster and generates flow traces in OpenTelemetry format, allowing you to see exactly what is happening inside your cluster. See [Mermin Overview](../) for a more detailed description of what Mermin can do for you.
+Thank you for participating in the Mermin beta program. Mermin captures network traffic passing through your Kubernetes cluster and generates flow traces in OpenTelemetry format,
+allowing you to see exactly what is happening inside your cluster. See [Mermin Overview](../) for a more detailed description of what Mermin can do for you.
 
 We plan to update the beta image multiple times throughout this beta period. We will reach out to you every time a new version is available and describe the changes included.
 
-### Accessing the Beta Image
+## Accessing the Beta Image
 
 > **Version Requirement**: v0.1.0-beta.40 or higher
 
@@ -16,7 +17,7 @@ helm repo add mermin https://elastiflow.github.io/mermin/
 helm repo update
 ```
 
-### Configuration Essentials
+## Configuration Essentials
 
 To view flows with Kubernetes metadata enrichment, Mermin requires four core configuration blocks: Network Interface Discovery, Kubernetes Informer, Flow-to-Kubernetes Attribute Mapping & Export.
 
@@ -26,7 +27,7 @@ A minimal example configuration is available here: [Example Configuration](../de
 
 <summary>Network Interface Discovery</summary>
 
-**CNI-Specific Patterns**
+**CNI-Specific Patterns:**
 
 ```hcl
 discovery "instrument" {
@@ -50,9 +51,9 @@ discovery "instrument" {
 }
 ```
 
-Default:
+**Default:**
 
-```
+```text
 "veth*", "tunl*", "ip6tnl*", "vxlan*", "flannel*", "cali*", "cilium_*", "lxc", "gke*", "eni*", "ovn-k8s*"
 ```
 
@@ -61,10 +62,11 @@ Default:
 **Use cases**: Fine-tuning for specific CNI setups, reducing monitored interface count
 
 {% hint style="info" %}
-Mermin's goal is to show you pod-to-pod traffic which is exposed by Virtual Ethernet Devices, which match patterns like `"veth*", "gke*", "cali*"`. Currently, bridge interfaces like `"tun*"` or `flannel*` are ignored, because Mermin does not support parsing tunneled/encapsulated traffic. This feature will come very soon.
+Mermin's goal is to show you pod-to-pod traffic which is exposed by Virtual Ethernet Devices, which match patterns like `"veth*", "gke*", "cali*"`. Currently, bridge interfaces like `"tun*"` or `flannel*` are ignored,
+because Mermin does not support parsing tunneled/encapsulated traffic. This feature will come very soon.
 {% endhint %}
 
-**Physical Interfaces Only**
+**Physical Interfaces Only:**
 
 {% hint style="warning" %}
 Most of the traffic on the physical interfaces will be ignored, because Mermin currently lacks support for tunneled/encapsulated traffic.
@@ -118,11 +120,11 @@ Configures how Mermin exports network flow data. Flows can be sent to an OTLP re
 
 </details>
 
-### Deploying Mermin
+## Deploying Mermin
 
 Once your configuration is ready, you can deploy with the following command:
 
-```
+```bash
 helm upgrade -i mermin mermin/mermin \
   --namespace elastiflow \
   --create-namespace \
@@ -138,7 +140,7 @@ kubectl -n elastiflow get pods -l app.kubernetes.io/name=mermin
   * [Mermin with NetObserv Flow and OpenSearch](../deployment/examples/netobserv_os_simple_svc/)
   * [Mermin with NetObserv Flow and OpenSearch in GKE with Gateway](../deployment/examples/netobserv_os_simple_gke_gw/)
 
-### See Your First Flows
+## See Your First Flows
 
 View network flows captured by Mermin:
 
@@ -152,7 +154,7 @@ kubectl run test-traffic --rm -it --image=busybox -- ping -c 5 8.8.8.8
 
 **Expected output** (flow span example):
 
-```
+```text
 Flow Span:
   TraceID: 1a2b3c4d5e6f7g8h9i0j
   Source: 10.244.1.5:54321 (test-traffic pod)
@@ -163,11 +165,11 @@ Flow Span:
   Duration: 4.2s
 ```
 
-### Known Limitations
+## Known Limitations
 
 <details>
 
-<summary><strong>Tunneled/Encapsulated Traffic Parsing</strong></summary>
+<summary><b>Tunneled/Encapsulated Traffic Parsing</b></summary>
 
 Deep packet parsing for tunneled traffic is not yet implemented in userspace.
 
@@ -188,7 +190,7 @@ The default configuration monitors veth interfaces and CNI-specific interfaces w
 
 <details>
 
-<summary><strong>Kernel and Platform Compatibility</strong></summary>
+<summary><b>Kernel and Platform Compatibility</b></summary>
 
 Mermin has been tested and verified on the following platforms:
 
@@ -203,9 +205,10 @@ Mermin has been tested and verified on the following platforms:
 
 </details>
 
-### eBPF Errors
+## eBPF Errors
 
-When deploying Mermin for the first time, you may encounter issues. Depending on your kernel version, you may encounter eBPF verifier errors, as shown [here](../troubleshooting/common-ebpf-errors.md).
+When deploying Mermin for the first time, you may encounter issues.
+Depending on your kernel version, you may encounter eBPF verifier errors. See [Troubleshoot Common eBPF Errors](../troubleshooting/common-ebpf-errors.md) for details.
 
 **Minimum requirements:**
 
@@ -215,7 +218,7 @@ When deploying Mermin for the first time, you may encounter issues. Depending on
 
 **Note:** While Mermin may work on kernels older than 6.1, it has been tested and validated on 6.1+. If you encounter verifier errors on older kernels, please report the issue with your kernel version using the template below.
 
-### Reporting Issues
+## Reporting Issues
 
 If you encounter problems during the beta, please report them using the template below. This information helps us diagnose and resolve issues quickly
 
@@ -225,6 +228,7 @@ Feedback Channels
 * **Slack:** [Click to Join](https://join.slack.com/t/elastiflowcommunity/shared_invite/zt-23jpnlw9g-Q4nKOwKKOE1N2MjfA2mXpg)
 
 {% code expandable="true" %}
+
 ```markup
 **Issue Title:** [Brief description of the problem]
 **Problem Description:**
@@ -246,4 +250,5 @@ Feedback Channels
 - **Resource Constraints**: Pod resource limits/requests if relevant
 - Additional Context: [Any other relevant information - recent changes, specific workloads, etc.]
 ```
+
 {% endcode %}


### PR DESCRIPTION
## Changes

- convert multiple h1 headings to h2 to ensure single h1 per page
- improve h1 titles for better seo discoverability
- update sidenav titles in SUMMARY.md to match page headings
- fix line-length issues by breaking long lines
- add language specifiers to fenced code blocks
- ensure consistent list marker style (dashes vs asterisks)
- add blank lines around fenced code blocks and lists
- fix duplicate heading names in cloud-platforms.md
- escape html-like content in table cells
- replace non-descriptive link text with descriptive alternatives