### PR TITLE
docs: restructure internal-tracing and metrics configuration docs

### DIFF
--- a/docs/configuration/internal-tracing.md
+++ b/docs/configuration/internal-tracing.md
@@ -1,106 +1,105 @@
 # Configure Internal Tracing Exporter
 
-This page documents the `internal "traces"` configuration (config path: `internal.traces`), which controls how Mermin exports its own telemetry data for self-monitoring and debugging.
-Mermin accepts HCL or YAML; the examples below use HCL (see [Configuration Overview](overview.md#file-format) for format details).
+**Block:** `internal.traces`
 
-## Overview
+Mermin can export traces about its own operation for self-monitoring and debugging. This is separate from network flow export and is primarily used for Mermin development and advanced troubleshooting.
 
-Mermin can export traces about its own operation, enabling you to:
+**Enables you to:**
 
-* Monitor Mermin's internal performance
-* Debug issues with flow processing
-* Track eBPF program execution
-* Observe internal component interactions
-
-This is separate from network flow export and is primarily used for Mermin development and advanced troubleshooting.
+- Monitor Mermin's internal performance
+- Debug issues with flow processing
+- Track eBPF program execution
+- Observe internal component interactions
 
 ## Configuration
 
-```hcl
-internal "traces" {
-  span_fmt = "full"
+A full configuration example may be found in the [Default Configuration](./default/config.hcl).
 
-  stdout = {
-    format = "text_indent"
+### `internal.traces` block
+
+- `span_fmt` attribute
+
+  Span event format for internal traces.
+
+  **Type:** String (enum)
+
+  **Default:** `"full"`
+
+  **Valid Values:**
+
+  - `"full"`: Record all span events (enter, exit, close). The value `"plain"` is accepted and treated as `"full"`.
+
+  **Example:** Complete span lifecycle
+
+  ```hcl
+  internal "traces" {
+    span_fmt = "full"
   }
+  ```
 
-  otlp = {
-    endpoint = "http://otel-collector:4317"
-    protocol = "grpc"
-  }
-}
-```
+- `stdout` attribute
 
-## Configuration Options
+  Stdout exporter configuration for internal traces.
 
-### `span_fmt`
+  **Type:** Object
 
-**Type:** String (enum) **Default:** `"full"`
+  **Default:** `null` (disabled)
 
-Span event format for internal traces.
+  **Sub-options:**
 
-**Valid Values:**
+  - `format`: String (enum). Valid values: `"text_indent"`
 
-* `"full"`: Record all span events (enter, exit, close). The value `"plain"` is accepted and treated as `"full"`.
+  **Example:** Enable stdout export with text indent format
 
-**Example:**
-
-```hcl
-internal "traces" {
-  span_fmt = "full"  # Complete span lifecycle
-}
-```
-
-### `stdout`
-
-**Type:** Object **Default:** `null` (disabled)
-
-Stdout exporter configuration for internal traces.
-
-**Sub-options:**
-
-#### `format`
-
-**Type:** String (enum) **Valid Values:** `"text_indent"`
-
-**Example:**
-
-```hcl
-internal "traces" {
-  stdout = {
-    format = "text_indent"
-  }
-}
-```
-
-### `otlp`
-
-**Type:** Object **Default:** `null` (disabled)
-
-OTLP exporter configuration for internal traces.
-
-Uses same configuration options as main OTLP exporter (see [OTLP Exporter](export-otlp.md)).
-
-**Example:**
-
-```hcl
-internal "traces" {
-  otlp = {
-    endpoint = "http://otel-collector:4318"
-    protocol = "http_binary"
-    timeout = "10s"
-    max_batch_size = 512
-    max_batch_interval = "5s"
-
-    auth = {
-      basic = {
-        user = "mermin-internal"
-        pass = "password"
-      }
+  ```hcl
+  internal "traces" {
+    stdout = {
+      format = "text_indent"
     }
   }
-}
-```
+  ```
+
+- `otlp` attribute
+
+  OTLP exporter configuration for internal traces. Uses same configuration options as main OTLP exporter (see [OTLP Exporter](export-otlp.md)).
+
+  **Type:** Object
+
+  **Default:** `null` (disabled)
+
+  **Examples:**
+
+  - Basic OTLP export
+
+    ```hcl
+    internal "traces" {
+      otlp = {
+        endpoint = "http://otel-collector:4317"
+        protocol = "grpc"
+      }
+    }
+    ```
+
+  - OTLP export with authentication
+
+    ```hcl
+    internal "traces" {
+      otlp = {
+        endpoint = "http://otel-collector:4318"
+        protocol = "http_binary"
+        timeout = "10s"
+        max_batch_size = 512
+        max_batch_interval = "5s"
+
+        auth = {
+          basic = {
+            user = "mermin-internal"
+            pass = "password"
+          }
+        }
+      }
+    }
+    ```
 
 ## Use Cases
 
@@ -121,10 +120,10 @@ internal "traces" {
 
 **Useful for:**
 
-* eBPF program loading issues
-* Flow processing bottlenecks
-* Informer synchronization problems
-* Export pipeline issues
+- eBPF program loading issues
+- Flow processing bottlenecks
+- Informer synchronization problems
+- Export pipeline issues
 
 ### Performance Analysis
 
@@ -142,9 +141,9 @@ internal "traces" {
 
 **Analyze:**
 
-* Span duration for operations
-* Bottlenecks in processing pipeline
-* Resource usage patterns
+- Span duration for operations
+- Bottlenecks in processing pipeline
+- Resource usage patterns
 
 ### Mermin Development
 
@@ -159,55 +158,6 @@ internal "traces" {
     format = "text_indent"
   }
 }
-```
-
-## Internal Trace Examples
-
-### eBPF Program Loading
-
-```text
-Span: load_ebpf_program
-  Start: 2025-10-27T15:30:00.000Z
-  Duration: 250ms
-  Attributes:
-    program.name: mermin
-    program.type: classifier
-    interface: eth0
-  Events:
-    - attach_to_interface (eth0)
-    - verify_program_loaded
-```
-
-### Flow Processing
-
-```text
-Span: process_packet
-  Start: 2025-10-27T15:30:01.234Z
-  Duration: 0.5ms
-  Attributes:
-    packet.size: 1500
-    flow.exists: true
-    flow.state: established
-  Events:
-    - lookup_flow_table
-    - update_counters
-    - check_timeouts
-```
-
-### Kubernetes Informer Sync
-
-```text
-Span: sync_k8s_informers
-  Start: 2025-10-27T15:30:05.000Z
-  Duration: 2.5s
-  Attributes:
-    informer.type: pod
-    resources.count: 1234
-  Events:
-    - connect_to_api_server
-    - list_resources
-    - populate_cache
-    - watch_started
 ```
 
 ## Separating Network Flows and Internal Traces
@@ -234,23 +184,10 @@ internal "traces" {
 
 **Benefits:**
 
-* Separate production Flow Traces from debug data
-* Different retention policies
-* Isolate development traffic
+- Separate production Flow Traces from debug data
+- Different retention policies
+- Isolate development traffic
 
-## Performance Impact
-
-Internal tracing has minimal performance overhead:
-
-**Stdout only:**
-
-* CPU: < 1%
-* Memory: Negligible
-
-**OTLP export:**
-
-* CPU: < 2%
-* Memory: \~10-20 MB (for buffering)
 
 Safe to enable in production for troubleshooting.
 
@@ -264,7 +201,7 @@ To completely disable internal traces:
 # internal "traces" {}
 ```
 
-This is the default and recommended for most deployments.
+This is the default.
 
 ## Troubleshooting
 
@@ -279,17 +216,6 @@ This is the default and recommended for most deployments.
 3. Ensure log level is sufficient: `log_level = "debug"`
 4. Check OTLP collector is receiving data
 
-### Too Much Internal Trace Data
-
-**Symptoms:** Overwhelming volume of internal traces
-
-**Solutions:**
-
-1. Disable internal traces if not needed
-2. Send to separate collector
-3. Use sampling (if supported)
-4. Filter by span name in collector
-
 ### Internal Traces Interfering with Flow Traces
 
 **Symptoms:** Internal traces mixed with network Flow Traces
@@ -303,11 +229,10 @@ This is the default and recommended for most deployments.
 
 ## Best Practices
 
-1. **Disable by default**: Only enable when needed
-2. **Use separate collectors**: Don't mix with production Flow Traces
-3. **Enable for debugging**: Temporarily enable for troubleshooting
-4. **Monitor overhead**: Watch resource usage if enabled
-5. **Document usage**: Note why internal traces are enabled
+1. **Use separate collectors**: Don't mix with production Flow Traces
+2. **Enable for debugging**: Temporarily enable for troubleshooting
+3. **Monitor overhead**: Watch resource usage if enabled
+4. **Document usage**: Note why internal traces are enabled
 
 ## Complete Configuration Examples
 
@@ -360,32 +285,9 @@ internal "traces" {
 }
 ```
 
-## Integration with Observability Stack
-
-Internal and flow traces both use `service.name="mermin"`. To find internal traces in your backend, filter by span name or other attributes (e.g. internal span names like `load_ebpf_program`, `process_packet`, `sync_k8s_informers`).
-
-### Grafana Tempo
-
-Query internal traces in Tempo using TraceQL (Tempo's trace query language, not PromQL):
-
-```traceql
-# Find internal spans for Mermin (filter by span name)
-{ resource.service.name="mermin" && name=~"load_ebpf_program|process_packet|sync_k8s_informers" }
-
-# Find slow internal operations (duration filter)
-{ resource.service.name="mermin" && name=~"load_ebpf_program|process_packet|sync_k8s_informers" } | duration > 1s
-```
-
-### Jaeger
-
-Filter internal traces:
-
-* **Service:** `mermin` (same as flow traces; use operation/span name to narrow)
-* **Operation (span name):** `load_ebpf_program`, `process_packet`, `sync_k8s_informers`, etc.
-
 ## Next Steps
 
-* [**Global Options**](reference/README.md#configure-global-agent-options): Configure logging levels
-* Internal [**Server**](reference/internal-server.md) and [**Metrics**](metrics.md): Monitor Mermin with Prometheus
-* [**Troubleshooting**](../troubleshooting/troubleshooting.md): Debug common issues
-* [**OTLP Exporter**](export-otlp.md): Configure trace export
+- [**Global Options**](reference/README.md#configure-global-agent-options): Configure log levels
+- Internal [**Server**](reference/internal-server.md) and [**Metrics**](metrics.md): Monitor with Prometheus
+- [**Troubleshooting**](../troubleshooting/troubleshooting.md): Debug common issues
+- [**OTLP Exporter**](export-otlp.md): Configure trace export


### PR DESCRIPTION
## Changes

- reformat configuration options to use consistent attribute-based structure
- add block notation headers for config path reference
- convert options to list items with type, default, and examples on separate lines
- standardize bullet points from asterisks to dashes
- fix heading level for "High Metrics Cardinality" section

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor