### PR TITLE
refactor(k8s): remove dead code, trim logs and redundant comments

### DIFF
--- a/mermin/src/k8s/attributor.rs
+++ b/mermin/src/k8s/attributor.rs
@@ -215,10 +215,8 @@ fn create_k8s_attributes_mapping(direction: &str) -> AttributesOptions {
 /// Holds metadata for a single Kubernetes object.
 #[derive(Debug, Clone)]
 pub struct K8sObjectMeta {
-    #[allow(dead_code)]
     pub kind: String,
     pub name: String,
-    #[allow(dead_code)]
     pub uid: Option<String>,
     pub namespace: Option<String>,
     #[allow(dead_code)]
@@ -271,8 +269,6 @@ pub enum DecorationInfo {
     },
     Service {
         service: K8sObjectMeta,
-        #[allow(dead_code)]
-        backend_ips: Vec<String>,
     },
     EndpointSlice {
         slice: K8sObjectMeta,
@@ -430,10 +426,6 @@ impl ResourceStore {
             }
         }
 
-        debug!(
-            event.name = "k8s.ip_index.initial_build",
-            "caches synced, performing initial ip index build"
-        );
         update_ip_index(&store, &ip_index, conf).await;
 
         let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(256);
@@ -459,10 +451,6 @@ impl ResourceStore {
                             update_ip_index(&store_clone, &ip_index_clone, &conf_clone).await;
                             timer.observe_duration();
                             pending_update = false;
-                            trace!(
-                                event.name = "k8s.ip_index.updated",
-                                "IP index rebuilt due to K8s resource changes"
-                            );
                         }
                     }
                 }
