### PR TITLE
fix: Workaround the LLVM SHA1 apt repo (trixie) issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN useradd --create-home --shell /bin/bash poseidon \
     && echo "poseidon ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/poseidon
 
 # Install LLVM
-# Workaround she LLVM signing issue, https://github.com/llvm/llvm-project/issues/153385#issuecomment-3239875987
+# Workaround for LLVM signing issue, https://github.com/llvm/llvm-project/issues/153385#issuecomment-3239875987
 # hadolint ignore=DL3059 # multi-stage build, more RUN -> better caching
 RUN sed -i 's/sha1.second_preimage_resistance = 2026-02-01/sha1.second_preimage_resistance = 2026-04-01/' /usr/share/apt/default-sequoia.config
 # hadolint ignore=DL3059 # multi-stage build, more RUN -> better caching


### PR DESCRIPTION
## Changes

Workaround the LLVM SHA1 apt repo (trixie) [issue](https://github.com/llvm/llvm-project/issues/153385#issuecomment-3239875987)

The workaround is simply to push the deadline for hard rejection of SHA1 till 2026-04-01, after the date if upstream is not fixed the workaround should be re-evaluated

Fixes #(issue)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

Local build + CI build

## Proof it works

N/A

## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [ ] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [ ] All tests pass

## Notes

<!-- Anything else reviewers should know? Areas where you'd like feedback? -->
