### PR TITLE
docs: add clarity to usage of em dashes across documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Mermin Documentation
 
-Mermin is a Kubernetes-native network observability tool that uses eBPF to capture network traffic and export it as **Flow Traces** via the OpenTelemetry Protocol (OTLP). Deploy once per node and gain deep visibility into your cluster's network communications—no application changes required.
+Mermin is a Kubernetes-native network observability tool that uses eBPF to capture network traffic and export it as **Flow Traces** via the OpenTelemetry Protocol (OTLP). Deploy once per node and gain deep visibility into your cluster's network communications — no application changes required.
 
 ![Mermin Overview](.gitbook/assets/mermin-overview.png)
 
@@ -13,18 +13,18 @@ Mermin is a Kubernetes-native network observability tool that uses eBPF to captu
 Your APM traces show application behavior. Your network monitoring shows IP-level statistics. But a critical gap exists between these two worlds: when a trace shows a slow network span, you have no way to correlate that with actual network flow data.
 When network teams see congestion, they cannot map it back to specific services or pods.
 
-The MELT stack (Metrics, Events, Logs, Traces) is missing network flow data—connection-level information that bridges application performance with network reality.
+The MELT stack (Metrics, Events, Logs, Traces) is missing network flow data — connection-level information that bridges application performance with network reality.
 
 ### What Mermin Does
 
-Mermin captures network traffic using eBPF and exports it as **Flow Traces**—network flows represented as OpenTelemetry spans. This brings network visibility into the OTel ecosystem using a standard signal type.
+Mermin captures network traffic using eBPF and exports it as **Flow Traces** — network flows represented as OpenTelemetry spans. This brings network visibility into the OTel ecosystem using a standard signal type.
 
 **The "Sweet Spot": Why Flow Data?**
 
 Observability involves trade-offs between granularity and overhead. Flow data sits between two extremes:
 
-- **Not Raw PCAP**: Full packet capture is expensive to store and query. Mermin aggregates packets into flows—you get connection-level detail without payload overhead.
-- **Not Just Counters**: Metrics tell you bandwidth usage but miss connection context—timing, retransmissions, directionality.
+- **Not Raw PCAP**: Full packet capture is expensive to store and query. Mermin aggregates packets into flows — you get connection-level detail without payload overhead.
+- **Not Just Counters**: Metrics tell you bandwidth usage but miss connection context — timing, retransmissions, directionality.
 
 Flow data provides **granular, connection-level detail that's lightweight enough to run always-on in production.**
 
@@ -51,9 +51,9 @@ Once deployed, Mermin runs as a DaemonSet with one pod per node, automatically c
 ## Key Capabilities
 
 - **Auto-Instrumentation for Your Network Stack**: Just as eBPF-based APM tools auto-instrument application code, Mermin auto-instruments your network layer.
-  Deploy once per node, get visibility into all traffic—no per-service configuration required.
+  Deploy once per node, get visibility into all traffic — no per-service configuration required.
 - **Kubernetes-Native Enrichment**: Flows include Pod, Service, and Deployment metadata. You see `frontend-service` → `redis-cache`, not `10.42.0.5` → `10.42.0.8`.
-- **Zero Code Changes**: eBPF captures traffic transparently—no sidecars, no application modifications, no service mesh required.
+- **Zero Code Changes**: eBPF captures traffic transparently — no sidecars, no application modifications, no service mesh required.
 - **Standards-Based Export**: Native OTLP output integrates with your existing observability stack (Tempo, Jaeger, Elastic, etc.).
 - **Production-Ready**: Low-overhead kernel-level capture designed for always-on operation.
 - **Comprehensive Protocol Support**: Parses and tracks TCP, UDP, ICMP traffic, with support for common tunneling protocols (VXLAN, Geneve, WireGuard).