@@ -637,7 +625,6 @@ pub struct FlowContext {
 
 impl FlowContext {
     pub async fn from_flow_span(flow_span: &FlowSpan, attributor: &Attributor) -> Self {
-        // Extract IPs and ports
         let (src_ip, dst_ip, port, protocol) = (
             flow_span.attributes.source_address,
             flow_span.attributes.destination_address,
@@ -645,7 +632,6 @@ impl FlowContext {
             flow_span.attributes.network_transport,
         );
 
-        // Resolve pods
         let src_pod = attributor.get_pod_by_ip(src_ip).await;
         let dst_pod = attributor.get_pod_by_ip(dst_ip).await;
 
@@ -662,8 +648,6 @@ impl FlowContext {
 
 /// A high-level client for querying Kubernetes resources.
 pub struct Attributor {
-    #[allow(dead_code)]
-    pub client: Client,
     pub resource_store: ResourceStore,
     pub owner_relations_manager: OwnerRelationsManager,
     pub selector_relations_manager: Option<SelectorRelationsManager>,
@@ -672,7 +656,6 @@ pub struct Attributor {
 }
 
 impl Attributor {
-    /// Creates a new Decorator, initializing all resource reflectors concurrently.
     pub async fn new(
         health_state: HealthState,
         owner_relations_opts: Option<OwnerRelationsRules>,
@@ -738,20 +721,15 @@ impl Attributor {
         )
         .await?;
 
-        // Use provided config or defaults
         let owner_relations_manager =
             OwnerRelationsManager::new(owner_relations_opts.unwrap_or_default());
 
-        // Create selector relations manager if rules are provided
-        // Note: If selector_relations is None or an empty list, no manager is created.
-        // This is intentional - without rules, selector matching cannot function.
-        // Both states effectively mean "selector relations disabled".
+        // If selector_relations is None or empty, no manager is created — selector matching is disabled.
         let selector_relations_manager = selector_relations_opts
             .filter(|rules| !rules.is_empty())
             .map(SelectorRelationsManager::new);
 
         Ok(Self {
-            client,
             resource_store,
             owner_relations_manager,
             selector_relations_manager,
@@ -854,28 +832,7 @@ impl Attributor {
             }
         }
 
-        // Apply conflict resolution logic
-        let resolved_resources =
-            self.resolve_ip_conflicts(ip, &pods, &nodes, &services, &other_resources);
-
-        // Log the final resolved resources after conflict resolution
-        for res in &resolved_resources {
-            let is_host_nw = is_host_network_resource(res.as_ref());
-            let kind = K::kind(&());
-
-            trace!(
-                event.name = "k8s.attributor.resolved",
-                k8s.resource.kind = %kind,
-                k8s.resource.name = %res.name_any(),
-                k8s.resource.namespace = %res.namespace().unwrap_or_default(),
-                k8s.resource.uid = %res.meta().uid.as_deref().unwrap_or_default(),
-                k8s.resource.ip = %ip,
-                k8s.resource.host_network = %is_host_nw,
-                "resource attributed to ip address"
-            );
-        }
-
-        resolved_resources
+        self.resolve_ip_conflicts(ip, &pods, &nodes, &services, &other_resources)
     }
 
     /// Looks up a Pod by its IP address.
@@ -898,35 +855,6 @@ impl Attributor {
         self.get_objects_by_ip(ip).await.into_iter().next()
     }
 
-    /// Takes a virtual IP (like a ClusterIP) and resolves it to the list of
-    /// real, ready backend IP addresses from the associated EndpointSlices.
-    ///
-    /// Returns `None` if the input IP does not belong to any Service.
-    /// Returns `Some(Vec<String>)` containing the backend IPs if resolution is successful.
-    pub async fn resolve_service_ip_to_backend_ips(
-        &self,
-        service_ip: IpAddr,
-    ) -> Option<Vec<String>> {
-        let service = self.get_service_by_ip(service_ip).await?;
-        let slices = self.get_endpointslices_for_service(&service);
-
-        let backend_ips = slices
-            .iter()
-            .flat_map(|slice| &slice.endpoints)
-            .filter(|endpoint| {
-                endpoint
-                    .conditions
-                    .as_ref()
-                    .and_then(|c| c.ready)
-                    .unwrap_or(false)
-            })
-            .flat_map(|endpoint| &endpoint.addresses)
-            .cloned()
-            .collect::<Vec<String>>();
-
-        Some(backend_ips)
-    }
-
     /// Looks up an EndpointSlice directly by one of its endpoint IP addresses.
     pub async fn get_endpointslice_by_ip(&self, ip: IpAddr) -> Option<Arc<EndpointSlice>> {
         self.get_objects_by_ip(ip).await.into_iter().next()
@@ -939,7 +867,7 @@ impl Attributor {
     /// # Arguments
     /// * `ip` - The IP address being resolved
     /// * `pods` - Pod resources found for this IP
-    /// * `nodes` - Node resources found for this IP  
+    /// * `nodes` - Node resources found for this IP
     /// * `services` - Service resources found for this IP
     /// * `other_resources` - Other resource types found for this IP
     ///
@@ -969,12 +897,6 @@ impl Attributor {
                 .collect();
 
             if !host_nw_pods.is_empty() {
-                trace!(
-                    event.name = "k8s.attributor.conflict_resolved",
-                    net.ip.address = %ip,
-                    resolution = "host_network_pod_on_node_ip",
-                    "resolved ip conflict: allowing host network pod on node ip"
-                );
                 return if is_k_pod {
                     self.downcast_arc_vec(&host_nw_pods)
                 } else {
@@ -982,28 +904,11 @@ impl Attributor {
                 };
             }
             if !nodes.is_empty() {
-                if !pods.is_empty() {
-                    trace!(
-                        event.name = "k8s.attributor.conflict_resolved",
-                        net.ip.address = %ip,
-                        resolution = "node_over_regular_pod_on_node_ip",
-                        "resolved ip conflict: preferring node over regular pod on node ip"
-                    );
-                }
                 return if is_k_node {
                     self.downcast_arc_vec(nodes)
                 } else {
                     Vec::new()
                 };
-            }
-
-            if !pods.is_empty() {
-                trace!(
-                    event.name = "k8s.attributor.conflict_resolved",
-                    net.ip.address = %ip,
-                    resolution = "reject_regular_pod_on_node_ip",
-                    "resolved ip conflict: rejecting regular pod claiming node ip"
-                );
             }
             return Vec::new();
         }
@@ -1055,32 +960,6 @@ impl Attributor {
         })
     }
 
-    /// Finds all EndpointSlices associated with a given Service.
-    pub fn get_endpointslices_for_service(&self, service: &Service) -> Vec<Arc<EndpointSlice>> {
-        let service_name = service.metadata.name.as_deref().unwrap_or_default();
-        if service_name.is_empty() {
-            return Vec::new();
-        }
-
-        self.resource_store
-            .endpoint_slices
-            .state()
-            .iter()
-            .filter(|slice| {
-                // Ensure the slice is in the same namespace as the service
-                slice.metadata.namespace == service.metadata.namespace &&
-                    // Check for the controlling label
-                    slice
-                        .metadata
-                        .labels
-                        .as_ref()
-                        .and_then(|labels| labels.get("kubernetes.io/service-name"))
-                        .is_some_and(|name| name == service_name)
-            })
-            .cloned()
-            .collect()
-    }
-
     /// Main entry point: finds all NetworkPolicies that permit the specified traffic flow
     pub fn get_matching_network_policies(
         &self,
@@ -1098,7 +977,7 @@ impl Attributor {
 
     /// Gets NetworkPolicies that apply to the given pod based on podSelector
     fn get_network_policies_for_pod(&self, pod: &Pod) -> Result<Vec<Arc<NetworkPolicy>>, K8sError> {
-        let pod_namespace = pod.clone().metadata.namespace.unwrap_or_default();
+        let pod_namespace = pod.metadata.namespace.clone().unwrap_or_default();
         let pod_labels = pod.labels();
 
         let policies = self
@@ -1106,11 +985,10 @@ impl Attributor {
             .get_by_namespace::<NetworkPolicy>(&pod_namespace)
             .into_iter()
             .filter(|policy| {
-                // Check if the policy's podSelector matches the destination pod
                 policy
                     .spec
                     .as_ref()
-                    .map(|spec| spec.clone().pod_selector)
+                    .map(|spec| spec.pod_selector.clone())
                     .is_some_and(|selector| self.selector_matches(&selector, pod_labels))
             })
             .collect();
@@ -1118,13 +996,11 @@ impl Attributor {
         Ok(policies)
     }
 
-    /// Checks if a label selector matches the given labels
     fn selector_matches(
         &self,
         selector: &LabelSelector,
         labels: &BTreeMap<String, String>,
     ) -> bool {
-        // Check match_labels
         if let Some(match_labels) = &selector.match_labels {
             for (key, value) in match_labels {
                 if labels.get(key) != Some(value) {
@@ -1133,7 +1009,6 @@ impl Attributor {
             }
         }
 
-        // Check match_expressions
         if let Some(match_expressions) = &selector.match_expressions {
             for expr in match_expressions {
                 if !self.expression_matches(expr, labels) {
@@ -1145,7 +1020,6 @@ impl Attributor {
         true
     }
 
-    /// Checks if a label selector requirement matches the given labels
     fn expression_matches(
         &self,
         expr: &LabelSelectorRequirement,
@@ -1248,14 +1122,12 @@ impl Attributor {
         })
     }
 
-    /// Enhanced port matching with support for ranges and named ports for a single port spec.
     fn port_matches(
         &self,
         ctx: &FlowContext,
         port_spec: &NetworkPolicyPort,
         direction: FlowDirection,
     ) -> bool {
-        // First, ensure the protocol matches. This is a good guard clause.
         let proto_match = port_spec
             .protocol
             .as_deref()
@@ -1266,7 +1138,6 @@ impl Attributor {
             return false;
         }
 
-        // Then, check the port number based on its type (Int, String, or None)
         match &port_spec.port {
             Some(IntOrString::Int(p_num)) => {
                 let start_port = *p_num as u16;
@@ -1276,18 +1147,17 @@ impl Attributor {
             Some(IntOrString::String(port_name)) => {
                 self.resolve_named_port(ctx, port_name, direction)
             }
-            None => true, // If `port` is not specified, it allows all ports for the given protocol.
+            // No port specified means all ports for the given protocol are allowed.
+            None => true,
         }
     }
 
-    /// Resolves named ports by searching through the containers of the relevant pod.
     fn resolve_named_port(
         &self,
         ctx: &FlowContext,
         port_name: &str,
         direction: FlowDirection,
     ) -> bool {
-        // Determine which pod to inspect based on traffic direction.
         let target_pod = match direction {
             FlowDirection::Ingress => &ctx.dst_pod,
             FlowDirection::Egress => &ctx.src_pod,
@@ -1321,19 +1191,16 @@ impl Attributor {
             (ctx.dst_ip, &ctx.dst_pod)
         };
 
-        // If the peer has an ipBlock, a match on CIDR is sufficient.
         if let Some(ip_block) = &peer.ip_block
             && self.ip_matches_cidr(target_ip, &ip_block.cidr)
         {
             return true;
         }
 
-        // If we didn't match an ipBlock and there's no pod, we can't match further.
         let Some(pod) = target_pod else {
             return false;
         };
 
-        // Check for namespace selector match.
         let namespace_matches =
             self.namespace_matches_selector_internal(pod, peer, policy_namespace);
 
@@ -1341,16 +1208,13 @@ impl Attributor {
             return false;
         }
 
-        // If namespace matches, check for pod selector match.
-        // No pod selector means it matches all pods in the selected namespace(s).
+        // No pod selector means all pods in the matched namespace(s) are allowed.
         peer.pod_selector
             .as_ref()
             .is_none_or(|ps| self.selector_matches(ps, pod.labels()))
     }
 
-    /// Checks if an IP address matches a CIDR block using the `ipnetwork` crate.
     fn ip_matches_cidr(&self, ip: IpAddr, cidr: &str) -> bool {
-        // The `ipnetwork` crate handles parsing both single IPs and CIDR notations correctly.
         match cidr.parse::<IpNetwork>() {
             Ok(network) => network.contains(ip),
             Err(_) => {
@@ -1364,7 +1228,6 @@ impl Attributor {
         }
     }
 
-    /// Consolidated namespace matching for both ingress and egress rules
     fn namespace_matches_selector_internal(
         &self,
         pod: &Pod,
@@ -1373,7 +1236,6 @@ impl Attributor {
     ) -> bool {
         match &peer.namespace_selector {
             Some(ns_selector) => {
-                // If namespace selector is present, evaluate it against the pod's namespace
                 let pod_namespace = pod.namespace().unwrap_or_default();
                 if let Some(ns) = self
                     .resource_store
@@ -1420,7 +1282,6 @@ fn extract_values_from_resource<K: serde::Serialize>(
     Ok(results)
 }
 
-/// (private helper) Resolves a hostname and adds all resulting IPs to the index.
 async fn index_hostname(
     new_index: &mut HashMap<String, Vec<K8sObjectMeta>>,
     hostname: &str,
@@ -1436,10 +1297,8 @@ async fn index_hostname(
     }
 }
 
-/// (private helper) Adds an IP address and metadata to the index.
 fn add_to_index(index: &mut HashMap<String, Vec<K8sObjectMeta>>, ip: &str, meta: &K8sObjectMeta) {
     let entries = index.entry(ip.to_string()).or_default();
-    // Only add if this specific resource (by UID) is not already indexed for this IP
     if !entries.iter().any(|existing| existing.uid == meta.uid) {
         entries.push(meta.clone());
     }
@@ -1486,7 +1345,7 @@ async fn index_resource_by_ip<K>(
             let meta = K8sObjectMeta::from(resource.as_ref());
 
             for path in &source.to {
-                // Skip hostIP/hostIPs paths if it's a regular pod
+                // Skip node IP paths for regular (non-host-network) pods
                 if is_pod
                     && !is_host_network
                     && (path.contains("hostIP") || path.contains("hostIPs"))
@@ -1677,12 +1536,6 @@ fn spawn_ip_resource_watcher<K, F>(
         let k8s_shrink_policy = ShrinkPolicy::k8s_cache();
 
         loop {
-            debug!(
-                event.name = "k8s.watcher.starting",
-                k8s.resource.name = %resource_name,
-                "Starting K8s resource watcher for IP index updates"
-            );
-
             let watcher_config = watcher::Config::default();
             let mut stream = watcher(api.clone(), watcher_config).boxed();
 
@@ -1696,39 +1549,20 @@ fn spawn_ip_resource_watcher<K, F>(
                             ])
                             .inc();
 
-                        let host_network = is_host_network_resource(&obj);
-
-                        // Extract current IPs from this resource
                         let current_ips = extract_ips(&obj);
                         let uid = obj.meta().uid.clone().unwrap_or_default();
 
-                        // Compare with cached IPs to detect if IPs actually changed
                         let ips_changed = if let Some(cached_ips) = ip_cache.get(&uid) {
                             cached_ips != &current_ips
                         } else {
-                            // New resource, IPs definitely changed (from none to some)
                             !current_ips.is_empty()
                         };
 
                         if ips_changed {
-                            // Update cache with new IPs
                             ip_cache.insert(uid.clone(), current_ips.clone());
 
-                            debug!(
-                                event.name = "k8s.watcher.add_uid",
-                                k8s.resource.kind = %resource_name,
-                                k8s.resource.object = ?obj.meta().name,
-                                k8s.resource.name = %obj.name_any(),
-                                k8s.resource.namespace = %obj.namespace().unwrap_or_default(),
-                                k8s.resource.uid = %uid,
-                                k8s.resource.ips = %current_ips.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(","),
-                                k8s.resource.host_network = %host_network,
-                                "resource ips changed, adding uid to ip cache"
-                            );
-
-                            // Trigger IP index rebuild. try_send is intentional: if the channel
-                            // is full, a signal is already pending (debounce handles it). If
-                            // closed, the consumer is gone and we stop the watcher.
+                            // try_send is intentional: if full, a rebuild is already pending.
+                            // If closed, the consumer is gone and we should stop.
                             match event_tx.try_send(()) {
                                 Ok(()) | Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
                                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
@@ -1740,21 +1574,6 @@ fn spawn_ip_resource_watcher<K, F>(
                                     return;
                                 }
                             }
-                            trace!(
-                                event.name = "k8s.watcher.ip_changed",
-                                k8s.resource.name = %resource_name,
-                                k8s.resource.object = ?obj.meta().name,
-                                k8s.resource.uid = %uid,
-                                old_ip_count = current_ips.len(),
-                                "Resource IPs changed, triggering IP index update"
-                            );
-                        } else {
-                            trace!(
-                                event.name = "k8s.watcher.ip_unchanged",
-                                k8s.resource.name = %resource_name,
-                                k8s.resource.object = ?obj.meta().name,
-                                "Resource updated but IPs unchanged, skipping rebuild"
-                            );
                         }
                     }
                     Ok(watcher::Event::Delete(obj)) => {
@@ -1765,18 +1584,15 @@ fn spawn_ip_resource_watcher<K, F>(
                             ])
                             .inc();
 
-                        // Remove from cache and trigger rebuild since IPs are being removed
                         let uid = obj.meta().uid.clone().unwrap_or_default();
                         ip_cache.remove(&uid);
 
-                        // Schedule cleanup of metrics for this resource
                         if let Some(ref tracker) = cleanup_tracker {
                             tracker.schedule_k8s_cleanup(resource_name.clone());
                         }
 
-                        // Shrink ip_cache capacity if it's significantly oversized.
-                        // This prevents capacity retention when many K8s resources are deleted
-                        // (e.g., during scale-down, pod churn, or cluster drain).
+                        // Shrink capacity after deletions to avoid retaining excess memory
+                        // during scale-down, pod churn, or cluster drain.
                         let cache_capacity = ip_cache.capacity();
                         let cache_len = ip_cache.len();
                         if k8s_shrink_policy.should_shrink(cache_capacity, cache_len) {
@@ -1794,14 +1610,6 @@ fn spawn_ip_resource_watcher<K, F>(
                                 return;
                             }
                         }
-                        trace!(
-                            event.name = "k8s.watcher.event",
-                            k8s.resource.name = %resource_name,
-                            k8s.resource.object = ?obj.meta().name,
-                            k8s.resource.uid = %uid,
-                            event_type = "delete",
-                            "Resource deleted, triggering IP index update"
-                        );
                     }
                     Ok(watcher::Event::Init) => {
                         metrics::registry::K8S_WATCHER_EVENTS_TOTAL
@@ -1817,13 +1625,7 @@ fn spawn_ip_resource_watcher<K, F>(
                             "K8s watcher initialization started"
                         );
                     }
-                    Ok(watcher::Event::InitApply(_)) => {
-                        trace!(
-                            event.name = "k8s.watcher.init_apply",
-                            k8s.resource.name = %resource_name,
-                            "K8s watcher loading initial object"
-                        );
-                    }
+                    Ok(watcher::Event::InitApply(_)) => {}
                     Ok(watcher::Event::InitDone) => {
                         metrics::registry::K8S_WATCHER_EVENTS_TOTAL
                             .with_label_values(&[
@@ -1879,16 +1681,10 @@ async fn update_ip_index(
     index: &Arc<ArcSwap<HashMap<String, Vec<K8sObjectMeta>>>>,
     conf: &Conf,
 ) {
-    debug!(
-        event.name = "k8s.ip_index.update_start",
-        "starting ip index update"
-    );
-
     let mut new_index = HashMap::new();
 
     if let Some(attributes_map) = &conf.attributes {
         for direction_map in attributes_map.values() {
-            // Iterate through every provider (k8s, etc.)
             if let Some(k8s_conf) = direction_map.get("k8s") {
                 let assoc = &k8s_conf.association;
 

--- a/mermin/src/k8s/decorator.rs
+++ b/mermin/src/k8s/decorator.rs
@@ -8,8 +8,8 @@
 
 use std::{collections::HashMap, net::IpAddr};
 
-use k8s_openapi::api::{core::v1::Pod, networking::v1::NetworkPolicySpec};
-use tracing::{debug, trace};
+use k8s_openapi::api::core::v1::Pod;
+use tracing::debug;
 
 use crate::{
     k8s::{
@@ -24,8 +24,6 @@ use crate::{
 #[derive(Debug)]
 pub struct NetworkPolicy {
     pub policy: K8sObjectMeta,
-    #[allow(dead_code)] // TODO: Use for network policy enforcement
-    pub spec: NetworkPolicySpec,
 }
 
 /// Kubernetes decoration processor that correlates a FlowSpan with Kubernetes metadata
@@ -68,12 +66,6 @@ impl<'a> Decorator<'a> {
 
         let src_info = self.enrich(ctx.src_pod.as_ref(), ctx.src_ip).await;
         if let Some(info) = &src_info {
-            trace!(
-                event.name = "k8s.decorator.associated",
-                flow.community_id = %flow_span.attributes.flow_community_id,
-                k8s.direction = "source",
-                "successfully associated source of flow"
-            );
             self.populate_k8s_attributes(
                 &mut decorated_flow,
                 info,
@@ -85,12 +77,6 @@ impl<'a> Decorator<'a> {
 
         let dst_info = self.enrich(ctx.dst_pod.as_ref(), ctx.dst_ip).await;
         if let Some(info) = &dst_info {
-            trace!(
-                event.name = "k8s.decorator.associated",
-                flow.community_id = %flow_span.attributes.flow_community_id,
-                k8s.direction = "destination",
-                "successfully associated destination of flow"
-            );
             self.populate_k8s_attributes(
                 &mut decorated_flow,
                 info,
@@ -123,15 +109,8 @@ impl<'a> Decorator<'a> {
         }
 
         if let Some(service) = self.attributor.get_service_by_ip(ip).await {
-            let service_meta = K8sObjectMeta::from(service.as_ref());
-            let backend_ips = self
-                .attributor
-                .resolve_service_ip_to_backend_ips(ip)
-                .await
-                .unwrap_or_default();
             return Some(DecorationInfo::Service {
-                service: service_meta,
-                backend_ips,
+                service: K8sObjectMeta::from(service.as_ref()),
             });
         }
 
@@ -147,11 +126,6 @@ impl<'a> Decorator<'a> {
             });
         }
 
-        trace!(
-            event.name = "k8s.ip_unattributable",
-            net.ip.address = %ip,
-            "ip could not be attributed to any known kubernetes resource"
-        );
         None
     }
 
@@ -231,7 +205,6 @@ impl<'a> Decorator<'a> {
                     self.set_k8s_attr_opt(flow_span, "node.name", node_name, is_source);
                 }
 
-                // Resolve and populate container information
                 if let Some((container_name, container_image)) =
                     pod.and_then(|p| resolve_pod_container_by_port(p, port))
                     && self.should_extract("container", "name", is_source)
@@ -245,14 +218,12 @@ impl<'a> Decorator<'a> {
                     );
                 }
 
-                // Populate workload controller information for all owners in the chain
                 if let Some(workload_owners) = owners {
                     for workload_owner in workload_owners {
                         self.populate_workload_attributes(flow_span, workload_owner, is_source);
                     }
                 }
 
-                // Populate selector-based relations (NetworkPolicies, Services that select this pod)
                 if let Some(relations) = selector_relations {
                     for relation in relations {
                         self.populate_selector_relation_attributes(flow_span, relation, is_source);
@@ -262,7 +233,7 @@ impl<'a> Decorator<'a> {
             DecorationInfo::Node { node } => {
                 self.populate_common_meta(flow_span, "node", node, is_source, false);
             }
-            DecorationInfo::Service { service, .. } => {
+            DecorationInfo::Service { service } => {
                 self.populate_common_meta(flow_span, "service", service, is_source, true);
             }
             DecorationInfo::EndpointSlice { slice } => {
@@ -302,15 +273,12 @@ impl<'a> Decorator<'a> {
         self.populate_common_meta(flow_span, kind, meta, is_source, false);
     }
 
-    /// Maps selector-based relation metadata to the appropriate K8s attributes.
-    /// Handles resources that have selectors matching the pod (e.g., NetworkPolicy, Service, workload controllers).
     fn populate_selector_relation_attributes(
         &self,
         flow_span: &mut FlowSpan,
         relation: &K8sObjectMeta,
         is_source: bool,
     ) {
-        // Match based on the kind field (case-insensitive comparison)
         match relation.kind.to_lowercase().as_str() {
             "networkpolicy" => {
                 self.set_k8s_attr(flow_span, "networkpolicy.name", &relation.name, is_source);
@@ -348,7 +316,6 @@ impl<'a> Decorator<'a> {
         }
     }
 
-    /// Sets a required Kubernetes attribute by wrapping the value in Some().
     fn set_k8s_attr(
         &self,
         flow_span: &mut FlowSpan,
@@ -359,7 +326,6 @@ impl<'a> Decorator<'a> {
         self.set_k8s_attr_opt(flow_span, attr_name, &Some(value.to_string()), is_source);
     }
 
-    /// Sets an optional Kubernetes attribute using a compact mapping approach.
     fn set_k8s_attr_opt(
         &self,
         flow_span: &mut FlowSpan,
@@ -379,7 +345,6 @@ impl<'a> Decorator<'a> {
             };
         }
 
-        // Get mutable reference to the appropriate k8s attribute based on direction and type
         let field = k8s_attr_mapping! {
             ("cluster.name", source_k8s_cluster_name, destination_k8s_cluster_name),
             ("namespace.name", source_k8s_namespace_name, destination_k8s_namespace_name),
@@ -399,11 +364,10 @@ impl<'a> Decorator<'a> {
         *field = value.clone();
     }
 
-    /// Sets an optional HashMap attribute.
     fn set_k8s_map_attr(
         &self,
         flow_span: &mut FlowSpan,
-        attr_name: &str, // e.g. "pod.annotations"
+        attr_name: &str,
         value: &Option<HashMap<String, String>>,
         is_source: bool,
     ) {
@@ -474,15 +438,12 @@ impl<'a> Decorator<'a> {
         }
     }
 
-    /// Populates network policy decoration in a FlowSpan.
-    /// Converts policy lists to comma-separated strings for telemetry.
     fn populate_network_policies(
         &self,
         flow_span: &mut FlowSpan,
         ingress_policies: &[NetworkPolicy],
         egress_policies: &[NetworkPolicy],
     ) {
-        // Format ingress policies (affecting destination pod)
         if !ingress_policies.is_empty() {
             let policy_names: Vec<String> = ingress_policies
                 .iter()
@@ -497,7 +458,6 @@ impl<'a> Decorator<'a> {
             flow_span.attributes.network_policies_ingress = Some(policy_names);
         }
 
-        // Format egress policies (affecting source pod)
         if !egress_policies.is_empty() {
             let policy_names: Vec<String> = egress_policies
                 .iter()
@@ -513,8 +473,6 @@ impl<'a> Decorator<'a> {
         }
     }
 
-    /// Evaluates NetworkPolicies for a flow and separates them by direction.
-    /// Returns (ingress_policies, egress_policies) for telemetry decoration.
     async fn evaluate_flow_policies(
         &self,
         ctx: &FlowContext,
@@ -522,12 +480,10 @@ impl<'a> Decorator<'a> {
         let mut ingress_policies = Vec::new();
         let mut egress_policies = Vec::new();
 
-        // Get ingress policies that apply to the destination pod
         if let Some(dst_pod) = &ctx.dst_pod {
             ingress_policies = self.get_policies_for_pod(ctx, dst_pod, FlowDirection::Ingress)?;
         }
 
-        // Get egress policies that apply to the source pod
         if let Some(src_pod) = &ctx.src_pod {
             egress_policies = self.get_policies_for_pod(ctx, src_pod, FlowDirection::Egress)?;
         }
@@ -535,8 +491,6 @@ impl<'a> Decorator<'a> {
         Ok((ingress_policies, egress_policies))
     }
 
-    /// Retrieves NetworkPolicies that match a specific pod in the given direction.
-    /// Converts from the internal policy representation to our NetworkPolicy struct.
     fn get_policies_for_pod(
         &self,
         ctx: &FlowContext,
@@ -551,48 +505,32 @@ impl<'a> Decorator<'a> {
             .iter()
             .map(|p| NetworkPolicy {
                 policy: K8sObjectMeta::from(p.as_ref()),
-                spec: p.spec.clone().unwrap_or_default(),
             })
             .collect())
     }
 }
 
-/// Resolves container information from a Pod by matching the specified port.
-///
-/// Logic:
-/// - Searches for a container with a matching containerPort
-/// - Returns None if no container matches the port
-/// - Validates that Kubernetes containerPort is in valid range (1-65535)
-/// - Skips containers without images defined
+/// Resolves container name and image from a Pod by matching the specified port number.
 pub fn resolve_pod_container_by_port(pod: &Pod, port: u16) -> Option<(String, String)> {
     let spec = pod.spec.as_ref()?;
 
-    // Iterate through all containers in the pod
     for container in &spec.containers {
-        // Skip containers without ports defined
         let Some(ports) = container.ports.as_ref() else {
             continue;
         };
 
-        // Check if any of the container's ports match the requested port
         for container_port in ports {
-            // Kubernetes containerPort is i32 but must be in valid port range (1-65535)
-            // Invalid values are rejected by the API server, so we can safely cast
             let port_num = container_port.container_port;
             if port_num > 0 && port_num <= 65535 && port_num as u16 == port {
-                // Found a match! Extract container name and image
-                // Clone is necessary since we're borrowing from the Pod and need owned data
                 let name = container.name.clone();
                 let Some(image_name) = container.image.clone() else {
-                    continue; // Skip containers without image
+                    continue;
                 };
-
                 return Some((name, image_name));
             }
         }
     }
 
-    // No matching container found
     None
 }
 

--- a/mermin/src/k8s/error.rs
+++ b/mermin/src/k8s/error.rs
@@ -2,23 +2,11 @@ use std::fmt;
 
 use thiserror::Error;
 
-/// Errors that can occur during Kubernetes operations
 #[derive(Debug, Error)]
 pub enum K8sError {
-    /// Failed to create or initialize Kubernetes client
     #[error("failed to initialize Kubernetes client: {0}")]
     ClientInitialization(#[source] Box<kube::Error>),
 
-    /// Failed to create or access resource store
-    #[error("failed to create resource store for {resource}: {source}")]
-    #[allow(dead_code)]
-    ResourceStore {
-        resource: String,
-        #[source]
-        source: Box<kube::Error>,
-    },
-
-    /// Failed to list Kubernetes resources
     #[error("failed to list {resource}: {source}")]
     ResourceList {
         resource: String,
@@ -26,70 +14,18 @@ pub enum K8sError {
         source: Box<kube::Error>,
     },
 
-    /// Critical resource reflector failed to initialize
     #[error("failed to create critical reflector for {resource}: {details}")]
     CriticalReflectorFailure { resource: String, details: String },
 
-    /// Network policy evaluation error
-    #[error("failed to evaluate network policies: {0}")]
-    #[allow(dead_code)]
-    NetworkPolicyEvaluation(String),
-
-    /// Label selector matching error
-    #[error("label selector matching failed: {0}")]
-    #[allow(dead_code)]
-    LabelSelectorMatching(String),
-
-    /// Pod lookup error
-    #[error("failed to lookup pod by IP {ip}: {details}")]
-    #[allow(dead_code)]
-    PodLookup { ip: String, details: String },
-
-    /// Service lookup error
-    #[error("failed to lookup service by IP {ip}: {details}")]
-    #[allow(dead_code)]
-    ServiceLookup { ip: String, details: String },
-
-    /// Node lookup error
-    #[error("failed to lookup node by IP {ip}: {details}")]
-    #[allow(dead_code)]
-    NodeLookup { ip: String, details: String },
-
-    /// Resource attribution error
     #[error("failed to attribute flow with Kubernetes metadata: {0}")]
-    #[allow(dead_code)]
     Attribution(String),
-
-    /// Flow context creation error
-    #[error("failed to create flow context: {0}")]
-    #[allow(dead_code)]
-    FlowContext(String),
 }
 
 impl K8sError {
-    /// Create a critical reflector failure error
     pub fn critical_reflector(resource: impl Into<String>, details: impl fmt::Display) -> Self {
         Self::CriticalReflectorFailure {
             resource: resource.into(),
             details: details.to_string(),
-        }
-    }
-
-    /// Create a resource store error
-    #[allow(dead_code)]
-    pub fn resource_store(resource: impl Into<String>, source: kube::Error) -> Self {
-        Self::ResourceStore {
-            resource: resource.into(),
-            source: Box::new(source),
-        }
-    }
-
-    /// Create a resource list error
-    #[allow(dead_code)]
-    pub fn resource_list(resource: impl Into<String>, source: kube::Error) -> Self {
-        Self::ResourceList {
-            resource: resource.into(),
-            source: Box::new(source),
         }
     }
 }

--- a/mermin/src/k8s/owner_relations.rs
+++ b/mermin/src/k8s/owner_relations.rs
@@ -1,8 +1,3 @@
-// owner_relations.rs - Owner reference walking and filtering
-//
-// This module provides functionality for walking Kubernetes owner references
-// and filtering which owner kinds appear in flow metadata based on configuration.
-
 use std::collections::HashSet;
 
 use k8s_openapi::{
@@ -15,7 +10,7 @@ use k8s_openapi::{
 };
 use kube::{Resource, ResourceExt};
 use serde::{Deserialize, Serialize};
-use tracing::{trace, warn};
+use tracing::{debug, warn};
 
 use crate::k8s::attributor::{K8sObjectMeta, ResourceStore, WorkloadOwner};
 
@@ -57,26 +52,7 @@ pub struct OwnerRelationsManager {
 const MAX_OWNERS: usize = 32;
 
 impl OwnerRelationsManager {
-    /// Creates a new OwnerRelationsManager from configuration
-    ///
     /// All kind names are normalized to lowercase for case-insensitive matching.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mermin::k8s::owner_relations::{OwnerRelationsManager, OwnerRelationsOptions};
-    ///
-    /// // Create a manager that only includes Deployment owners, up to 3 levels deep
-    /// let config = OwnerRelationsOptions {
-    ///     max_depth: 3,
-    ///     include_kinds: vec!["Deployment".to_string()],
-    ///     exclude_kinds: vec![],
-    /// };
-    /// let manager = OwnerRelationsManager::new(config);
-    ///
-    /// // Use with defaults
-    /// let manager = OwnerRelationsManager::new(OwnerRelationsOptions::default());
-    /// ```
     pub fn new(config: OwnerRelationsRules) -> Self {
         let include_kinds = config
             .include_kinds
@@ -104,42 +80,13 @@ impl OwnerRelationsManager {
     /// flow metadata. Returns None if no owners are found or all are filtered out.
     #[must_use]
     pub fn get_owners(&self, pod: &Pod, store: &ResourceStore) -> Option<Vec<WorkloadOwner>> {
-        let pod_name = pod.name_any();
-        let owner_refs = pod.owner_references();
-
-        trace!(
-            event.name = "k8s.get_owners.start",
-            k8s.pod.name = %pod_name,
-            k8s.owner_refs.count = owner_refs.len(),
-            "starting owner chain walk"
-        );
-
         let all_owners = self.walk_owner_chain(pod, store);
 
-        trace!(
-            event.name = "k8s.get_owners.walked",
-            k8s.pod.name = %pod_name,
-            k8s.owners.collected = all_owners.len(),
-            "completed owner chain walk"
-        );
-
         if all_owners.is_empty() {
-            trace!(
-                event.name = "k8s.get_owners.empty",
-                k8s.pod.name = %pod_name,
-                "no owners found in chain"
-            );
             return None;
         }
 
         let filtered = self.filter_owners(all_owners);
-
-        trace!(
-            event.name = "k8s.get_owners.filtered",
-            k8s.pod.name = %pod_name,
-            k8s.owners.filtered = filtered.len(),
-            "completed owner filtering"
-        );
 
         if filtered.is_empty() {
             None
@@ -148,12 +95,6 @@ impl OwnerRelationsManager {
         }
     }
 
-    /// Walks the owner reference chain up to max_depth, collecting all owners encountered.
-    ///
-    /// # Behavior
-    /// - If `max_depth` is 0, returns an empty vector (no owners walked)
-    /// - Stops early if no more owner references are found
-    /// - Stops if MAX_OWNERS limit is reached to prevent resource exhaustion
     fn walk_owner_chain(&self, pod: &Pod, store: &ResourceStore) -> Vec<WorkloadOwner> {
         let mut all_owners = Vec::with_capacity(self.max_depth.min(8));
         let mut current_owners = pod.owner_references().to_vec();
@@ -163,8 +104,6 @@ impl OwnerRelationsManager {
         while !current_owners.is_empty() && depth < self.max_depth && all_owners.len() < MAX_OWNERS
         {
             depth += 1;
-
-            // Process all owners at this level
             let mut next_level_owners = Vec::new();
 
             for owner_ref in current_owners {
@@ -173,22 +112,20 @@ impl OwnerRelationsManager {
                 {
                     all_owners.push(owner.clone());
 
-                    // Update namespace if this owner has one
                     if let Some(ns) = self.get_owner_namespace(&owner) {
                         namespace = ns;
                     }
 
-                    // Queue up the next level of owners
                     if let Some(next_owners) = next_owners_opt {
                         next_level_owners.extend(next_owners);
                     }
                 } else {
-                    trace!(
+                    debug!(
                         event.name = "k8s.owner_ref_missing",
                         k8s.owner.name = %owner_ref.name,
                         k8s.owner.kind = %owner_ref.kind,
                         k8s.namespace = %namespace,
-                        "failed to find owner reference in local store"
+                        "owner reference not found in local store"
                     );
                 }
             }
@@ -208,12 +145,6 @@ impl OwnerRelationsManager {
         all_owners
     }
 
-    /// Filters the list of owners based on include/exclude rules.
-    ///
-    /// Logic:
-    /// - If exclude_kinds contains the kind, exclude it (highest priority)
-    /// - If include_kinds is non-empty and doesn't contain the kind, exclude it
-    /// - Otherwise, include it
     fn filter_owners(&self, owners: Vec<WorkloadOwner>) -> Vec<WorkloadOwner> {
         owners
             .into_iter()
@@ -232,17 +163,14 @@ impl OwnerRelationsManager {
             WorkloadOwner::CronJob(_) => "cronjob",
         };
 
-        // Exclude takes precedence
         if self.exclude_kinds.contains(kind) {
             return false;
         }
 
-        // If include_kinds is empty, include all (that aren't excluded)
         if self.include_kinds.is_empty() {
             return true;
         }
 
-        // Otherwise, only include if in the include list
         self.include_kinds.contains(kind)
     }
 
@@ -254,48 +182,22 @@ impl OwnerRelationsManager {
         store: &ResourceStore,
     ) -> Option<(WorkloadOwner, Option<Vec<OwnerReference>>)> {
         let name = &owner_ref.name;
-        let kind = &owner_ref.kind;
-
-        trace!(
-            event.name = "k8s.lookup_owner.start",
-            k8s.owner.name = %name,
-            k8s.owner.kind = %kind,
-            k8s.namespace = %namespace,
-            "looking up owner in resource store"
-        );
 
         macro_rules! find_in_store {
             ($store_type:ty, $variant:ident) => {{
-                let resources = store.get_by_namespace::<$store_type>(namespace);
-                let resource_count = resources.len();
-                trace!(
-                    event.name = "k8s.lookup_owner.store_check",
-                    k8s.owner.kind = %kind,
-                    k8s.namespace = %namespace,
-                    k8s.resources.count = resource_count,
-                    "checking resource store"
-                );
-
-                resources
-                    .iter()
+                store
+                    .get_by_namespace::<$store_type>(namespace)
+                    .into_iter()
                     .find(|obj| obj.name_any() == *name)
                     .map(|obj| {
                         let meta = K8sObjectMeta::from(obj.as_ref());
                         let next_owners = obj.meta().owner_references.clone();
-                        let next_refs_count = next_owners.as_ref().map(|v| v.len()).unwrap_or(0);
-                        trace!(
-                            event.name = "k8s.lookup_owner.found",
-                            k8s.owner.name = %name,
-                            k8s.owner.kind = %kind,
-                            k8s.owner.next_refs = next_refs_count,
-                            "found owner in store"
-                        );
                         (WorkloadOwner::$variant(meta), next_owners)
                     })
             }};
         }
 
-        let result = match owner_ref.kind.as_str() {
+        match owner_ref.kind.as_str() {
             "ReplicaSet" => find_in_store!(ReplicaSet, ReplicaSet),
             "Deployment" => find_in_store!(Deployment, Deployment),
             "StatefulSet" => find_in_store!(StatefulSet, StatefulSet),
@@ -303,26 +205,14 @@ impl OwnerRelationsManager {
             "Job" => find_in_store!(Job, Job),
             "CronJob" => find_in_store!(CronJob, CronJob),
             _ => {
-                trace!(
+                debug!(
                     event.name = "k8s.unsupported_owner_kind",
                     k8s.owner.kind = %owner_ref.kind,
-                    "owner lookup for this resource kind is not implemented"
+                    "owner lookup for this resource kind is not supported"
                 );
                 None
             }
-        };
-
-        if result.is_none() {
-            trace!(
-                event.name = "k8s.lookup_owner.not_found",
-                k8s.owner.name = %name,
-                k8s.owner.kind = %kind,
-                k8s.namespace = %namespace,
-                "owner not found in resource store"
-            );
         }
-
-        result
     }
 
     /// Gets the namespace from a WorkloadOwner.

--- a/mermin/src/k8s/selector_relations.rs
+++ b/mermin/src/k8s/selector_relations.rs
@@ -1,9 +1,3 @@
-// selector_relations.rs - Selector-based K8s resource relations
-//
-// This module provides functionality for matching Kubernetes resources based on
-// label selectors defined in other resources (e.g., NetworkPolicy -> Pod via podSelector,
-// Service -> Pod via spec.selector).
-
 use std::collections::BTreeMap;
 
 use k8s_openapi::{
@@ -15,10 +9,9 @@ use k8s_openapi::{
     },
     apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement},
 };
-use kube::ResourceExt;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{debug, trace, warn};
+use tracing::{debug, warn};
 
 use crate::k8s::attributor::{K8sObjectMeta, ResourceStore};
 
@@ -63,26 +56,7 @@ pub(crate) struct NormalizedRule {
 }
 
 impl SelectorRelationsManager {
-    /// Creates a new SelectorRelationsManager from configuration rules
-    ///
     /// All kind names are normalized to lowercase for case-insensitive matching.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mermin::k8s::selector_relations::SelectorRelationsManager;
-    /// use mermin::runtime::conf::SelectorRelationRule;
-    ///
-    /// let rules = vec![
-    ///     SelectorRelationRule {
-    ///         kind: "NetworkPolicy".to_string(),
-    ///         to: "Pod".to_string(),
-    ///         selector_match_labels_field: Some("spec.podSelector.matchLabels".to_string()),
-    ///         selector_match_expressions_field: Some("spec.podSelector.matchExpressions".to_string()),
-    ///     },
-    /// ];
-    /// let manager = SelectorRelationsManager::new(rules);
-    /// ```
     pub fn new(rules: Vec<SelectorRelationRule>) -> Self {
         let normalized_rules = rules
             .into_iter()
@@ -197,7 +171,6 @@ impl SelectorRelationsManager {
         }
     }
 
-    /// Finds NetworkPolicies whose podSelector matches the given pod labels
     fn find_matching_network_policies(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -205,40 +178,17 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let policies = store.get_by_namespace::<NetworkPolicy>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_network_policies",
-            k8s.namespace = %pod_namespace,
-            k8s.policies.count = policies.len(),
-            "checking NetworkPolicies for selector matches"
-        );
-
-        policies
+        store
+            .get_by_namespace::<NetworkPolicy>(pod_namespace)
             .iter()
             .filter_map(|policy| {
-                let policy_name = policy.name_any();
-
-                // Extract selector from the NetworkPolicy spec
                 let selector = self.extract_selector_from_network_policy(policy, rule)?;
-
-                // Check if selector matches pod labels
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.networkpolicy.name = %policy_name,
-                        k8s.namespace = %pod_namespace,
-                        "NetworkPolicy selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(policy.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(policy.as_ref()))
             })
             .collect()
     }
 
-    /// Finds Services whose selector matches the given pod labels
     fn find_matching_services(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -246,84 +196,54 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let services = store.get_by_namespace::<Service>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_services",
-            k8s.namespace = %pod_namespace,
-            k8s.services.count = services.len(),
-            "checking Services for selector matches"
-        );
-
-        services
+        store
+            .get_by_namespace::<Service>(pod_namespace)
             .iter()
             .filter_map(|service| {
-                let service_name = service.name_any();
-
-                // Extract selector from the Service spec
                 let selector = self.extract_selector_from_service(service, rule)?;
-
-                // Check if selector matches pod labels
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.service.name = %service_name,
-                        k8s.namespace = %pod_namespace,
-                        "Service selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(service.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(service.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a NetworkPolicy based on the rule configuration
     fn extract_selector_from_network_policy(
         &self,
         policy: &NetworkPolicy,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(policy, rule);
         }
 
-        // Otherwise, use default built-in extraction: spec.podSelector
         policy.spec.as_ref().map(|spec| spec.pod_selector.clone())
     }
 
-    /// Extracts a LabelSelector from a Service based on the rule configuration
     fn extract_selector_from_service(
         &self,
         service: &Service,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(service, rule);
         }
 
-        // Otherwise, use default built-in extraction: spec.selector as matchLabels
         let selector_map = service.spec.as_ref()?.selector.as_ref()?;
 
         if selector_map.is_empty() {
             return None;
         }
 
-        // Convert the selector map to a LabelSelector
         Some(LabelSelector {
             match_labels: Some(selector_map.clone()),
             match_expressions: None,
         })
     }
 
-    /// Finds ReplicaSets whose selector matches the given pod labels
     fn find_matching_replicasets(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -331,54 +251,30 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let replicasets = store.get_by_namespace::<ReplicaSet>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_replicasets",
-            k8s.namespace = %pod_namespace,
-            k8s.replicasets.count = replicasets.len(),
-            "checking ReplicaSets for selector matches"
-        );
-
-        replicasets
+        store
+            .get_by_namespace::<ReplicaSet>(pod_namespace)
             .iter()
             .filter_map(|rs| {
-                let rs_name = rs.name_any();
                 let selector = self.extract_selector_from_replicaset(rs, rule)?;
-
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.replicaset.name = %rs_name,
-                        k8s.namespace = %pod_namespace,
-                        "ReplicaSet selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(rs.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(rs.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a ReplicaSet
     fn extract_selector_from_replicaset(
         &self,
         replicaset: &ReplicaSet,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(replicaset, rule);
         }
-
-        // Otherwise, use default built-in extraction: spec.selector
         Some(replicaset.spec.as_ref()?.selector.clone())
     }
 
-    /// Finds Deployments whose selector matches the given pod labels
     fn find_matching_deployments(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -386,54 +282,30 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let deployments = store.get_by_namespace::<Deployment>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_deployments",
-            k8s.namespace = %pod_namespace,
-            k8s.deployments.count = deployments.len(),
-            "checking Deployments for selector matches"
-        );
-
-        deployments
+        store
+            .get_by_namespace::<Deployment>(pod_namespace)
             .iter()
             .filter_map(|deployment| {
-                let deployment_name = deployment.name_any();
                 let selector = self.extract_selector_from_deployment(deployment, rule)?;
-
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.deployment.name = %deployment_name,
-                        k8s.namespace = %pod_namespace,
-                        "Deployment selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(deployment.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(deployment.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a Deployment
     fn extract_selector_from_deployment(
         &self,
         deployment: &Deployment,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(deployment, rule);
         }
-
-        // Otherwise, use default built-in extraction: spec.selector
         Some(deployment.spec.as_ref()?.selector.clone())
     }
 
-    /// Finds StatefulSets whose selector matches the given pod labels
     fn find_matching_statefulsets(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -441,54 +313,30 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let statefulsets = store.get_by_namespace::<StatefulSet>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_statefulsets",
-            k8s.namespace = %pod_namespace,
-            k8s.statefulsets.count = statefulsets.len(),
-            "checking StatefulSets for selector matches"
-        );
-
-        statefulsets
+        store
+            .get_by_namespace::<StatefulSet>(pod_namespace)
             .iter()
             .filter_map(|sts| {
-                let sts_name = sts.name_any();
                 let selector = self.extract_selector_from_statefulset(sts, rule)?;
-
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.statefulset.name = %sts_name,
-                        k8s.namespace = %pod_namespace,
-                        "StatefulSet selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(sts.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(sts.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a StatefulSet
     fn extract_selector_from_statefulset(
         &self,
         statefulset: &StatefulSet,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(statefulset, rule);
         }
-
-        // Otherwise, use default built-in extraction: spec.selector
         Some(statefulset.spec.as_ref()?.selector.clone())
     }
 
-    /// Finds DaemonSets whose selector matches the given pod labels
     fn find_matching_daemonsets(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -496,54 +344,30 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let daemonsets = store.get_by_namespace::<DaemonSet>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_daemonsets",
-            k8s.namespace = %pod_namespace,
-            k8s.daemonsets.count = daemonsets.len(),
-            "checking DaemonSets for selector matches"
-        );
-
-        daemonsets
+        store
+            .get_by_namespace::<DaemonSet>(pod_namespace)
             .iter()
             .filter_map(|ds| {
-                let ds_name = ds.name_any();
                 let selector = self.extract_selector_from_daemonset(ds, rule)?;
-
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.daemonset.name = %ds_name,
-                        k8s.namespace = %pod_namespace,
-                        "DaemonSet selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(ds.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(ds.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a DaemonSet
     fn extract_selector_from_daemonset(
         &self,
         daemonset: &DaemonSet,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(daemonset, rule);
         }
-
-        // Otherwise, use default built-in extraction: spec.selector
         Some(daemonset.spec.as_ref()?.selector.clone())
     }
 
-    /// Finds Jobs whose selector matches the given pod labels
     fn find_matching_jobs(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -551,49 +375,26 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let jobs = store.get_by_namespace::<Job>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_jobs",
-            k8s.namespace = %pod_namespace,
-            k8s.jobs.count = jobs.len(),
-            "checking Jobs for selector matches"
-        );
-
-        jobs.iter()
+        store
+            .get_by_namespace::<Job>(pod_namespace)
+            .iter()
             .filter_map(|job| {
-                let job_name = job.name_any();
                 let selector = self.extract_selector_from_job(job, rule)?;
-
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.job.name = %job_name,
-                        k8s.namespace = %pod_namespace,
-                        "Job selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(job.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(job.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a Job
     fn extract_selector_from_job(&self, job: &Job, rule: &NormalizedRule) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(job, rule);
         }
-
-        // Otherwise, use default built-in extraction: spec.selector
         job.spec.as_ref()?.selector.clone()
     }
 
-    /// Finds CronJobs whose job template selector matches the given pod labels
     fn find_matching_cronjobs(
         &self,
         pod_labels: &BTreeMap<String, String>,
@@ -601,50 +402,28 @@ impl SelectorRelationsManager {
         rule: &NormalizedRule,
         store: &ResourceStore,
     ) -> Vec<K8sObjectMeta> {
-        let cronjobs = store.get_by_namespace::<CronJob>(pod_namespace);
-
-        trace!(
-            event.name = "selector_relations.check_cronjobs",
-            k8s.namespace = %pod_namespace,
-            k8s.cronjobs.count = cronjobs.len(),
-            "checking CronJobs for selector matches"
-        );
-
-        cronjobs
+        store
+            .get_by_namespace::<CronJob>(pod_namespace)
             .iter()
             .filter_map(|cronjob| {
-                let cronjob_name = cronjob.name_any();
                 let selector = self.extract_selector_from_cronjob(cronjob, rule)?;
-
-                if self.selector_matches(&selector, pod_labels) {
-                    trace!(
-                        event.name = "selector_relations.match_found",
-                        k8s.cronjob.name = %cronjob_name,
-                        k8s.namespace = %pod_namespace,
-                        "CronJob selector matches pod labels"
-                    );
-                    Some(K8sObjectMeta::from(cronjob.as_ref()))
-                } else {
-                    None
-                }
+                self.selector_matches(&selector, pod_labels)
+                    .then(|| K8sObjectMeta::from(cronjob.as_ref()))
             })
             .collect()
     }
 
-    /// Extracts a LabelSelector from a CronJob's job template
     fn extract_selector_from_cronjob(
         &self,
         cronjob: &CronJob,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // If custom field paths are specified in the rule, use generic extraction
         if rule.selector_match_labels_field.is_some()
             || rule.selector_match_expressions_field.is_some()
         {
             return self.extract_selector_generic(cronjob, rule);
         }
 
-        // Otherwise, use default built-in extraction: spec.jobTemplate.spec.selector
         cronjob
             .spec
             .as_ref()?
@@ -655,17 +434,11 @@ impl SelectorRelationsManager {
             .clone()
     }
 
-    /// Checks if a label selector matches the given labels
-    ///
-    /// This implements the Kubernetes label selector matching logic:
-    /// - All matchLabels must be present with exact values
-    /// - All matchExpressions must evaluate to true
     pub(crate) fn selector_matches(
         &self,
         selector: &LabelSelector,
         labels: &BTreeMap<String, String>,
     ) -> bool {
-        // Check match_labels
         if let Some(match_labels) = &selector.match_labels {
             for (key, value) in match_labels {
                 if labels.get(key) != Some(value) {
@@ -674,7 +447,6 @@ impl SelectorRelationsManager {
             }
         }
 
-        // Check match_expressions
         if let Some(match_expressions) = &selector.match_expressions {
             for expr in match_expressions {
                 if !self.expression_matches(expr, labels) {
@@ -686,7 +458,6 @@ impl SelectorRelationsManager {
         true
     }
 
-    /// Checks if a label selector requirement matches the given labels
     fn expression_matches(
         &self,
         expr: &LabelSelectorRequirement,
@@ -724,29 +495,18 @@ impl SelectorRelationsManager {
         }
     }
 
-    /// Generic selector extraction using JSON field paths from rule configuration.
-    ///
-    /// This method enables dynamic field path extraction for CRDs and custom resources
-    /// where selectors may be at non-standard locations.
-    ///
-    /// # Arguments
-    /// * `resource` - The resource to extract selector from (must be serializable to JSON)
-    /// * `rule` - The rule containing field paths to matchLabels and matchExpressions
-    ///
-    /// # Returns
-    /// A `LabelSelector` if extraction succeeds, None otherwise
+    /// Extracts a `LabelSelector` from a resource using JSON field paths defined in the rule.
+    /// Enables selector matching for CRDs where selectors may be at non-standard locations.
     pub(crate) fn extract_selector_generic<T: serde::Serialize>(
         &self,
         resource: &T,
         rule: &NormalizedRule,
     ) -> Option<LabelSelector> {
-        // Serialize resource to JSON for field path extraction
         let json_value = serde_json::to_value(resource).ok()?;
 
         let mut selector = LabelSelector::default();
         let mut has_content = false;
 
-        // Extract matchLabels if field path is specified
         if let Some(labels_path) = &rule.selector_match_labels_field
             && let Some(labels_value) = self.extract_json_field(&json_value, labels_path)
             && let Some(labels_map) = labels_value.as_object()
@@ -762,7 +522,6 @@ impl SelectorRelationsManager {
             }
         }
 
-        // Extract matchExpressions if field path is specified
         if let Some(expr_path) = &rule.selector_match_expressions_field
             && let Some(expressions_value) = self.extract_json_field(&json_value, expr_path)
             && let Some(expr_array) = expressions_value.as_array()
@@ -781,11 +540,6 @@ impl SelectorRelationsManager {
         if has_content { Some(selector) } else { None }
     }
 
-    /// Extracts a field from a JSON value using a dot-separated path.
-    ///
-    /// # Examples
-    /// - Path "spec.selector" on {"spec": {"selector": {...}}} returns the selector object
-    /// - Path "spec.podSelector.matchLabels" navigates through nested objects
     fn extract_json_field<'a>(&self, value: &'a Value, path: &str) -> Option<&'a Value> {
         let parts: Vec<&str> = path.split('.').collect();
         let mut current = value;
@@ -797,16 +551,6 @@ impl SelectorRelationsManager {
         Some(current)
     }
 
-    /// Parses a JSON value into a LabelSelectorRequirement.
-    ///
-    /// Expected JSON structure:
-    /// ```json
-    /// {
-    ///   "key": "environment",
-    ///   "operator": "In",
-    ///   "values": ["prod", "staging"]
-    /// }
-    /// ```
     fn parse_label_selector_requirement(&self, value: &Value) -> Option<LabelSelectorRequirement> {
         let obj = value.as_object()?;
 


### PR DESCRIPTION
## Changes

- error.rs: delete 7 unused error variants and 2 dead helper methods
- decorator.rs: remove NetworkPolicy.spec dead field and the expensive resolve_service_ip_to_backend_ips call whose result was never consumed; drop noisy per-flow trace logs
- attributor.rs: drop Attributor.client dead field; remove hot-path trace logs (ip resolution, conflict resolution, watcher ip_changed/ ip_unchanged/delete/init_apply events, ip_index start/rebuilt notices); fix unnecessary full-struct clones in get_network_policies_for_pod
- owner_relations.rs: remove per-flow trace instrumentation throughout get_owners and lookup_owner; upgrade meaningful events to debug
- selector_relations.rs: collapse 8 find_matching_X methods to remove per-kind trace logs and unused local variables; drop ResourceExt import