### PR TITLE
refactor: reduce logging noise, simplify docs, and remove dead code

### DIFF
--- a/mermin/src/error.rs
+++ b/mermin/src/error.rs
@@ -5,58 +5,43 @@ use crate::{
     span::producer::BootTimeError,
 };
 
-/// Main application error type for Mermin
 #[derive(Debug, Error)]
 pub enum MerminError {
-    /// Kubernetes-related errors
     #[error("kubernetes error: {0}")]
     K8s(#[from] K8sError),
 
-    /// OTLP/tracing-related errors
     #[error("OTLP error: {0}")]
     Otlp(#[from] OtlpError),
 
-    /// Health check/API server errors
     #[error("health check error: {0}")]
     Health(#[from] HealthError),
 
-    /// Runtime initialization errors
     #[error("configuration error: {0}")]
     Conf(#[from] ConfError),
 
-    /// Boot time calculation errors
     #[error("boot time error: {0}")]
     BootTime(#[from] BootTimeError),
 
-    /// eBPF loading errors
     #[error("failed to load eBPF program: {0}")]
     EbpfLoad(#[from] aya::EbpfError),
 
-    /// eBPF program errors
     #[error("eBPF program error: {0}")]
     EbpfProgram(#[from] aya::programs::ProgramError),
 
-    /// eBPF map conversion errors
     #[error("eBPF map conversion error: {0}")]
     EbpfMapConversion(#[from] aya::maps::MapError),
 
-    /// Signal handling errors
     #[error("signal handling error: {0}")]
     Signal(#[from] std::io::Error),
 
-    /// Generic internal error
     #[error("internal error: {0}")]
-    #[allow(dead_code)]
     Internal(String),
 }
 
 impl MerminError {
-    /// Create an internal error
-    #[allow(dead_code)]
     pub fn internal(msg: impl Into<String>) -> Self {
         Self::Internal(msg.into())
     }
 }
 
-/// Type alias for Result with MerminError
 pub type Result<T> = std::result::Result<T, MerminError>;

--- a/mermin/src/health/handlers.rs
+++ b/mermin/src/health/handlers.rs
@@ -14,7 +14,7 @@ use axum::{
 use serde_json::json;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use crate::{health::HealthError, runtime::opts::ServerConf};
 
@@ -38,8 +38,6 @@ impl Default for HealthState {
 }
 
 pub async fn liveness_handler(State(state): State<HealthState>) -> impl IntoResponse {
-    let start = std::time::Instant::now();
-
     let ebpf_loaded = state.ebpf_loaded.load(Ordering::Relaxed);
     let startup_complete = state.startup_complete.load(Ordering::Relaxed);
 
@@ -58,16 +56,6 @@ pub async fn liveness_handler(State(state): State<HealthState>) -> impl IntoResp
         );
         StatusCode::SERVICE_UNAVAILABLE
     };
-
-    let duration = start.elapsed();
-    debug!(
-        event.name = "health.liveness.checked",
-        http.response.status_code = status_code.as_u16(),
-        duration_us = duration.as_micros(),
-        ebpf_loaded = ebpf_loaded,
-        startup_complete = startup_complete,
-        "liveness check completed"
-    );
 
     let body = Json(json!({
         "status": if is_alive { "ok" } else { "unavailable" },
@@ -117,11 +105,7 @@ pub async fn startup_handler(State(state): State<HealthState>) -> impl IntoRespo
     let status_code = if startup_complete {
         StatusCode::OK
     } else {
-        warn!(
-            event.name = "health.startup.failed",
-            startup_complete = %startup_complete,
-            "startup check failed"
-        );
+        warn!(event.name = "health.startup.failed", "startup check failed");
         StatusCode::SERVICE_UNAVAILABLE
     };
 

--- a/mermin/src/iface/controller.rs
+++ b/mermin/src/iface/controller.rs
@@ -144,7 +144,7 @@ use aya::{
 use crossbeam::channel::Sender;
 use globset::Glob;
 use pnet::datalink;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::{
     error::MerminError,
@@ -239,24 +239,8 @@ const PROGRAM_NAME_EGRESS: &str = "mermin_flow_egress";
 const DIRECTIONS: &[&str] = &[DIRECTION_INGRESS, DIRECTION_EGRESS];
 
 impl IfaceController {
-    /// Create blocking controller that runs in host network namespace.
-    ///
-    /// This constructor is called from the MAIN thread (before namespace switch).
-    /// The controller is then moved to a dedicated thread which enters the host
-    /// namespace via `setns()`. Interface discovery happens in `initialize()` after
-    /// the namespace switch.
-    ///
-    /// ## Arguments
-    ///
-    /// - `patterns` - Glob patterns for matching interface names (e.g., "eth*", "ens*")
-    /// - `iface_map` - Shared interface index → name map for packet decoration
-    /// - `ebpf` - eBPF object with loaded programs (maps must be extracted beforehand)
-    /// - `use_tcx` - Whether to use TCX (kernel >= 6.6) or netlink attachment
-    /// - `bpf_fs_writable` - Whether /sys/fs/bpf is writable for TCX link pinning
-    /// - `tc_priority` - TC priority for netlink mode (lower number = higher priority)
-    /// - `tcx_order` - TCX ordering strategy (First or Last in chain)
-    /// - `event_tx` - Optional channel for sending controller events for observability
-    /// - `cleanup_tracker` - Optional cleanup tracker for removing stale metrics
+    /// Create controller. Called from the main thread before namespace switch;
+    /// interface discovery happens in `initialize()` after `setns()`.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         patterns: Vec<String>,
@@ -297,7 +281,7 @@ impl IfaceController {
     /// This is a blocking operation that should be called once after controller creation.
     /// Thread must already be in host network namespace.
     pub fn initialize(&mut self) -> Result<(), MerminError> {
-        info!(
+        debug!(
             event.name = "interface_controller.init_resolving_interfaces",
             pattern_count = self.patterns.len(),
             "resolving interface patterns to concrete interface names"
@@ -311,7 +295,7 @@ impl IfaceController {
             v
         };
 
-        info!(
+        debug!(
             event.name = "interface_controller.init_interfaces_resolved",
             iface_count = self.active_ifaces.len(),
             interfaces = ?sorted_ifaces,
@@ -319,23 +303,10 @@ impl IfaceController {
         );
 
         if self.use_tcx {
-            info!(
-                event.name = "interface_controller.init_mode_resolved",
-                tcx_mode = true,
-                bpf_fs_writable = self.bpf_fs_writable,
-                tcx_order = %self.tcx_order,
-                "tcx mode enabled (kernel >= 6.6), using bpf_fs for cleanup"
-            );
             metrics::registry::EBPF_ATTACHMENT_MODE
                 .with_label_values(&["tcx"])
                 .set(1);
         } else {
-            info!(
-                event.name = "interface_controller.init_mode_resolved",
-                tcx_mode = false,
-                tc_priority = self.tc_priority,
-                "legacy tc mode enabled (netlink), using internal cleanup"
-            );
             metrics::registry::EBPF_ATTACHMENT_MODE
                 .with_label_values(&["tc"])
                 .set(1);
@@ -377,7 +348,6 @@ impl IfaceController {
             }
         }
 
-        // Send events for failed attachments
         for failed_iface in &failed_ifaces {
             if let Some(ref tx) = self.event_tx {
                 let _ = tx.send(ControllerEvent::AttachmentFailed {
@@ -387,8 +357,6 @@ impl IfaceController {
             }
         }
 
-        // Only remove interfaces that had failures and didn't succeed completely
-        // Cleanup partial attachments for these interfaces
         for failed_iface in &failed_ifaces {
             let successful_attachments = success_per_iface.get(failed_iface).copied().unwrap_or(0);
             if successful_attachments < programs.len() as u32 {
@@ -408,7 +376,6 @@ impl IfaceController {
             }
         }
 
-        // Send events for successfully attached interfaces
         for iface in &ifaces {
             if !failed_ifaces.contains(iface)
                 && let Some(ref tx) = self.event_tx
@@ -447,7 +414,7 @@ impl IfaceController {
         let mut detached_count = 0;
         let mut failed_count = 0;
 
-        info!(
+        debug!(
             event.name = "interface_controller.shutdown_started",
             total_links = total_links,
             "starting graceful shutdown and ebpf program detachment"
@@ -459,12 +426,6 @@ impl IfaceController {
             match self.detach_program(&iface, direction, link_id) {
                 Ok(_) => {
                     detached_count += 1;
-                    debug!(
-                        event.name = "interface_controller.program_detached",
-                        network.interface.name = %iface,
-                        ebpf.program.direction = %direction,
-                        "successfully detached ebpf program"
-                    );
                 }
                 Err(e) => {
                     failed_count += 1;
@@ -479,7 +440,7 @@ impl IfaceController {
             }
         }
 
-        info!(
+        debug!(
             event.name = "interface_controller.shutdown_completed",
             total_links = total_links,
             detached_count = detached_count,
@@ -604,7 +565,6 @@ impl IfaceController {
                                     "failed to attach program to new interface, rolling back"
                                 );
 
-                                // Rollback: detach any successfully attached programs
                                 for prev_attach_type in attached_programs {
                                     let direction = prev_attach_type.direction_name();
                                     if let Err(detach_err) =
@@ -703,19 +663,9 @@ impl IfaceController {
         let direction_name = attach_type.direction_name();
         let use_tcx = self.use_tcx;
         let tc_priority = self.tc_priority;
-
         let program_name = attach_type.program_name();
 
-        // TCX (kernel >= 6.6) doesn't require clsact qdisc
-        // Netlink mode (kernel < 6.6) requires clsact qdisc
-        if !use_tcx && let Err(e) = tc::qdisc_add_clsact(&iface_owned) {
-            debug!(
-                event.name = "interface_controller.qdisc_add_skipped",
-                network.interface.name = %iface_owned,
-                error = %e,
-                "clsact qdisc add failed (likely already exists)"
-            );
-        }
+        if !use_tcx && let Err(_) = tc::qdisc_add_clsact(&iface_owned) {}
 
         let program: &mut SchedClassifier = self
             .ebpf
@@ -728,31 +678,11 @@ impl IfaceController {
             .try_into()
             .map_err(|e| MerminError::internal(format!("failed to cast program: {e}")))?;
 
-        // TC Priority-Aware Attachment
-        //
-        // For TCX (kernel >= 6.6): use configured ordering strategy
-        // For Netlink (kernel < 6.6): use priority-aware attachment
-        //
-        // Note: TCX provides better multi-program support without priority conflicts.
-        // On older kernels, we explicitly use netlink with our configured priority.
-
         if use_tcx {
-            // TCX mode: kernel >= 6.6, attach with configured ordering
-            // TCX supports multiple programs on the same hook, so attachment
-            // succeeds even if orphaned programs exist from crashed instances
             let link_order = match self.tcx_order {
                 TcxOrderStrategy::Last => LinkOrder::last(),
                 TcxOrderStrategy::First => LinkOrder::first(),
             };
-
-            debug!(
-                event.name = "interface_controller.attaching_tcx",
-                network.interface.name = %iface_owned,
-                ebpf.program.direction = direction_name,
-                ebpf.tcx.order = %self.tcx_order,
-                "attaching ebpf program with TCX ordering - \
-                 will pin link for orphan cleanup on restart"
-            );
 
             let options = TcAttachOptions::TcxOrder(link_order);
             let link_id = program
@@ -827,15 +757,6 @@ impl IfaceController {
                 );
             }
         } else {
-            // Netlink mode: kernel < 6.6, use priority
-            debug!(
-                event.name = "interface_controller.attaching_with_priority",
-                network.interface.name = %iface_owned,
-                ebpf.program.priority = tc_priority,
-                ebpf.program.direction = direction_name,
-                "attaching ebpf program with TC priority (netlink mode)"
-            );
-
             let link_id =
                 Self::attach_tc_with_priority(program, &iface_owned, attach_type, tc_priority)?;
             self.register_tc_link(iface.to_string(), direction_name, link_id);
@@ -851,38 +772,13 @@ impl IfaceController {
                 .inc();
         }
 
-        debug!(
-            event.name = "interface_controller.program_attached",
-            ebpf.program.direction = direction_name,
-            ebpf.program.priority = tc_priority,
-            network.interface.name = %iface,
-            "ebpf program attached to interface"
-        );
-
         Ok(())
     }
 
     /// Attach eBPF TC program with specified priority (netlink-based).
     ///
-    /// Uses aya's built-in `attach_with_options()` method with `NlOptions` to set priority.
-    /// This allows mermin to coexist with other TC programs like Cilium by controlling
-    /// execution order through priority values.
-    ///
-    /// ## Priority Semantics
-    /// - Lower numeric values = higher priority = runs earlier in TC chain
-    /// - Cilium typically uses priorities 1-20
-    /// - mermin default is 50 (runs after Cilium)
-    /// - Valid range: 1-65535 (we validate 30-32767 in config)
-    ///
-    /// ## Parameters
-    /// - `program`: Mutable reference to the SchedClassifier program
-    /// - `iface`: Interface name to attach to
-    /// - `attach_type`: TC attach type (ingress/egress)
-    /// - `priority`: TC priority value (higher = lower priority = runs later)
-    ///
-    /// ## Returns
-    /// - `Ok(SchedClassifierLinkId)` on success
-    /// - `Err(MerminError)` if attachment fails
+    /// Lower priority values run earlier in the TC chain. Cilium typically uses 1–20;
+    /// mermin defaults to 50. Valid configured range is 30–32767.
     fn attach_tc_with_priority(
         program: &mut SchedClassifier,
         iface: &str,
@@ -950,7 +846,7 @@ impl IfaceController {
                     }
                     Err(e) => {
                         debug!(
-                            event.name = "interface_controller.tcx_unpin_failed_fallback",
+                            event.name = "interface_controller.tcx_unpin_failed",
                             network.interface.name = %iface_owned,
                             ebpf.program.direction = %direction,
                             pin_path = %pin_path,
@@ -960,24 +856,14 @@ impl IfaceController {
                     }
                 },
                 Err(e) => {
-                    if Self::is_not_found_error(&e) {
-                        debug!(
-                            event.name = "interface_controller.tcx_pin_not_found",
-                            network.interface.name = %iface_owned,
-                            ebpf.program.direction = %direction,
-                            pin_path = %pin_path,
-                            "pinned link not found, using standard detach"
-                        );
-                    } else {
-                        debug!(
-                            event.name = "interface_controller.tcx_pin_load_failed_fallback",
-                            network.interface.name = %iface_owned,
-                            ebpf.program.direction = %direction,
-                            pin_path = %pin_path,
-                            error = %e,
-                            "failed to load pinned link, falling back to standard detach"
-                        );
-                    }
+                    debug!(
+                        event.name = "interface_controller.tcx_pin_unavailable",
+                        network.interface.name = %iface_owned,
+                        ebpf.program.direction = %direction,
+                        pin_path = %pin_path,
+                        error = %e,
+                        "pinned link unavailable, using standard detach"
+                    );
                 }
             }
         }
@@ -1024,56 +910,42 @@ impl IfaceController {
         direction: &'static str,
     ) -> Result<(), MerminError> {
         if self.use_tcx {
-            // Try pinned link first (if /sys/fs/bpf was available during attachment)
             let pin_path = Self::pin_path(iface, direction);
-            match PinnedLink::from_pin(&pin_path) {
-                Ok(pinned_link) => {
-                    // Found pinned link, unpin and detach
-                    match pinned_link.unpin() {
-                        Ok(_fd_link) => {
-                            debug!(
-                                event.name = "interface_controller.tcx_pinned_link_detached",
-                                network.interface.name = %iface,
-                                ebpf.program.direction = %direction,
-                                pin_path = %pin_path,
-                                "detached TCX program via pinned link"
-                            );
-                            metrics::registry::TC_PROGRAMS_TOTAL
-                                .with_label_values(&[TcOperation::Detached.as_str()])
-                                .inc();
+            if let Ok(pinned_link) = PinnedLink::from_pin(&pin_path) {
+                match pinned_link.unpin() {
+                    Ok(_fd_link) => {
+                        debug!(
+                            event.name = "interface_controller.tcx_link_detached",
+                            network.interface.name = %iface,
+                            ebpf.program.direction = %direction,
+                            pin_path = %pin_path,
+                            "detached TCX program via pinned link"
+                        );
+                        metrics::registry::TC_PROGRAMS_TOTAL
+                            .with_label_values(&[TcOperation::Detached.as_str()])
+                            .inc();
 
-                            if metrics::registry::debug_enabled() {
-                                metrics::registry::TC_PROGRAMS_DETACHED_BY_INTERFACE_TOTAL
-                                    .with_label_values(&[iface, direction])
-                                    .inc();
-                            }
-                            return Ok(());
+                        if metrics::registry::debug_enabled() {
+                            metrics::registry::TC_PROGRAMS_DETACHED_BY_INTERFACE_TOTAL
+                                .with_label_values(&[iface, direction])
+                                .inc();
                         }
-                        Err(e) => {
-                            warn!(
-                                event.name = "interface_controller.tcx_unpin_failed",
-                                network.interface.name = %iface,
-                                ebpf.program.direction = %direction,
-                                pin_path = %pin_path,
-                                error = %e,
-                                "failed to unpin TCX link, trying standard detachment"
-                            );
-                        }
+                        return Ok(());
                     }
-                }
-                Err(_) => {
-                    // No pinned link found, fall through to standard detachment
-                    trace!(
-                        event.name = "interface_controller.tcx_no_pinned_link",
-                        network.interface.name = %iface,
-                        ebpf.program.direction = %direction,
-                        "no pinned link found, using standard detachment"
-                    );
+                    Err(e) => {
+                        debug!(
+                            event.name = "interface_controller.tcx_unpin_failed",
+                            network.interface.name = %iface,
+                            ebpf.program.direction = %direction,
+                            pin_path = %pin_path,
+                            error = %e,
+                            "failed to unpin TCX link, trying standard detachment"
+                        );
+                    }
                 }
             }
         }
 
-        // Fall back to standard detachment (works for both TCX and Netlink)
         self.detach_netlink_program(iface, direction)
     }
 
@@ -1088,16 +960,9 @@ impl IfaceController {
         direction: &'static str,
     ) -> Result<(), MerminError> {
         if let Some(link_id) = self.unregister_tc_link(iface, direction) {
-            self.detach_program(iface, direction, link_id)
-        } else {
-            debug!(
-                event.name = "interface_controller.netlink_link_not_found",
-                network.interface.name = %iface,
-                ebpf.program.direction = %direction,
-                "no netlink link found in tc_links HashMap (may have been already removed)"
-            );
-            Ok(())
+            return self.detach_program(iface, direction, link_id);
         }
+        Ok(())
     }
 
     /// Clean up orphaned TC programs from all active interfaces before attachment.
@@ -1110,35 +975,19 @@ impl IfaceController {
     ///
     /// Blocking operation. Thread must be in host network namespace.
     fn cleanup_orphaned_programs(&mut self) -> Result<(), MerminError> {
-        if self.use_tcx && self.bpf_fs_writable {
-            // TCX mode: Try to clean up orphaned programs using pinned links
-            info!(
-                event.name = "interface_controller.tcx_cleanup_started",
-                kernel.tcx_mode = true,
-                iface_count = self.active_ifaces.len(),
-                "attempting to clean up orphaned TCX programs via pinned links"
-            );
+        if self.use_tcx {
+            if self.bpf_fs_writable {
+                let mut total_removed = 0u32;
+                let ifaces: Vec<String> = self.active_ifaces.iter().cloned().collect();
 
-            let mut total_removed = 0u32;
-            let ifaces: Vec<String> = self.active_ifaces.iter().cloned().collect();
-
-            for iface in &ifaces {
-                for direction in DIRECTIONS {
-                    let pin_path = Self::pin_path(iface, direction);
-                    match PinnedLink::from_pin(&pin_path) {
-                        Ok(pinned_link) => {
-                            debug!(
-                                event.name = "interface_controller.tcx_orphan_found",
-                                network.interface.name = %iface,
-                                ebpf.program.direction = %direction,
-                                pin_path = %pin_path,
-                                "found orphaned TCX link from previous instance"
-                            );
-
+                for iface in &ifaces {
+                    for direction in DIRECTIONS {
+                        let pin_path = Self::pin_path(iface, direction);
+                        if let Ok(pinned_link) = PinnedLink::from_pin(&pin_path) {
                             match pinned_link.unpin() {
                                 Ok(_fd_link) => {
                                     total_removed += 1;
-                                    info!(
+                                    debug!(
                                         event.name = "interface_controller.tcx_orphan_removed",
                                         network.interface.name = %iface,
                                         ebpf.program.direction = %direction,
@@ -1147,7 +996,7 @@ impl IfaceController {
                                     );
                                 }
                                 Err(e) => {
-                                    warn!(
+                                    debug!(
                                         event.name = "interface_controller.tcx_orphan_unpin_failed",
                                         network.interface.name = %iface,
                                         ebpf.program.direction = %direction,
@@ -1158,93 +1007,44 @@ impl IfaceController {
                                 }
                             }
                         }
-                        Err(e) => {
-                            if Self::is_not_found_error(&e) {
-                                trace!(
-                                    event.name = "interface_controller.tcx_no_orphan",
-                                    network.interface.name = %iface,
-                                    ebpf.program.direction = %direction,
-                                    pin_path = %pin_path,
-                                    "no orphaned TCX link found (expected on first run)"
-                                );
-                            } else {
-                                debug!(
-                                    event.name = "interface_controller.tcx_orphan_load_failed",
-                                    network.interface.name = %iface,
-                                    ebpf.program.direction = %direction,
-                                    pin_path = %pin_path,
-                                    error = %e,
-                                    "could not load pinned link (may not exist or /sys/fs/bpf not mounted)"
-                                );
-                            }
-                        }
                     }
                 }
-            }
 
-            if total_removed > 0 {
-                info!(
-                    event.name = "interface_controller.tcx_cleanup_completed",
-                    total_programs_removed = total_removed,
-                    interfaces_cleaned = ifaces.len(),
-                    "orphaned TCX program cleanup completed successfully"
-                );
+                if total_removed > 0 {
+                    debug!(
+                        event.name = "interface_controller.tcx_cleanup_completed",
+                        total_programs_removed = total_removed,
+                        interfaces_cleaned = ifaces.len(),
+                        "orphaned TCX program cleanup completed successfully"
+                    );
+                }
             } else {
                 debug!(
-                    event.name = "interface_controller.tcx_cleanup_none_found",
-                    "no orphaned TCX programs found"
+                    event.name = "interface_controller.tcx_cleanup_skipped",
+                    kernel.tcx_mode = true,
+                    bpf_fs_writable = false,
+                    "skipping TCX orphan cleanup - /sys/fs/bpf not writable, no pinned links exist"
                 );
             }
-
             return Ok(());
         }
-
-        if self.use_tcx && !self.bpf_fs_writable {
-            info!(
-                event.name = "interface_controller.tcx_cleanup_skipped",
-                kernel.tcx_mode = true,
-                bpf_fs_writable = false,
-                "skipping TCX orphan cleanup - /sys/fs/bpf not writable, no pinned links exist"
-            );
-            return Ok(());
-        }
-
-        // Netlink mode: kernel < 6.6, use qdisc_detach_program
-        info!(
-            event.name = "interface_controller.cleanup_started",
-            iface_count = self.active_ifaces.len(),
-            "cleaning up orphaned TC programs before attachment"
-        );
 
         let mut total_removed = 0u32;
         let ifaces: Vec<String> = self.active_ifaces.iter().cloned().collect();
 
         for iface in &ifaces {
-            let iface_owned = iface.clone();
-            let removed = Self::cleanup_orphaned_programs_on_iface(&iface_owned, self.use_tcx)?;
-
+            let removed = Self::cleanup_orphaned_programs_on_iface(iface, self.use_tcx)?;
             if removed > 0 {
-                info!(
-                    event.name = "interface_controller.cleanup_completed",
-                    network.interface.name = %iface,
-                    programs_removed = removed,
-                    "cleaned up orphaned TC programs from interface"
-                );
                 total_removed += removed;
             }
         }
 
         if total_removed > 0 {
-            info!(
+            debug!(
                 event.name = "interface_controller.cleanup_summary",
                 total_programs_removed = total_removed,
                 interfaces_cleaned = ifaces.len(),
                 "orphaned TC program cleanup completed"
-            );
-        } else {
-            debug!(
-                event.name = "interface_controller.cleanup_none_found",
-                "no orphaned TC programs found"
             );
         }
 
@@ -1265,8 +1065,7 @@ impl IfaceController {
     fn cleanup_orphaned_programs_on_iface(iface: &str, use_tcx: bool) -> Result<u32, MerminError> {
         let mut removed_count = 0u32;
 
-        // Only netlink mode supports cleanup by program name
-        // TCX requires link_id for detachment, which we don't have from previous instances
+        // TCX requires link_id for detachment — unavailable from previous instances
         if !use_tcx {
             let program_names = [
                 (PROGRAM_NAME_INGRESS, TcAttachType::Ingress),
@@ -1277,24 +1076,9 @@ impl IfaceController {
                 match qdisc_detach_program(iface, *attach_type, program_name) {
                     Ok(()) => {
                         removed_count += 1;
-                        debug!(
-                            event.name = "interface_controller.orphaned_program_removed",
-                            network.interface.name = %iface,
-                            attach_type = ?attach_type,
-                            program = %program_name,
-                            "removed orphaned TC program (netlink mode)"
-                        );
                     }
                     Err(e) => {
-                        if Self::is_not_found_error(&e) {
-                            trace!(
-                                event.name = "interface_controller.no_orphaned_program",
-                                network.interface.name = %iface,
-                                attach_type = ?attach_type,
-                                program = %program_name,
-                                "no orphaned program found (expected)"
-                            );
-                        } else {
+                        if !Self::is_not_found_error(&e) {
                             warn!(
                                 event.name = "interface_controller.program_detach_failed",
                                 network.interface.name = %iface,
@@ -1319,12 +1103,6 @@ impl IfaceController {
         direction: &'static str,
         link_id: SchedClassifierLinkId,
     ) {
-        debug!(
-            event.name = "interface_controller.tc_link_registered",
-            iface = %iface,
-            direction = %direction,
-            "TC link registered"
-        );
         self.tc_links.insert((iface, direction), link_id);
     }
 
@@ -1335,17 +1113,7 @@ impl IfaceController {
         direction: &str,
     ) -> Option<SchedClassifierLinkId> {
         let static_direction = Self::to_static_direction(direction)?;
-
-        let link_id = self.tc_links.remove(&(iface.to_string(), static_direction));
-        if link_id.is_some() {
-            debug!(
-                event.name = "interface_controller.tc_link_unregistered",
-                iface = %iface,
-                direction = %direction,
-                "TC link unregistered"
-            );
-        }
-        link_id
+        self.tc_links.remove(&(iface.to_string(), static_direction))
     }
 
     /// Generate consistent BPF filesystem path for pinning TCX links.
@@ -1391,30 +1159,13 @@ impl IfaceController {
         );
 
         let mut resolved = HashSet::new();
-        let mut matches_per_pattern = HashMap::new();
 
         for pattern in patterns {
-            let mut pattern_matches = Vec::new();
             for iface in &available {
                 if Self::matches_pattern(iface, std::slice::from_ref(pattern)) {
                     resolved.insert(iface.clone());
-                    pattern_matches.push(iface.clone());
                 }
             }
-            if !pattern_matches.is_empty() {
-                pattern_matches.sort();
-                matches_per_pattern.insert(pattern.clone(), pattern_matches);
-            }
-        }
-
-        for (pattern, matches) in &matches_per_pattern {
-            debug!(
-                event.name = "interface_controller.pattern_matched",
-                pattern = %pattern,
-                match_count = matches.len(),
-                matches = ?matches,
-                "pattern matched interfaces"
-            );
         }
 
         let mut resolved_list: Vec<_> = resolved.iter().collect();

--- a/mermin/src/iface/threads.rs
+++ b/mermin/src/iface/threads.rs
@@ -27,7 +27,7 @@ use netlink_packet_route::{
 use netlink_sys::protocols::NETLINK_ROUTE;
 use nix::sched::{CloneFlags, setns};
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
 use super::{
     controller::IfaceController,
@@ -58,11 +58,6 @@ impl Drop for NetlinkSocket {
         unsafe {
             libc::close(self.0);
         }
-        trace!(
-            event.name = "interface_controller.netlink.socket_closed",
-            socket_fd = self.0,
-            "netlink socket closed via RAII cleanup"
-        );
     }
 }
 
@@ -74,29 +69,12 @@ const NETLINK_RECV_BUFFER_SIZE: usize = 8192;
 
 /// Spawn controller thread that permanently stays in host network namespace.
 ///
-/// This thread:
-/// - Enters host namespace once at startup via `setns()`
-/// - Stays in host namespace permanently (never switches back)
-/// - Handles commands from main thread via `cmd_rx` channel
-/// - Handles netlink events from netlink thread via `netlink_rx` channel
-/// - Sends status events back to main thread via `event_tx` channel (if provided)
-/// - Performs all eBPF attach/detach operations
+/// Enters host namespace once via `setns()`, then processes commands from `cmd_rx`
+/// and netlink events from `netlink_rx` in a single-threaded loop.
 ///
-/// ## Arguments
+/// # Panics
 ///
-/// - `host_netns` - Arc-wrapped File handle for `/proc/1/ns/net` (host namespace)
-/// - `controller` - Initialized controller (will be moved to thread)
-/// - `cmd_rx` - Receiver for commands from main thread
-/// - `netlink_rx` - Receiver for netlink events from netlink thread
-/// - `event_tx` - Optional sender for status events back to main thread
-///
-/// ## Errors
-///
-/// Returns an error if the thread cannot be spawned due to system resource limitations.
-///
-/// ## Panics
-///
-/// The spawned thread panics if unable to enter host network namespace (requires CAP_SYS_ADMIN).
+/// Panics if unable to enter host network namespace (requires CAP_SYS_ADMIN).
 pub fn spawn_controller_thread(
     host_netns: Arc<std::fs::File>,
     mut controller: IfaceController,
@@ -152,12 +130,6 @@ pub fn spawn_controller_thread(
                     recv(cmd_rx) -> result => {
                         match result {
                             Ok(cmd) => {
-                                debug!(
-                                    event.name = "interface_controller.command_received",
-                                    command = %cmd,
-                                    "received command from main thread"
-                                );
-
                                 match cmd {
                                     ControllerCommand::Initialize => {
                                         info!(
@@ -175,7 +147,6 @@ pub fn spawn_controller_thread(
                                                     });
                                                 }
 
-                                                // Process buffered netlink events that arrived during initialization
                                                 if !netlink_event_buffer.is_empty() {
                                                     debug!(
                                                         event.name = "interface_controller.processing_buffered_events",
@@ -252,7 +223,6 @@ pub fn spawn_controller_thread(
                                     event.name = "interface_controller.netlink_channel_closed",
                                     "netlink channel closed, continuing to process commands"
                                 );
-                                // Continue processing commands even if netlink monitoring fails
                             }
                         }
                     }
@@ -275,48 +245,20 @@ pub fn spawn_controller_thread(
 
 /// Spawn netlink monitoring thread that permanently stays in host network namespace.
 ///
-/// This thread:
-/// - Enters host namespace once at startup via `setns()`
-/// - Stays in host namespace permanently (never switches back)
-/// - Creates a raw netlink socket (AF_NETLINK, SOCK_RAW, NETLINK_ROUTE)
-/// - Subscribes to RTNLGRP_LINK multicast group for interface events
-/// - Blocks on `recv()` with 1-second timeout waiting for kernel netlink messages
-/// - Parses RTM_NEWLINK/RTM_SETLINK/RTM_DELLINK messages
-/// - Extracts interface name and UP flag from link attributes
-/// - Sends `NetlinkEvent::InterfaceUp` or `InterfaceDown` to controller thread
-/// - Handles message boundaries correctly using NLMSG_ALIGN
-/// - Exits gracefully when channel is disconnected (detected during recv timeout)
+/// Subscribes to RTNLGRP_LINK, parses RTM_NEWLINK/RTM_SETLINK/RTM_DELLINK messages,
+/// and sends `NetlinkEvent` to the controller thread. Uses `poll()` on both the netlink
+/// socket and a shutdown eventfd for instant, zero-CPU shutdown response.
 ///
-/// ## Graceful Shutdown
+/// Uses raw libc socket APIs rather than `netlink-sys` due to buffering issues
+/// with that crate's blocking `recv()`.
 ///
-/// Uses `poll()` to wait on both the netlink socket and a shutdown eventfd. When shutdown
-/// is requested, the main thread signals the eventfd, causing `poll()` to wake immediately.
-/// This avoids busy loops and provides instant shutdown response with zero CPU overhead.
+/// # Panics
 ///
-/// ## Arguments
-///
-/// - `host_netns` - Arc-wrapped File handle for `/proc/1/ns/net` (host namespace)
-/// - `event_tx` - Sender to send netlink events to controller thread
-///
-/// ## Errors
-///
-/// Returns an error if the thread cannot be spawned due to system resource limitations.
-///
-/// ## Panics
-///
-/// The spawned thread panics if unable to enter host network namespace (requires CAP_SYS_ADMIN).
-/// Errors during netlink socket setup or recv are logged and cause thread to exit gracefully.
-///
-/// ## Implementation Notes
-///
-/// Uses raw libc socket APIs instead of netlink-sys crate due to buffering
-/// issues with blocking recv(). All unsafe operations are documented with
-/// SAFETY comments explaining invariants.
+/// Panics if unable to enter host network namespace (requires CAP_SYS_ADMIN).
 pub fn spawn_netlink_thread(
     host_netns: Arc<std::fs::File>,
     event_tx: Sender<NetlinkEvent>,
 ) -> Result<(thread::JoinHandle<()>, Arc<ShutdownEventFd>), std::io::Error> {
-    // Create shutdown eventfd before spawning thread
     let shutdown_fd = Arc::new(ShutdownEventFd::new()?);
     let shutdown_fd_clone = Arc::clone(&shutdown_fd);
     thread::Builder::new()
@@ -355,7 +297,6 @@ pub fn spawn_netlink_thread(
                 return;
             }
 
-            // Wrap socket in RAII guard to ensure cleanup on all exit paths
             let sock = NetlinkSocket(sock_fd);
 
             info!(
@@ -391,11 +332,6 @@ pub fn spawn_netlink_thread(
                 return;
             }
 
-            debug!(
-                event.name = "interface_controller.netlink.socket_bound",
-                "netlink socket bound successfully"
-            );
-
             // Add multicast group membership (RTNLGRP_LINK for interface events)
             // SAFETY: sock is a valid socket, RTNLGRP_LINK is a valid i32 constant,
             // and we're passing the correct size for the option value.
@@ -430,7 +366,6 @@ pub fn spawn_netlink_thread(
             let mut total_messages_received = 0u64;
             let mut total_messages_skipped = 0u64;
 
-            // Setup poll fds: watch both netlink socket and shutdown eventfd
             let mut fds = [
                 pollfd {
                     fd: sock.as_raw_fd(),
@@ -445,7 +380,6 @@ pub fn spawn_netlink_thread(
             ];
 
             loop {
-                // Wait for events on either socket or shutdown signal
                 // SAFETY: fds array is properly initialized, timeout -1 means wait indefinitely
                 let poll_ret = unsafe { poll(fds.as_mut_ptr(), fds.len() as u64, -1) };
 
@@ -459,7 +393,6 @@ pub fn spawn_netlink_thread(
                     break;
                 }
 
-                // Check for errors on either FD first
                 if (fds[0].revents & (POLLERR | POLLHUP | POLLNVAL)) != 0 {
                     error!(
                         event.name = "interface_controller.netlink.socket_error",
@@ -477,7 +410,6 @@ pub fn spawn_netlink_thread(
                     break;
                 }
 
-                // Check if shutdown was signaled
                 if (fds[1].revents & POLLIN) != 0 {
                     info!(
                         event.name = "interface_controller.netlink.shutdown_signaled",
@@ -488,9 +420,7 @@ pub fn spawn_netlink_thread(
                     break;
                 }
 
-                // Check if socket has data ready
                 if (fds[0].revents & POLLIN) == 0 {
-                    // No data on socket, loop again
                     continue;
                 }
 
@@ -521,13 +451,6 @@ pub fn spawn_netlink_thread(
                     break;
                 }
 
-                trace!(
-                    event.name = "interface_controller.netlink.data_received",
-                    bytes = n,
-                    "received netlink data"
-                );
-
-                // Parse all messages in buffer (may contain multiple netlink messages)
                 let mut offset = 0;
                 let mut messages_in_batch = 0;
                 let mut skipped_in_batch = 0;
@@ -572,7 +495,7 @@ pub fn spawn_netlink_thread(
                                                         link_msg.header.flags.contains(LinkFlags::Up);
 
                                                     if is_up {
-                                                        trace!(
+                                                        debug!(
                                                             event.name = "interface_controller.netlink.interface_up",
                                                             network.interface.name = %if_name,
                                                             "interface came up, sending event to controller"
@@ -590,7 +513,7 @@ pub fn spawn_netlink_thread(
                                                             return;
                                                         }
                                                     } else {
-                                                        trace!(
+                                                        debug!(
                                                             event.name = "interface_controller.netlink.interface_down_newlink",
                                                             network.interface.name = %if_name,
                                                             "interface reported without UP flag"
@@ -609,7 +532,7 @@ pub fn spawn_netlink_thread(
                                                         }
                                                     })
                                                 {
-                                                    trace!(
+                                                    debug!(
                                                         event.name = "interface_controller.netlink.interface_down",
                                                         network.interface.name = %if_name,
                                                         "interface went down, sending event to controller"
@@ -643,20 +566,12 @@ pub fn spawn_netlink_thread(
                                 }
                             }
                         }
-                        Err(e) => {
-                            trace!(
-                                event.name = "interface_controller.netlink.buffer_check_failed",
-                                error = ?e,
-                                offset = offset,
-                                remaining = n - offset,
-                                "not enough bytes for complete message, ending parse loop"
-                            );
+                        Err(_) => {
                             break;
                         }
                     }
                 }
 
-                // Update counters
                 total_messages_received += messages_in_batch;
                 total_messages_skipped += skipped_in_batch;
 
@@ -679,23 +594,8 @@ pub fn spawn_netlink_thread(
         .map(|handle| (handle, shutdown_fd))
 }
 
-/// Wait for controller thread to enter host namespace and become ready.
-///
-/// This function blocks until the controller thread sends the `Ready` event,
-/// indicating it has successfully entered the host network namespace and is
-/// ready to receive commands.
-///
-/// Timeout is controlled by `CONTROLLER_READY_TIMEOUT_SECS` constant.
-///
-/// ## Arguments
-///
-/// - `event_rx` - Receiver for controller events
-/// - `cmd_tx` - Sender for commands (used to send shutdown on timeout)
-///
-/// ## Returns
-///
-/// - `Ok(())` if controller becomes ready within timeout
-/// - `Err(MerminError)` if timeout occurs or unexpected event received
+/// Block until the controller thread sends `Ready`, indicating it has entered
+/// the host network namespace. Sends `Shutdown` and returns an error on timeout.
 pub fn wait_for_controller_ready(
     event_rx: &Receiver<ControllerEvent>,
     cmd_tx: &Sender<ControllerCommand>,
@@ -730,23 +630,9 @@ pub fn wait_for_controller_ready(
     }
 }
 
-/// Wait for controller initialization to complete.
-///
-/// This function blocks until the controller thread sends the `Initialized` event,
-/// draining intermediate events like `InterfaceAttached` and `AttachmentFailed` that
-/// may arrive during the initialization process.
-///
-/// Timeout is controlled by `CONTROLLER_INIT_TIMEOUT_SECS` constant.
-///
-/// ## Arguments
-///
-/// - `event_rx` - Receiver for controller events
-/// - `cmd_tx` - Sender for commands (used to send shutdown on timeout)
-///
-/// ## Returns
-///
-/// - `Ok(interface_count)` if initialization completes successfully
-/// - `Err(MerminError)` if timeout occurs or unexpected event received
+/// Block until the controller thread sends `Initialized`, draining intermediate
+/// `InterfaceAttached`/`AttachmentFailed` events. Sends `Shutdown` and returns
+/// an error on timeout.
 pub fn wait_for_controller_initialized(
     event_rx: &Receiver<ControllerEvent>,
     cmd_tx: &Sender<ControllerCommand>,
@@ -757,9 +643,6 @@ pub fn wait_for_controller_initialized(
         "waiting for initialization to complete"
     );
 
-    // Loop to drain intermediate events (InterfaceAttached, AttachmentFailed) until we receive
-    // the final Initialized event. During initialization, the controller sends an event for each
-    // interface attachment (success or failure), which may arrive before the Initialized event.
     let init_deadline =
         time::Instant::now() + time::Duration::from_secs(CONTROLLER_INIT_TIMEOUT_SECS);
 
@@ -816,18 +699,7 @@ pub fn wait_for_controller_initialized(
     }
 }
 
-/// Spawn background task to handle controller events for observability.
-///
-/// This creates a blocking thread that continuously receives and logs controller events.
-/// The task will exit when the controller sends `ShutdownComplete` or the channel closes.
-///
-/// ## Arguments
-///
-/// - `event_rx` - Receiver for controller events
-///
-/// ## Returns
-///
-/// - `JoinHandle` for the spawned thread
+/// Spawn background thread that logs controller events until `ShutdownComplete`.
 pub fn spawn_controller_event_handler(
     event_rx: Receiver<ControllerEvent>,
 ) -> Result<thread::JoinHandle<()>, std::io::Error> {
@@ -858,36 +730,15 @@ pub fn spawn_controller_event_handler(
                             "interface attachment failed"
                         );
                     }
-                    ControllerEvent::Ready => {
-                        // Ready event is waited for synchronously before this task spawns,
-                        // but log it if we somehow receive it here
-                        debug!(
-                            event.name = "interface_controller.unexpected_ready",
-                            "received ready event in background handler"
-                        );
-                    }
-                    ControllerEvent::Initialized { interface_count } => {
-                        // Initialization is waited for synchronously before this task spawns,
-                        // but log it if we somehow receive it here
-                        debug!(
-                            event.name = "interface_controller.unexpected_initialization",
-                            interface_count = interface_count,
-                            "received initialization event in background handler"
-                        );
-                    }
                     ControllerEvent::ShutdownComplete => {
                         info!(
                             event.name = "interface_controller.shutdown_complete",
                             "controller thread shutdown successfully"
                         );
-                        // Exit the event loop since controller is shutting down
                         break;
                     }
+                    _ => {}
                 }
             }
-            debug!(
-                event.name = "interface_controller.event_handler_stopped",
-                "controller event handler stopped"
-            );
         })
 }


### PR DESCRIPTION
## Changes

- remove trace/debug logs that are dev artifacts (per-iteration, hot-path, or already covered by higher-level info logs) from iface controller and netlink thread
- drop unused trace import from controller.rs and threads.rs
- unify two separate use_tcx guard blocks in cleanup_orphaned_programs and remove redundant iface_owned clone
- remove matches_per_pattern HashMap and pattern_matches vec from resolve_ifaces, which existed solely to feed the removed debug loop
- simplify unregister_tc_link to a direct HashMap::remove; remove debug logs from register/unregister helpers
- trim verbose ## Arguments / ## Returns doc sections to single-line summaries on public functions in threads.rs
- remove inline comments that restate what the code does
- remove unused variant-level doc comments
- remove per-request debug timing instrumentation from liveness_handler