### PR TITLE
refactor: simplify iface controller logic and trim verbose logging

### DIFF
--- a/mermin/src/iface/controller.rs
+++ b/mermin/src/iface/controller.rs
@@ -263,7 +263,7 @@ impl IfaceController {
 
         Ok(Self {
             patterns,
-            active_ifaces: HashSet::new(), // Will be populated by initialize() after namespace switch
+            active_ifaces: HashSet::new(),
             tc_links: HashMap::new(),
             iface_map,
             ebpf,
@@ -312,7 +312,7 @@ impl IfaceController {
                 .set(1);
         }
 
-        self.build_iface_map()?;
+        self.build_iface_map();
 
         // Clean up any orphaned TC programs from previous instances before attaching new ones.
         // This prevents the issue where killed pods leave TC programs attached that intercept traffic.
@@ -460,24 +460,16 @@ impl IfaceController {
         Ok(())
     }
 
-    /// Consume the controller and return the `Ebpf` object.
-    ///
-    /// Called after [`shutdown()`] to recover the `Ebpf` object for reuse across
-    /// pipeline restarts.  Dropping the controller first ensures all other fields
-    /// (tc_links, active_ifaces, …) are cleaned up before the `Ebpf` is handed off.
     pub fn into_ebpf(self) -> Ebpf {
         self.ebpf
     }
 
-    /// Get shared iface_map for flow decoration. ArcSwap allows lock-free reads
-    /// while controller updates it dynamically.
     #[must_use]
     pub fn iface_map(&self) -> Arc<ArcSwap<HashMap<u32, String>>> {
         Arc::clone(&self.iface_map)
     }
 
-    /// Build interface index → name mapping from host namespace.
-    fn build_iface_map(&mut self) -> Result<(), MerminError> {
+    fn build_iface_map(&mut self) {
         let mut new_map = HashMap::with_capacity(self.active_ifaces.len());
         for iface in datalink::interfaces() {
             if self.active_ifaces.contains(&iface.name) {
@@ -485,11 +477,8 @@ impl IfaceController {
             }
         }
         self.iface_map.store(Arc::new(new_map));
-
-        Ok(())
     }
 
-    /// Add newly discovered interface to iface_map.
     fn iface_map_add(&mut self, iface_name: &str) -> Result<(), MerminError> {
         for iface in datalink::interfaces() {
             if iface.name == iface_name {
@@ -510,7 +499,6 @@ impl IfaceController {
         )))
     }
 
-    /// Remove interface from iface_map.
     fn iface_map_remove(&mut self, iface_name: &str) {
         let mut new_map = (**self.iface_map.load()).clone();
         new_map.retain(|idx, name| {
@@ -787,7 +775,7 @@ impl IfaceController {
     ) -> Result<SchedClassifierLinkId, MerminError> {
         let options = TcAttachOptions::Netlink(NlOptions {
             priority,
-            handle: 0, // Let system choose handle
+            handle: 0,
         });
 
         program
@@ -819,7 +807,6 @@ impl IfaceController {
 
         let iface_owned = iface.to_string();
 
-        // In TCX mode, try to unpin the link before detaching
         if self.use_tcx {
             let pin_path = Self::pin_path(&iface_owned, direction);
             match PinnedLink::from_pin(&pin_path) {
@@ -1051,7 +1038,7 @@ impl IfaceController {
         Ok(())
     }
 
-    /// Remove orphaned TC programs from an interface.
+    /// Remove orphaned TC programs from an interface using netlink.
     ///
     /// Uses Aya's native netlink functions to find and detach TC programs by name.
     /// Returns the count of removed programs.

--- a/mermin/src/iface/threads.rs
+++ b/mermin/src/iface/threads.rs
@@ -100,11 +100,6 @@ pub fn spawn_controller_thread(
                      requires hostPID: true and CAP_SYS_ADMIN capability.",
                 );
             }
-            info!(
-                event.name = "interface_controller.started",
-                "controller thread started and permanently in host network namespace"
-            );
-
             if let Some(ref tx) = event_tx && tx.send(ControllerEvent::Ready).is_err() {
                 error!(
                     event.name = "interface_controller.ready_send_failed",
@@ -284,7 +279,6 @@ pub fn spawn_netlink_thread(
                 "netlink monitoring thread started and permanently in host network namespace"
             );
 
-            // Create netlink socket using raw libc (netlink-sys Socket has buffering issues)
             // SAFETY: socket() syscall is safe to call. We check the return value for errors.
             let sock_fd = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE as i32) };
             if sock_fd < 0 {
@@ -299,18 +293,11 @@ pub fn spawn_netlink_thread(
 
             let sock = NetlinkSocket(sock_fd);
 
-            info!(
-                event.name = "interface_controller.netlink.socket_created",
-                socket_fd = sock.as_raw_fd(),
-                "netlink socket created successfully"
-            );
-
-            // Bind with kernel-assigned PID and no groups (will subscribe via setsockopt)
             // SAFETY: sockaddr_nl is a C-compatible struct that is safe to zero-initialize.
             let mut addr: sockaddr_nl = unsafe { mem::zeroed() };
             addr.nl_family = AF_NETLINK as u16;
-            addr.nl_pid = 0; // Kernel assigns PID
-            addr.nl_groups = 0; // No groups in bind, use setsockopt instead
+            addr.nl_pid = 0;
+            addr.nl_groups = 0;
 
             // SAFETY: sock is a valid socket descriptor, addr is properly initialized,
             // and we're passing the correct size. Return value is checked for errors.
@@ -494,30 +481,18 @@ pub fn spawn_netlink_thread(
                                                     let is_up =
                                                         link_msg.header.flags.contains(LinkFlags::Up);
 
-                                                    if is_up {
-                                                        debug!(
-                                                            event.name = "interface_controller.netlink.interface_up",
-                                                            network.interface.name = %if_name,
-                                                            "interface came up, sending event to controller"
-                                                        );
-                                                        if event_tx
+                                                    if is_up
+                                                        && event_tx
                                                             .send(NetlinkEvent::InterfaceUp {
                                                                 name: if_name,
                                                             })
                                                             .is_err()
-                                                        {
-                                                            error!(
-                                                                event.name = "interface_controller.netlink.channel_send_failed",
-                                                                "controller channel closed, exiting"
-                                                            );
-                                                            return;
-                                                        }
-                                                    } else {
-                                                        debug!(
-                                                            event.name = "interface_controller.netlink.interface_down_newlink",
-                                                            network.interface.name = %if_name,
-                                                            "interface reported without UP flag"
+                                                    {
+                                                        error!(
+                                                            event.name = "interface_controller.netlink.channel_send_failed",
+                                                            "controller channel closed, exiting"
                                                         );
+                                                        return;
                                                     }
                                                 }
                                             }
@@ -531,24 +506,17 @@ pub fn spawn_netlink_thread(
                                                             _ => None,
                                                         }
                                                     })
+                                                && event_tx
+                                                    .send(NetlinkEvent::InterfaceDown {
+                                                        name: if_name,
+                                                    })
+                                                    .is_err()
                                                 {
-                                                    debug!(
-                                                        event.name = "interface_controller.netlink.interface_down",
-                                                        network.interface.name = %if_name,
-                                                        "interface went down, sending event to controller"
+                                                    error!(
+                                                        event.name = "interface_controller.netlink.channel_send_failed",
+                                                        "controller channel closed, exiting"
                                                     );
-                                                    if event_tx
-                                                        .send(NetlinkEvent::InterfaceDown {
-                                                            name: if_name,
-                                                        })
-                                                        .is_err()
-                                                    {
-                                                        error!(
-                                                            event.name = "interface_controller.netlink.channel_send_failed",
-                                                            "controller channel closed, exiting"
-                                                        );
-                                                        return;
-                                                    }
+                                                    return;
                                                 }
                                             }
                                             _ => {}
@@ -567,7 +535,7 @@ pub fn spawn_netlink_thread(
                             }
                         }
                         Err(_) => {
-                            break;
+                        break;
                         }
                     }
                 }


### PR DESCRIPTION
## Changes

- change build_iface_map to return () instead of Result (was infallible)
- remove redundant doc comments and inline code comments
- collapse nested if/event_tx error checks into combined conditions
- remove debug log events for interface up/down netlink transitions
- remove info log for controller thread start and socket creation