--- a/docs/concepts/agent-architecture.md
+++ b/docs/concepts/agent-architecture.md
@@ -107,7 +107,7 @@ The userspace Mermin agent receives packets from eBPF and aggregates them into n
 - **State Tracking**: Maintains connection state for TCP (SYN, FIN, RST flags)
 - **Timeout Management**: Expires inactive flows based on [configurable timeouts](../configuration/reference/flow-span-producer.md)
 - **Protocol Parsing**: Deep packet inspection for tunneling protocols (VXLAN, Geneve, WireGuard)
-- **Community ID**: Generates standard [Community ID](https://github.com/corelight/community-id-spec) hashes—a deterministic identifier based on the flow's five-tuple that enables correlation across different monitoring points
+- **Community ID**: Generates standard [Community ID](https://github.com/corelight/community-id-spec) hashes — a deterministic identifier based on the flow's five-tuple that enables correlation across different monitoring points
 
 A [Flow Trace Span](semantic-conventions.md) includes:
 

--- a/docs/concepts/introduction-to-flow-traces.md
+++ b/docs/concepts/introduction-to-flow-traces.md
@@ -12,14 +12,14 @@ It is intended for those who want to understand the core concepts and motivation
 A **Flow Trace** is an OpenTelemetry trace that represents a network connection. It is composed of one or more **Flow Trace Spans**, where each span captures a measurement interval of the network conversation.
 
 Unlike traditional OpenTelemetry traces that focus on application-level requests (HTTP calls, database queries, etc.),
-a Flow Trace captures the network conversation itself—the bidirectional exchange of packets between two endpoints as observed by an independent monitoring point like an eBPF agent.
+a Flow Trace captures the network conversation itself — the bidirectional exchange of packets between two endpoints as observed by an independent monitoring point like an eBPF agent.
 
 ### Flow Trace vs. Flow Trace Span
 
-- **Flow Trace Span**: A single OpenTelemetry span representing one flow record—a snapshot of the network conversation during a specific observation window.
+- **Flow Trace Span**: A single OpenTelemetry span representing one flow record — a snapshot of the network conversation during a specific observation window.
 When a flow is active, the agent exports periodic spans (e.g., every 60 seconds) with delta metrics for that interval.
 
-- **Flow Trace**: The complete collection of related Flow Trace Spans that together represent the full lifecycle of a network connection—from the first packet to the last.
+- **Flow Trace**: The complete collection of related Flow Trace Spans that together represent the full lifecycle of a network connection — from the first packet to the last.
 
 Think of it like a long-running database connection: individual spans might represent periodic health checks or query batches, but the trace as a whole represents the connection's lifetime.
 
@@ -29,7 +29,7 @@ Think of it like a long-running database connection: individual spans might repr
 
 ### The Observability Gap
 
-The modern observability stack—Metrics, Events, Logs, and Traces (MELT)—excels at application-level visibility. APM traces show you request latency, error rates, and service dependencies.'
+The modern observability stack — Metrics, Events, Logs, and Traces (MELT) — excels at application-level visibility. APM traces show you request latency, error rates, and service dependencies.'
 Network monitoring gives you bandwidth utilization and interface statistics.
 
 But there's a gap between these two worlds:
@@ -42,7 +42,7 @@ But there's a gap between these two worlds:
 
 ### Why Traces?
 
-Representing network flows as OpenTelemetry traces—rather than logs, events, or metrics—is a deliberate choice that unlocks capabilities the other signal types cannot provide.
+Representing network flows as OpenTelemetry traces — rather than logs, events, or metrics — is a deliberate choice that unlocks capabilities the other signal types cannot provide.
 
 #### Traces Preserve Temporal Context
 
@@ -51,7 +51,7 @@ Unlike logs or flat events, traces have explicit start and end times that repres
 - **Connection lifecycle visibility**: See exactly when a connection started, how long it lasted, and when it ended.
 - **Smooth, continuous export**: Flow Trace Spans are exported based on timeouts (active/inactive), spreading data evenly rather than dumping all tracked flows in bursts.
 
-Treating flows as logs or events loses this timing precision—you get timestamps, but not duration or the natural parent-child relationships traces provide.
+Treating flows as logs or events loses this timing precision — you get timestamps, but not duration or the natural parent-child relationships traces provide.
 
 #### Traces Are Richer Than Metrics
 
@@ -64,7 +64,7 @@ Flow Traces preserve connection-level detail that metrics cannot:
 - **Per-connection timing**: Analyze handshake latency, round-trip time, and jitter for individual flows.
 - **Full five-tuple context**: Every flow is tied to specific source/destination addresses and ports.
 
-This is the kind of data network engineers are used to from traditional flow tools—but now it's available in your observability platform alongside your application traces.
+This is the kind of data network engineers are used to from traditional flow tools — but now it's available in your observability platform alongside your application traces.
 
 #### Native OTel Ecosystem Integration
 
@@ -76,13 +76,13 @@ By using OTLP traces as the export format, Flow Traces slot directly into the Op
 
 ### Why Not Just Use Existing Conventions?
 
-Existing OpenTelemetry network conventions are designed from the perspective of an instrumented application—capturing a client's outbound request or a server's inbound response. They model a single side of a single request.
+Existing OpenTelemetry network conventions are designed from the perspective of an instrumented application — capturing a client's outbound request or a server's inbound response. They model a single side of a single request.
 
 Network flow observability is fundamentally different:
 
 1. **Third-Party Observation**: The observer (an eBPF agent or network device) is independent of both endpoints. It sees the complete, bidirectional conversation without being a participant.
 
-2. **Bidirectional by Nature**: A network flow inherently includes both directions—packets from source to destination *and* packets from destination back to source. Both must be captured together.
+2. **Bidirectional by Nature**: A network flow inherently includes both directions — packets from source to destination *and* packets from destination back to source. Both must be captured together.
 
 3. **Continuous Measurement**: Unlike request/response traces that have clear start and end points, network connections can persist for hours or days. Flow Traces handle this through periodic span exports with delta metrics.
 
@@ -94,7 +94,7 @@ Observability involves trade-offs between granularity and overhead. Flow data oc
 
 - **Not Raw Packet Capture**: Full PCAP is expensive to store and query, capturing every byte of every packet. Flow Traces aggregate packets into connection-level summaries.
 
-- **Not Just Counters**: Metrics tell you bandwidth usage but lose connection context—timing, retransmissions, TCP flags, and directionality are all lost in aggregation.
+- **Not Just Counters**: Metrics tell you bandwidth usage but lose connection context — timing, retransmissions, TCP flags, and directionality are all lost in aggregation.
 
 Flow data provides **granular, connection-level detail that's lightweight enough to run always-on in production**.
 
@@ -108,7 +108,7 @@ Flow data provides **granular, connection-level detail that's lightweight enough
 
 - **Provide Full Context**: Capture not just the five-tuple, but also bidirectional metrics, performance data (latency/jitter), tunnel information, and rich Kubernetes metadata.
 
-- **Backend Flexibility**: Use standard OTLP export so Flow Traces work with any OpenTelemetry-compatible observability platform—no specialized NetFlow collectors required.
+- **Backend Flexibility**: Use standard OTLP export so Flow Traces work with any OpenTelemetry-compatible observability platform — no specialized NetFlow collectors required.
 
 ---
 
@@ -119,7 +119,7 @@ Flow data provides **granular, connection-level detail that's lightweight enough
 The fundamental mapping is straightforward: one flow record becomes one span.
 
 - The **span's start and end times** represent the observation window of the flow record.
-- The **span's attributes** contain all the details of the flow—endpoints, protocol, metrics, and metadata.
+- The **span's attributes** contain all the details of the flow — endpoints, protocol, metrics, and metadata.
 - The **span kind** (`CLIENT`, `SERVER`, or `INTERNAL`) indicates the observer's inferred direction of the connection.
 
 ### Bidirectional Metrics
@@ -137,7 +137,7 @@ Attributes are organized into logical groups to keep the convention clean and qu
 
 | Namespace                    | Purpose                                                                                       |
 |------------------------------|-----------------------------------------------------------------------------------------------|
-| `flow.*`                     | The conversation itself—metrics, state, and metadata that can change over the flow's lifetime |
+| `flow.*`                     | The conversation itself — metrics, state, and metadata that can change over the flow's lifetime |
 | `network.*`                  | Protocol-specific details that remain static for the flow (IP version, transport protocol)    |
 | `source.*` / `destination.*` | Information about the two endpoints, including addresses, ports, and Kubernetes metadata      |
 | `tunnel.*`                   | Encapsulation details when traffic is tunneled (VXLAN, Geneve, WireGuard, etc.)               |

--- a/docs/concepts/semantic-conventions.md
+++ b/docs/concepts/semantic-conventions.md
@@ -31,8 +31,8 @@ The values mirror [IPFIX biflow](https://datatracker.ietf.org/doc/html/rfc5103) 
 
 | Value     | Description                                                                                                                 |
 |-----------|-----------------------------------------------------------------------------------------------------------------------------|
-| `forward` | The flow record describes traffic in the forward direction—from the connection initiator to the responder (client → server) |
-| `reverse` | The flow record describes traffic in the reverse direction—from the responder back to the initiator (server → client)       |
+| `forward` | The flow record describes traffic in the forward direction — from the connection initiator to the responder (client → server) |
+| `reverse` | The flow record describes traffic in the reverse direction — from the responder back to the initiator (server → client)       |
 | `unknown` | The direction could not be reliably determined                                                                              |
 
 The `flow.direction` attribute MUST be consistent with the Span Kind when both are present:
@@ -62,7 +62,7 @@ To ensure clarity, this convention uses and defines specific attribute namespace
 - **`tunnel.*`**: Describes tunneling protocols and encapsulation metadata (e.g., tunnel.type, tunnel.id). This is always the outer-most tunnel or encapsulation.
 - **`process.*` / `container.*`**: Existing OTel namespaces used to identify the host process or container associated with the flow's socket.
 
-The `flow.*` namespace is critical for creating a clear semantic distinction. It separates attributes of a flow—a dynamic conversation between two endpoints over time—from attributes of a network entity, like a physical interface,
+The `flow.*` namespace is critical for creating a clear semantic distinction. It separates attributes of a flow — a dynamic conversation between two endpoints over time — from attributes of a network entity, like a physical interface,
 whose properties are generally static. Overloading the existing network.\* namespace with dynamic flow concepts would create ambiguity.
 
 ### Why `source.k8s.*` Instead of `k8s.source.*`?
@@ -77,8 +77,8 @@ There is no privileged "recording side." The `source`/`destination` prefixes est
 3. **Consistency with networking industry conventions.** Traditional flow protocols (NetFlow, IPFIX, sFlow) and eBPF-based tools universally structure directional metadata with the direction first.
    Using `source.k8s.*` aligns with these patterns, making the schema intuitive for network engineers.
 4. **Query ergonomics and grouping.** Placing the directional prefix first enables efficient queries like `source.k8s.*` to retrieve all Kubernetes context for one side of the flow. If the hierarchy were inverted (`k8s.source.*`),
-querying "all source endpoint attributes" would require combining `source.address`, `source.port`, and `k8s.source.*`—three separate prefix patterns instead of one.
-5. **Avoiding OTel resource attribute ambiguity.** Standard OTel `k8s.*` attributes (e.g., `k8s.pod.name`) describe the resource where telemetry originates—typically the observing agent's own pod. For flow data,
+querying "all source endpoint attributes" would require combining `source.address`, `source.port`, and `k8s.source.*` — three separate prefix patterns instead of one.
+5. **Avoiding OTel resource attribute ambiguity.** Standard OTel `k8s.*` attributes (e.g., `k8s.pod.name`) describe the resource where telemetry originates — typically the observing agent's own pod. For flow data,
 we need to describe _two_ remote endpoints, neither of which is necessarily the agent itself. Using `source.k8s.*` / `destination.k8s.*` clearly distinguishes flow endpoint metadata from resource-level attributes,
 preventing confusion about which entity is being described.
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -43,7 +43,7 @@ Flow capture may pause briefly during reload. Some changes (e.g. interface selec
 
 ## Minimal configuration
 
-Without a config file, Mermin uses built-in defaults and does not configure an exporter—flow data is not sent anywhere. To send flow traces to an OTLP endpoint with default settings, create a config file that sets only the export block:
+Without a config file, Mermin uses built-in defaults and does not configure an exporter — flow data is not sent anywhere. To send flow traces to an OTLP endpoint with default settings, create a config file that sets only the export block:
 
 ```hcl
 export "traces" {
@@ -243,7 +243,7 @@ Fix the file and restart (or rely on auto-reload after fixing). In Kubernetes, M
 
 ## HCL functions
 
-HCL config files (not YAML) support the `env` function to read environment variables—useful for secrets or environment-specific values without hardcoding. The function evaluates when the config loads and again on reload.
+HCL config files (not YAML) support the `env` function to read environment variables — useful for secrets or environment-specific values without hardcoding. The function evaluates when the config loads and again on reload.
 
 - `env("VAR_NAME")`
   Returns the value of the environment variable, or an empty string if unset. Mermin logs a warning when the variable is not set.

--- a/docs/configuration/reference/flow-span-producer.md
+++ b/docs/configuration/reference/flow-span-producer.md
@@ -101,7 +101,7 @@ A full configuration example can be found in the [Default Configuration](../defa
 
 - `tcp_rst_timeout` attribute
 
-  When a TCP RST (reset) is observed—indicating an abrupt connection termination—the flow waits for the specified `tcp_rst_timeout` before being exported.
+  When a TCP RST (reset) is observed — indicating an abrupt connection termination — the flow waits for the specified `tcp_rst_timeout` before being exported.
   This timeout is evaluated for each flow individually after an RST is detected, ensuring even abruptly closed connections are accounted for with a brief post-RST delay before export.
 
   **Type:** Duration

--- a/docs/configuration/reference/network-interface-discovery.md
+++ b/docs/configuration/reference/network-interface-discovery.md
@@ -2,7 +2,7 @@
 
 **Block:** `discovery.instrument`
 
-Mermin attaches eBPF programs to network interfaces to capture packets as they traverse the network stack. Interface selection is critical because different interfaces see different traffic—choosing the right interfaces ensures you capture pod-to-pod, inter-node, and external traffic without gaps or duplication. You specify interfaces using flexible patterns (literals, globs, or regex) that are resolved against available host interfaces at startup and during runtime.
+Mermin attaches eBPF programs to network interfaces to capture packets as they traverse the network stack. Interface selection is critical because different interfaces see different traffic — choosing the right interfaces ensures you capture pod-to-pod, inter-node, and external traffic without gaps or duplication. You specify interfaces using flexible patterns (literals, globs, or regex) that are resolved against available host interfaces at startup and during runtime.
 
 ## Configuration
 

--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -368,7 +368,7 @@ Congratulations! You've successfully deployed Mermin and captured network flows.
 {% endtab %}
 
 {% tab title="Learn the Fundamentals" %}
-1. [**Understand How Mermin Works**](../concepts/agent-architecture.md): Deep dive into the agent architecture
+1. [**Understand How Mermin Works**](../concepts/agent-architecture.md): Deep-dive into the agent architecture
 2. [**Explore Flow Trace Semantics**](../concepts/introduction-to-flow-traces.md): Learn what each attribute means
 {% endtab %}
 

--- a/docs/troubleshooting/common-ebpf-errors.md
+++ b/docs/troubleshooting/common-ebpf-errors.md
@@ -23,11 +23,11 @@ For detailed explanations and solutions, see the sections below.
 
 ## What You Need to Know About the Verifier
 
-Verifier errors are rare on modern kernels. Most Mermin deployments work without issues.
+Verifier errors are rare on modern kernels. Most Mermin deployments work without issues. 
 
-Problems typically occur on older kernel versions (< 5.16) that lack sophisticated complexity analysis. These kernels are more conservative and may reject programs that newer kernels accept.
+Problems typically occur on older kernel versions (< 5.16) that lack sophisticated complexity analysis, and are more conservative.
 
-The eBPF verifier has evolved considerably over time. A program that loads perfectly on a newer kernel might fail on an older one:
+The eBPF verifier has evolved considerably over time. What newer kernels accept, older kernels may reject:
 
 - **Kernel 5.4-5.10**: The early days - stricter bounds checking, more conservative validation
 - **Kernel 5.11-5.15**: Getting smarter - improved range tracking and better loop handling
@@ -130,7 +130,7 @@ back-edge from insn X to Y
 infinite loop detected at insn X
 ```
 
-**Cause**: The verifier found a loop without a provable upper bound. Every eBPF loop must have a maximum iteration count determinable at verification time. The verifier rejects programs with loops that cannot be proven to exit—a fundamental safety requirement to prevent kernel freezes.
+**Cause**: The verifier found a loop without a provable upper bound. Every eBPF loop must have a maximum iteration count determinable at verification time. The verifier rejects programs with loops that cannot be proven to exit – a fundamental safety requirement to prevent kernel freezes.
 
 ### Stack Size Exceeded
 
@@ -206,7 +206,7 @@ ERROR mermin: ebpf - ring buffer full - dropping flow event for new flow
 
 ## Understanding TC Priority and TCX Order
 
-Beyond verifier errors, there's another important aspect of eBPF program loading: execution order. When multiple eBPF programs are attached to the same network interface, the order they run in matters—a lot.
+Beyond verifier errors, there's another important aspect of eBPF program loading: execution order. When multiple eBPF programs are attached to the same network interface, the order they run in matters — a lot.
 
 TC (Traffic Control) priority and TCX ordering control when your eBPF program runs relative to other programs (like your CNI). This affects which packets Mermin sees and in what state (before or after CNI modifications like NAT or encapsulation).
 

--- a/docs/troubleshooting/deployment-issues.md
+++ b/docs/troubleshooting/deployment-issues.md
@@ -190,7 +190,7 @@ kubectl exec -n mermin $POD -- env MERMIN_LOG_LEVEL=debug mermin diagnose bpf --
 
 #### 1. Missing Linux Capabilities
 
-`Operation not permitted` indicates missing Linux capabilities—the most common issue.
+`Operation not permitted` indicates missing Linux capabilities — the most common issue.
 
 **The Helm chart sets `privileged: true` by default**, which grants all necessary capabilities. This is the simplest and most reliable approach:
 
@@ -229,7 +229,7 @@ Without `hostPID: true`, Mermin can't attach eBPF programs to host network inter
 
 #### 2. Kernel Version Too Old
 
-`Invalid argument` or `Function not implemented` indicates a kernel too old for eBPF support.
+`Invalid argument` or `Function not implemented` indicates a kernel which is too old for eBPF support.
 
 **Check your kernel version**:
 

--- a/docs/troubleshooting/interface-visibility-and-traffic-decapsulation.md
+++ b/docs/troubleshooting/interface-visibility-and-traffic-decapsulation.md
@@ -102,7 +102,7 @@ Imagine Pod A on Node 1 wants to send an HTTP request to Pod B on Node 2. Here's
 └───────────────────────────────────────────────────────────────┘
 ```
 
-**The key insight**: Same-node traffic never gets encapsulated because it never needs to leave the host. It's like two people in the same building passing notes directly—no need for the postal system!
+**The key insight**: Same-node traffic never gets encapsulated because it never needs to leave the host. It's like two people in the same building passing notes directly — no need for the postal system!
 
 ## What You See on Different Interface Types
 


### PR DESCRIPTION
## Changes

Standardize em dash usage across documentation for improved readability.

Style guides disagree on this concept, but when doing a full review I found the lack of spaces challenging to read, especially when the word following the dash was compound (e.g. something like data—connection-level). This PR makes the docs consistent.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Documentation
- [ ] Refactor
- [ ] Other: