### PR TITLE
fix(helm): Remove default resources from Mermin Helm chart

### DIFF
--- a/charts/mermin/templates/daemonset.yaml
+++ b/charts/mermin/templates/daemonset.yaml
@@ -96,7 +96,7 @@ spec:
                   containerName: {{ .Chart.Name }}
                   resource: requests.memory
             {{- end }}
-            {{- if (.Values.resources | dig "requests" "memory" false) }}
+            {{- if (.Values.resources | dig "limits" "memory" false) }}
             - name: POD_RESOURCES_LIMITS_MEM
               valueFrom:
                 resourceFieldRef:

--- a/docs/contributor-guide/development-workflow.md
+++ b/docs/contributor-guide/development-workflow.md
@@ -230,7 +230,7 @@ helm upgrade -i --wait --timeout 15m -n default --create-namespace \
 make helm-upgrade
 
 # With custom local config
-make helm-upgrade EXTRA_HELM_ARGS='--set-file config.content=local/config.hcl'
+make helm-upgrade HELM_EXTRA_ARGS='--set-file config.content=local/config.hcl'
 ```
 
 **Optionally install `metrics-server` to get metrics if it has not been installed yet**

--- a/docs/deployment/examples/local/values.yaml
+++ b/docs/deployment/examples/local/values.yaml
@@ -1,11 +1,3 @@
 image:
   repository: mermin
   tag: latest
-
-resources:
-  limits:
-    cpu: 201m
-    memory: 220Mi
-  requests:
-    cpu: 201m
-    memory: 220Mi

--- a/makefiles/helm.mk
+++ b/makefiles/helm.mk
@@ -21,7 +21,7 @@ define HELM_ARGS
 	--create-namespace \
 	--values ${HELM_VALUES}
 endef
-EXTRA_HELM_ARGS?=
+HELM_EXTRA_ARGS?=
 
 #######################
 # Deployment targets
@@ -31,20 +31,20 @@ helm-template:
 	rm -rf ${HELM_OUTPUT_DIR_PREFIX}
 	helm template ${APP} ${HELM_CHART} \
 		--output-dir ${HELM_OUTPUT_DIR_PREFIX} \
-		${HELM_ARGS} ${EXTRA_HELM_ARGS}
+		${HELM_ARGS} ${HELM_EXTRA_ARGS}
 
 .PHONY: helm-template-silent
 helm-template-silent:
 	@rm -rf ${HELM_OUTPUT_DIR_PREFIX} > /dev/null
 	@helm template ${APP} ${HELM_CHART} \
 		--output-dir ${HELM_OUTPUT_DIR_PREFIX} \
-		${HELM_ARGS} ${EXTRA_HELM_ARGS} > /dev/null
+		${HELM_ARGS} ${HELM_EXTRA_ARGS} > /dev/null
 
 .PHONY: helm-upgrade
 helm-upgrade:
 	helm upgrade \
 		--install --wait --timeout 10m \
-		${HELM_ARGS} ${EXTRA_HELM_ARGS} \
+		${HELM_ARGS} ${HELM_EXTRA_ARGS} \
 		${APP} ${HELM_CHART}
 
 .PHONY: k8s-diff

--- a/mermin/tests/e2e/common/setup.sh
+++ b/mermin/tests/e2e/common/setup.sh
@@ -157,7 +157,7 @@ deploy_helm_chart() {
     HELM_CHART="$HELM_CHART_PATH" \
     HELM_NAMESPACE="$NAMESPACE" \
     HELM_VALUES="$VALUES_FILE" \
-    EXTRA_HELM_ARGS="--set image.repository=$DOCKER_REPOSITORY --set image.tag=$DOCKER_IMAGE_TAG --set-file config.content=$MERMIN_CONFIG_PATH --wait --timeout=10m --create-namespace"
+    HELM_EXTRA_ARGS="--set image.repository=$DOCKER_REPOSITORY --set image.tag=$DOCKER_IMAGE_TAG --set-file config.content=$MERMIN_CONFIG_PATH --wait --timeout=10m --create-namespace"
 }
 
 # --- Main Execution ---

--- a/mermin/tests/e2e/grafana/README.md
+++ b/mermin/tests/e2e/grafana/README.md
@@ -59,7 +59,7 @@ helm repo update
 helm dependency build charts/mermin
 
 # 4.
-make helm-upgrade EXTRA_HELM_ARGS='--set-file config.content=docs/deployment/examples/local/config.hcl'
+make helm-upgrade HELM_EXTRA_ARGS='--set-file config.content=docs/deployment/examples/local/config.hcl'
 
 # 5. (optional) if you already have a Helm release, uninstall it first
 helm uninstall mermin


### PR DESCRIPTION
## Changes

Keeping default `resources` in the Helm chart may cause potential issues for the users that use default values for the `resources`

@nathaniel-d-ef Note, this change removes `POD_RESOURCES_REQUESTS_MEM`/`POD_LIMITS_REQUESTS_MEM` env. vars by default, although those are present once `resources.requersts.memory`/`resources.limits.memory` are defined.
We could use total visible memory for the calculations that were done in the feature you've worked on.

If resource requests/limits are modified in the chart, user may face unintended change when upgrading the chart

### Changes summary 
* fix: Remove default resources from Mermin Helm chart
* docs: Rename `EXTRA_HELM_ARGS` -> `HELM_EXTRA_ARGS` for consistency

Fixes #413

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Local Kind cluster

## Proof it works

<!-- Screenshots, logs, test output, or other evidence showing your changes work as expected -->

## Checklist

- [x] I've tested my changes
- [x] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [ ] All tests pass

## Notes

<!-- Anything else reviewers should know? Areas where you'd like feedback? -->
