### PR TITLE
docs: improve network-interface-discovery reference documentation

### DIFF
--- a/docs/configuration/reference/network-interface-discovery.md
+++ b/docs/configuration/reference/network-interface-discovery.md
@@ -2,9 +2,6 @@
 
 **Block:** `discovery.instrument`
 
-This page explains how Mermin discovers and monitors network interfaces on the host. Interface selection is critical for determining what network traffic Mermin captures.
-## Overview
-
 Mermin attaches eBPF programs to network interfaces to capture packets as they traverse the network stack. Interface selection is critical because different interfaces see different traffic—choosing the right interfaces ensures you capture pod-to-pod, inter-node, and external traffic without gaps or duplication. You specify interfaces using flexible patterns (literals, globs, or regex) that are resolved against available host interfaces at startup and during runtime.
 
 ## Configuration


### PR DESCRIPTION
## Changes

- Add missing configuration attributes:
  - `auto_discover_interfaces` - Enable/disable automatic interface discovery
  - `tc_priority` - TC priority for eBPF program attachment
  - `tcx_order` - TCX chain ordering (kernel ≥ 6.6)
-  Apply standard documentation outline
   - Attribute name with proper formatting
   - Clear description with context
   - Type specification
   - Default value
   - Valid values/ranges where applicable
   - Examples with use cases
   
 ### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation
- [ ] Refactor
- [ ] Other:

## Checklist
- [ ] I've tested my changes
- [X] I've updated relevant documentation
- [X] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [X] All tests pass