### PR TITLE
docs: restructure configuration reference format for owner-relations and pipeline

### DIFF
--- a/docs/configuration/owner-relations.md
+++ b/docs/configuration/owner-relations.md
@@ -1,5 +1,7 @@
 # Configure Owner Relations of Kubernetes Resources
 
+**Block:** `discovery.informer.k8s.owner_relations`
+
 Owner relations control how Mermin walks Kubernetes owner references to enrich flows with workload controller metadata (Deployment, StatefulSet, etc.).
 Mermin accepts HCL or YAML for the config file; the examples below use HCL (see [Configuration Overview](overview.md#file-format) for format details).
 
@@ -10,73 +12,132 @@ Owner relations apply when Kubernetes discovery is enabled (`discovery "informer
 
 ## Configuration
 
-```hcl
-discovery "informer" "k8s" {
-  owner_relations = {
-    max_depth = 5
-    include_kinds = []
-    exclude_kinds = []
+A full configuration example may be found in the [Default Configuration](./default/config.hcl).
+
+### `discovery.informer.k8s` block
+
+- `owner_relations` attribute
+
+  Configuration object for Kubernetes owner reference walking and filtering.
+
+  **Type:** Object
+
+  **Default:** `{ max_depth = 5, include_kinds = [], exclude_kinds = [] }`
+
+  **Example:** Basic owner relations configuration
+
+  ```hcl
+  discovery "informer" "k8s" {
+    owner_relations = {
+      max_depth = 5
+      include_kinds = []
+      exclude_kinds = []
+    }
   }
-}
-```
+  ```
 
-## Configuration Options
+### `owner_relations` block
 
-### `max_depth`
+- `max_depth` attribute
 
-**Type:** Integer **Default:** `5`
+  Maximum depth to walk owner reference chain. Set to `0` to disable owner walking entirely.
 
-Maximum depth to walk owner reference chain.
+  **Type:** Integer
 
-**Example:**
+  **Default:** `5`
+
+  **Valid Range:** `0` to `100` (practical limit)
+
+  **Examples:**
+
+  - Walk up to 5 levels (default):
+
+    ```hcl
+    owner_relations = {
+      max_depth = 5  # Pod → RS → Deploy → ... (up to 5 levels)
+    }
+    ```
+
+  - Disable owner walking:
+
+    ```hcl
+    discovery "informer" "k8s" {
+      owner_relations = {
+        max_depth = 0
+      }
+    }
+    ```
+
+- `include_kinds` attribute
+
+  Only include these owner kinds in flow metadata. Empty array means include all supported kinds. Kind names are case-insensitive (e.g., `Deployment` and `deployment` are equivalent).
+
+  **Type:** Array of strings
+
+  **Default:** `[]` (include all)
+
+  **Valid Kinds:** `Deployment`, `ReplicaSet`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`
+
+  **Examples:**
+
+  - Include only Deployment and StatefulSet owners:
+
+    ```hcl
+    owner_relations = {
+      include_kinds = ["Deployment", "StatefulSet"]
+    }
+    ```
+
+  - Include only Job and CronJob owners:
+
+    ```hcl
+    owner_relations = {
+      include_kinds = ["Job", "CronJob"]
+    }
+    ```
+
+- `exclude_kinds` attribute
+
+  Exclude these owner kinds from flow metadata. Takes precedence over `include_kinds`. Kind names are case-insensitive.
+
+  **Type:** Array of strings
+
+  **Default:** `[]` (exclude none)
+
+  **Valid Kinds:** `Deployment`, `ReplicaSet`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`
+
+  **Examples:**
+
+  - Exclude ReplicaSet (commonly used to skip intermediate owner):
+
+    ```hcl
+    owner_relations = {
+      exclude_kinds = ["ReplicaSet"]
+    }
+    ```
+
+  - Exclude multiple kinds:
+
+    ```hcl
+    owner_relations = {
+      exclude_kinds = ["ReplicaSet", "Job"]
+    }
+    ```
+
+## Filter Priority
+
+When both `include_kinds` and `exclude_kinds` are specified:
+
+1. **Exclude takes precedence**: If a kind is in `exclude_kinds`, it is excluded regardless of `include_kinds`
+2. **Then include is applied**: If `include_kinds` is non-empty, only those kinds are included
+3. **Empty include means all**: If `include_kinds` is empty, all kinds (except excluded) are included
+
+**Example:** Include Deployment and Job, but exclude Deployment (result: only Job)
 
 ```hcl
 owner_relations = {
-  max_depth = 5  # Pod → RS → Deploy → ... (up to 5 levels)
-}
-```
-
-### `include_kinds`
-
-**Type:** Array of strings **Default:** `[]` (include all)
-
-Only include these owner kinds in flow metadata. Empty array means include all. Kind names are case-insensitive (e.g. `Deployment` and `deployment` are equivalent).
-
-**Valid kinds:** Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob
-
-**Example:**
-
-```hcl
-owner_relations = {
-  include_kinds = ["Deployment", "StatefulSet"]
-}
-```
-
-### `exclude_kinds`
-
-**Type:** Array of strings **Default:** `[]` (exclude none)
-
-Exclude these owner kinds from flow metadata. Takes precedence over `include_kinds`. Kind names are case-insensitive.
-
-**Example:**
-
-```hcl
-owner_relations = {
-  exclude_kinds = ["ReplicaSet"]
-}
-```
-
-### Default behavior
-
-If you omit the `owner_relations` block, Mermin uses default settings: `max_depth = 5`, `include_kinds = []` (include all kinds), `exclude_kinds = []`. Owner walking is enabled and all supported owner kinds are included in flow metadata.
-
-To disable owner walking (no owner metadata on flows), set `max_depth = 0`:
-
-```hcl
-discovery "informer" "k8s" {
-  owner_relations = {
-    max_depth = 0
-  }
+  include_kinds = ["Deployment", "Job"]
+  exclude_kinds = ["Deployment"]
 }
 ```
 
@@ -86,11 +147,11 @@ discovery "informer" "k8s" {
 
 **Without owner relations (or max_depth = 0):**
 
-* Flow shows only: Pod name, namespace, labels
+- Flow shows only: Pod name, namespace, labels
 
 **With owner relations (default or custom):**
 
-* Flow shows: Pod + ReplicaSet + Deployment metadata (up to `max_depth` levels, filtered by include/exclude)
+- Flow shows: Pod + ReplicaSet + Deployment metadata (up to `max_depth` levels, filtered by include/exclude)
 
 ## Complete Example
 
@@ -111,5 +172,5 @@ discovery "informer" "k8s" {
 
 ## Next Steps
 
-* [**Selector Relations**](selector-relations.md): Configure selector-based matching
-* [**Flow Attributes**](attributes.md): Configure metadata extraction
+- [**Selector Relations**](selector-relations.md): Configure selector-based matching
+- [**Flow Attributes**](attributes.md): Configure metadata extraction


### PR DESCRIPTION
## Changes

- add block name headers to document titles
- convert attribute docs to nested bullet format with separate type/default/examples
- replace plain-text tuning guidelines with tables for better readability
- standardize bullet points from asterisks to dashes
- improve code example descriptions with context

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor