### PR TITLE
fix: avoid attribution to closing pods

### DIFF
--- a/mermin/src/k8s/attributor.rs
+++ b/mermin/src/k8s/attributor.rs
@@ -1473,6 +1473,10 @@ async fn index_resource_by_ip<K>(
 
     for source in ip_sources {
         for resource in store.store().state() {
+            if resource.meta().deletion_timestamp.is_some() {
+                continue;
+            }
+
             let is_pod = std::any::TypeId::of::<K>() == std::any::TypeId::of::<Pod>();
             let is_host_network = if is_pod {
                 is_host_network_resource(resource.as_ref())
@@ -1516,6 +1520,10 @@ async fn index_resource_by_ip<K>(
 
 /// Extracts IP addresses from a Pod resource
 fn extract_pod_ips(pod: &Pod) -> HashSet<String> {
+    if pod.metadata.deletion_timestamp.is_some() {
+        return HashSet::new();
+    }
+
     let mut ips = HashSet::new();
     let is_host_network = is_host_network_resource(pod);
 


### PR DESCRIPTION
## Changes

Fixes race condition in Kubernetes IP attribution caused by IP reuse during pod termination. When a pod is deleted, Kubernetes sets a `deletion_timestamp` but the pod may still retain its IP address during the terminating phase. This caused attribution conflicts when a new pod was assigned the same IP before the old pod fully terminated.

The fix adds checks for `deletion_timestamp` in two key locations:
1. **`extract_pod_ips` function**: Immediately returns empty IP set for pods marked for deletion
2. **`index_resource_by_ip` function**: Skips indexing any resource (including pods) that has a deletion timestamp

This ensures that the moment a pod starts terminating, its IP is "freed" in Mermin's attribution index, preventing conflicts with new pods that receive the same IP.

Fixes #MER-48

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [ ] Other:

## Testing

The fix was tested by reproducing the race condition scenario where:
1. A `traffic-gen` pod in the `default` namespace was active
2. A `traffic-gen` pod in `remote-ns` was terminating but still held the same IP (10.244.2.5)
3. Before the fix: Both pods appeared in attribution for the same IP, causing incorrect metadata attribution
4. After the fix: Only the active pod appears in attribution, eliminating the race condition

Testing environment: Kubernetes cluster with rapid pod creation/deletion cycles to trigger IP reuse scenarios.

## Proof it works

**Before the fix:**
- Panel 3 in Grafana showed interleaved attribution: `default / traffic-gen` and `remote-ns / traffic-gen` for the same IP
- Race condition occurred at timestamp `19:05:35` showing both namespaces attributed to IP `10.244.2.5`

<img width="1306" height="1130" alt="image" src="https://github.com/user-attachments/assets/969e127f-0805-498e-b156-e81305bb457a" />

**After the fix:**
- Clean attribution transition: `default` rows stop cleanly, `remote-ns` rows start without overlap
- No more "ghost" attributions from terminating pods
- IP conflicts resolved immediately when pods enter terminating state

<img width="1350" height="635" alt="Screenshot 2026-02-19 at 1 40 05 PM" src="https://github.com/user-attachments/assets/50a982b1-4749-44d3-a117-91561130d27e" />

## Checklist

- [x] I've tested my changes
- [ ] I've updated relevant documentation
- [x] My code follows the project's style (run `cargo fmt` and `cargo clippy`)
- [x] All tests pass

## Notes

**Technical Details:**
- The fix leverages Kubernetes' `metadata.deletion_timestamp` field which is set immediately when a pod deletion is initiated
- This approach is more reliable than waiting for the pod to fully terminate, as it prevents the attribution conflict window entirely
- The fix is applied both at the IP extraction level (`extract_pod_ips`) and at the indexing level (`index_resource_by_ip`) for comprehensive coverage

**Impact:**
- Eliminates false positive attributions in network flow monitoring
- Improves accuracy of Kubernetes network observability
- Prevents confusion in dashboards and metrics during pod lifecycle transitions

The fix is minimal, focused, and addresses the root cause without affecting normal pod attribution functionality.