### PR TITLE
refactor(otlp): remove dead code, dev logs, and redundant comments

### DIFF
--- a/mermin/src/otlp/error.rs
+++ b/mermin/src/otlp/error.rs
@@ -1,66 +1,21 @@
 use thiserror::Error;
 
-/// Errors that can occur during OTLP operations
 #[derive(Debug, Error)]
 pub enum OtlpError {
-    /// Failed to initialize OTLP provider
-    #[error("failed to initialize OTLP provider: {0}")]
-    #[allow(dead_code)]
-    ProviderInitialization(String),
-
-    /// Failed to create OTLP exporter
     #[error("failed to create OTLP exporter: {0}")]
-    #[allow(dead_code)]
-    ExporterCreation(String),
-
-    /// Failed to configure OTLP exporter
-    #[error("failed to configure OTLP exporter: {0}")]
-    #[allow(dead_code)]
     ExporterConfiguration(String),
 
-    /// Failed to export trace data
-    #[error("failed to export trace data: {0}")]
-    #[allow(dead_code)]
-    TraceExport(String),
-
-    /// Failed to initialize internal tracing
-    #[error("failed to initialize internal tracing: {0}")]
-    #[allow(dead_code)]
-    InternalTracingInitialization(String),
-
-    /// Failed to set global tracer provider
-    #[error("failed to set global tracer provider: {0}")]
-    #[allow(dead_code)]
-    GlobalTracerProvider(String),
-
-    /// Invalid exporter options
-    #[error("invalid exporter options: {0}")]
-    #[allow(dead_code)]
-    InvalidOptions(String),
-
-    /// Exporter endpoint error
     #[error("invalid exporter endpoint '{endpoint}': {details}")]
-    #[allow(dead_code)]
     InvalidEndpoint { endpoint: String, details: String },
 
-    /// TLS configuration error
     #[error("TLS configuration error: {0}")]
-    #[allow(dead_code)]
     TlsConfiguration(String),
 
-    /// Batch processor configuration error
-    #[error("batch processor configuration error: {0}")]
-    #[allow(dead_code)]
-    BatchProcessorConfiguration(String),
-
-    /// Tonic transport error
     #[error("tonic transport error: {0}")]
     TonicTransport(#[from] tonic::transport::Error),
 }
 
 impl OtlpError {
-    /// Create an invalid endpoint error
-    #[allow(dead_code)]
     pub fn invalid_endpoint(endpoint: impl Into<String>, details: impl Into<String>) -> Self {
         Self::InvalidEndpoint {
             endpoint: endpoint.into(),

--- a/mermin/src/otlp/opts.rs
+++ b/mermin/src/otlp/opts.rs
@@ -8,17 +8,6 @@ use crate::runtime::conf::conf_serde::{duration, exporter_protocol, stdout_fmt};
 
 /// Configuration options for the Mermin traces exporter.
 ///
-/// This struct defines the top-level exporter configuration, allowing the user to specify
-/// multiple exporter backends (such as OTLP and stdout) and their individual settings.
-/// Each exporter type (e.g., OTLP, stdout) is represented as an optional map, where the key
-/// is a unique exporter name (as referenced in the agent configuration), and the value is
-/// the configuration for that specific exporter instance.
-///
-/// Exporters are responsible for sending telemetry data (such as traces and metrics)
-/// to external systems. The configuration enables flexible selection and customization
-/// of exporters, supporting scenarios where multiple exporters of the same type may be
-/// defined and enabled independently.
-///
 /// # Example (YAML)
 /// ```yaml
 /// export:
@@ -28,26 +17,14 @@ use crate::runtime::conf::conf_serde::{duration, exporter_protocol, stdout_fmt};
 ///       protocol: grpc
 ///     stdout: text_indent
 /// ```
-///
-/// # Fields
-/// - `traces`: Trace exporter configuration options.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct ExportOptions {
-    /// Trace exporter configuration options.
     pub traces: TracesExportOptions,
 }
 
-/// Configuration options for trace exporters.
-///
-/// # Fields
-/// - `otlp`: Optional OTLP exporter configuration.
-/// - `stdout`: Optional stdout exporter format.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct TracesExportOptions {
-    /// Stdout exporter configuration options.
     pub stdout: Option<StdoutExportOptions>,
-
-    /// OTLP (OpenTelemetry Protocol) exporter configurations.
     pub otlp: Option<OtlpExportOptions>,
 }
 
@@ -65,13 +42,6 @@ impl Default for StdoutExportOptions {
     }
 }
 
-/// StdoutFmt enum defines the format for a stdout exporter,
-/// which outputs telemetry data (such as traces or metrics) directly to
-/// the standard output (stdout) of the running process. This is useful
-/// for debugging, development, or environments where logs are collected
-/// from container or process output.
-///
-/// Note: Only "text_indent" is supported.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StdoutFmt {
@@ -99,7 +69,7 @@ impl From<String> for StdoutFmt {
             "text_indent" => StdoutFmt::TextIndent,
             // "json" => StdoutFmt::Json,
             // "json_indent" => StdoutFmt::JsonIndent,
-            _ => StdoutFmt::TextIndent, // Default to Text
+            _ => StdoutFmt::TextIndent,
         }
     }
 }
@@ -112,16 +82,7 @@ impl std::str::FromStr for StdoutFmt {
     }
 }
 
-/// Configuration options for an individual OTLP (OpenTelemetry Protocol) exporter instance.
-///
-/// This struct defines all the necessary parameters to configure an OTLP exporter,
-/// which is responsible for sending telemetry data (such as traces and metrics)
-/// to a remote OTLP-compatible backend (e.g., OpenTelemetry Collector, observability platforms).
-///
-/// Each OTLP exporter is uniquely identified by a name in the configuration file,
-/// and its settings are provided via this struct. The fields allow for specifying
-/// the network address and port of the OTLP endpoint, as well as optional authentication
-/// and TLS (Transport Layer Security) settings.
+/// Configuration options for an individual OTLP exporter instance.
 ///
 /// # Example (HCL)
 /// ```hcl
@@ -150,19 +111,6 @@ impl std::str::FromStr for StdoutFmt {
 ///   }
 /// }
 /// ```
-///
-/// # Fields
-/// - `endpoint`: The full OTLP endpoint URL (e.g., "http://localhost:4317")
-/// - `protocol`: The OTLP protocol to use (grpc or http_binary)
-/// - `timeout`: Request timeout duration
-/// - `auth`: Optional authentication configuration (e.g., basic auth)
-/// - `headers`: Optional additional headers to be sent with each request
-/// - `tls`: Optional TLS configuration for secure communication
-/// - `max_batch_size`: Maximum number of spans to batch before export (default: 512)
-/// - `max_batch_interval`: Maximum time to wait before exporting a batch (default: 5s)
-/// - `max_queue_size`: Maximum queue size to buffer spans for delayed processing (default: 2048)
-/// - `max_concurrent_exports`: Maximum number of concurrent exports (default: 1, experimental)
-/// - `max_export_timeout`: Maximum duration to export a batch of data (default: 30s, experimental)
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct OtlpExportOptions {
     #[serde(default = "defaults::endpoint")]
@@ -187,35 +135,12 @@ pub struct OtlpExportOptions {
     pub tls: Option<TlsOptions>,
 }
 
-/// Authentication configuration for exporters.
-///
-/// This struct encapsulates the authentication options that can be used when connecting
-/// to telemetry backends (such as OTLP collectors). It is designed to be extensible for
-/// supporting multiple authentication mechanisms. Currently, it supports basic authentication
-/// via the `basic` field, which allows specifying a username and password (with support for
-/// environment variable substitution).
-///
-/// # Fields
-/// - `basic`: Optional basic authentication configuration. If present, the exporter will use
-///   HTTP Basic Auth with the provided credentials.
-///
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AuthOptions {
     pub basic: Option<BasicAuthOptions>,
     pub bearer: Option<String>, // TODO: Add support for api_key, oauth2, mtls, etc. - ENG-120
 }
 
-/// Configuration for HTTP Basic Authentication credentials.
-///
-/// This struct defines the username and password used for HTTP Basic Auth
-/// when connecting to telemetry backends (such as OTLP exporters).
-/// The fields support direct string values or, optionally, environment variable
-/// substitution (e.g., `env("MY_PASSWORD_ENV_VAR")`) for secure secret management.
-///
-/// # Fields
-/// - `user`: The username for authentication. Can be a plain string or an environment variable reference.
-/// - `pass`: The password for authentication. Can be a plain string or an environment variable reference.
-///
 /// # Example (YAML)
 /// ```yaml
 /// auth:
@@ -226,98 +151,53 @@ pub struct AuthOptions {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct BasicAuthOptions {
     pub user: String,
-    pub pass: String, // TODO: Support environment variable substitution like env("USER_SPECIFIED_ENV_VAR_TRITON_PASS") - ENG-120
+    pub pass: String, // TODO: Support environment variable substitution - ENG-120
 }
 
-/// TLS (Transport Layer Security) configuration for secure exporter connections.
+/// TLS configuration for secure exporter connections.
 ///
-/// This struct defines the options for enabling and customizing TLS when connecting
-/// to telemetry backends (such as OTLP collectors).
+/// ## Automatic TLS behavior
 ///
-/// # Automatic TLS Behavior
+/// - **https:// endpoints**: TLS is automatically enabled using system root certificates.
+/// - **http:// endpoints**: No TLS unless explicitly configured via this struct.
 ///
-/// - **https:// endpoints**: TLS is automatically enabled using system root certificates
-///   when an endpoint uses the `https://` scheme, even without an explicit `tls` configuration.
-/// - **http:// endpoints**: No TLS is used unless explicitly configured via this struct.
+/// ## Certificate verification
 ///
-/// # Certificate Verification
+/// - **Custom CA**: Provide `ca_cert` to use a custom CA instead of system roots (for private CAs or self-signed certs).
+/// - **Mutual TLS**: Provide both `client_cert` and `client_key` for mTLS authentication.
+/// - **Skip verification**: Set `insecure_skip_verify: true` to disable certificate verification entirely.
 ///
-/// By default, TLS connections validate server certificates against system root certificates.
-/// You can customize this behavior:
-///
-/// - **Custom CA**: Provide a `ca_cert` path to use a custom certificate authority
-///   instead of system root certificates (useful for private CAs and self-signed certificates).
-/// - **Mutual TLS**: Provide both `client_cert` and `client_key` for mutual TLS authentication.
-/// - **Skip Verification**: Set `insecure_skip_verify: true` to disable certificate verification entirely.
-///
-/// # Self-Signed Certificates
-///
-/// For self-signed certificates in production, use the `ca_cert` option to specify the self-signed
-/// certificate or the CA that signed it. This is the recommended secure approach.
-///
-/// For development/testing environments where you want to skip verification entirely,
-/// you can use `insecure_skip_verify: true`, but be aware this makes your connection vulnerable to
-/// man-in-the-middle attacks.
-///
-/// # Insecure Skip Verify Mode
-///
-/// WARNING: Setting `insecure_skip_verify: true` disables all certificate verification and should ONLY
-/// be used for development and testing purposes. In production, use the `ca_cert` option instead.
-///
-/// When insecure skip verify mode is enabled:
-/// - TLS is still used for encryption
-/// - Server certificates are not validated
-/// - Hostname verification is skipped
-/// - Any certificate will be accepted (including invalid, expired, or self-signed certificates)
-/// - The connection is vulnerable to man-in-the-middle attacks
-/// - Cannot be combined with client certificates (mutual TLS)
-/// - A warning will be logged each time a connection is established
-///
-/// # Fields
-/// - `insecure_skip_verify`: Skip certificate and hostname verification while maintaining TLS encryption. WARNING: Only use for development/testing!
-/// - `ca_cert`: Optional path to a custom CA certificate file (overrides system root certificates).
-/// - `client_cert`: Optional path to a client certificate file for mutual TLS.
-/// - `client_key`: Optional path to a client private key file for mutual TLS.
+/// WARNING: `insecure_skip_verify: true` disables all certificate verification and should ONLY be used
+/// for development and testing. It cannot be combined with client certificates.
 ///
 /// # Examples
 ///
-/// ## Example 1: Custom CA for self-signed certificates (RECOMMENDED)
+/// ## Custom CA (recommended for self-signed certs)
 /// ```yaml
 /// tls:
-///   insecure_skip_verify: false
-///   ca_cert: /etc/certs/self-signed-ca.crt  # Add your self-signed cert here
-///   client_cert: /etc/certs/client.crt      # Optional: for mutual TLS
-///   client_key: /etc/certs/client.key       # Optional: for mutual TLS
+///   ca_cert: /etc/certs/self-signed-ca.crt
+///   client_cert: /etc/certs/client.crt  # optional, for mTLS
+///   client_key: /etc/certs/client.key   # optional, for mTLS
 /// ```
 ///
-/// ## Example 2: Skip verification for development/testing (NOT for production!)
+/// ## Skip verification (development only)
 /// ```yaml
 /// tls:
-///   insecure_skip_verify: true  # Skip all certificate verification
+///   insecure_skip_verify: true
 /// ```
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TlsOptions {
-    /// Skip certificate and hostname verification while maintaining TLS encryption.
-    /// WARNING: Only use for development/testing! Makes connections vulnerable to MITM attacks.
-    /// Cannot be combined with client certificates.
+    /// Skip certificate and hostname verification. WARNING: development/testing only; vulnerable to MITM.
     pub insecure_skip_verify: Option<bool>,
-    /// Path to the CA certificate file for server verification.
-    /// When provided, this overrides system root certificates.
-    /// Use this for self-signed certificates by specifying your self-signed cert or CA.
+    /// Path to a CA certificate file. Overrides system root certificates.
     pub ca_cert: Option<String>,
-    /// Path to the client certificate file for mutual TLS.
-    /// Must be provided together with client_key.
-    /// Cannot be used with insecure_skip_verify mode.
+    /// Path to a client certificate file for mutual TLS. Must be paired with `client_key`.
     pub client_cert: Option<String>,
-    /// Path to the client private key file for mutual TLS.
-    /// Must be provided together with client_cert.
-    /// Cannot be used with insecure_skip_verify mode.
+    /// Path to a client private key file for mutual TLS. Must be paired with `client_cert`.
     pub client_key: Option<String>,
 }
 
 impl AuthOptions {
-    // TODO: Implement authentication header generation for OTLP exporters - ENG-120
-    // This should create appropriate headers based on the auth configuration
     pub fn generate_auth_headers(&self) -> Result<HashMap<String, String>, String> {
         let mut headers = HashMap::new();
 
@@ -433,12 +313,10 @@ mod tests {
 
     #[test]
     fn test_exporter_protocol_serialization() {
-        // Test Grpc variant
         let grpc = ExporterProtocol::Grpc;
         let serialized = serde_json::to_string(&grpc).unwrap();
         assert_eq!(serialized, "\"grpc\"");
 
-        // Test HttpBinary variant
         let http_binary = ExporterProtocol::HttpBinary;
         let serialized = serde_json::to_string(&http_binary).unwrap();
         assert_eq!(serialized, "\"http_binary\"");
@@ -446,19 +324,15 @@ mod tests {
 
     #[test]
     fn test_exporter_protocol_deserialization() {
-        // Test grpc string
         let deserialized: ExporterProtocol = serde_json::from_str("\"grpc\"").unwrap();
         assert!(matches!(deserialized, ExporterProtocol::Grpc));
 
-        // Test http_binary string
         let deserialized: ExporterProtocol = serde_json::from_str("\"http_binary\"").unwrap();
         assert!(matches!(deserialized, ExporterProtocol::HttpBinary));
 
-        // Test case insensitive
         let deserialized: ExporterProtocol = serde_json::from_str("\"GRPC\"").unwrap();
         assert!(matches!(deserialized, ExporterProtocol::Grpc));
 
-        // Test invalid value defaults to Grpc
         let deserialized: ExporterProtocol = serde_json::from_str("\"invalid\"").unwrap();
         assert!(matches!(deserialized, ExporterProtocol::Grpc));
     }

--- a/mermin/src/otlp/provider.rs
+++ b/mermin/src/otlp/provider.rs
@@ -27,7 +27,7 @@ use rustls::{
 use rustls_pemfile::{certs, private_key};
 use serde::{Deserialize, Serialize};
 use tonic::{metadata::MetadataMap, transport::Channel};
-use tracing::{Level, debug, info, warn};
+use tracing::{Level, info, warn};
 use tracing_subscriber::{
     EnvFilter, Registry,
     fmt::{Layer, format::FmtSpan},
@@ -101,7 +101,6 @@ impl ServerCertVerifier for NoCertVerifier {
         _ocsp_response: &[u8],
         _now: UnixTime,
     ) -> Result<ServerCertVerified, RustlsError> {
-        // Accept any certificate without verification
         Ok(ServerCertVerified::assertion())
     }
 
@@ -111,7 +110,6 @@ impl ServerCertVerifier for NoCertVerifier {
         _cert: &CertificateDer<'_>,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, RustlsError> {
-        // Accept any signature without verification
         Ok(HandshakeSignatureValid::assertion())
     }
 
@@ -121,12 +119,10 @@ impl ServerCertVerifier for NoCertVerifier {
         _cert: &CertificateDer<'_>,
         _dss: &DigitallySignedStruct,
     ) -> Result<HandshakeSignatureValid, RustlsError> {
-        // Accept any signature without verification
         Ok(HandshakeSignatureValid::assertion())
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        // Support modern signature schemes (excluding deprecated SHA1-based schemes)
         vec![
             SignatureScheme::RSA_PKCS1_SHA256,
             SignatureScheme::ECDSA_NISTP256_SHA256,
@@ -155,17 +151,9 @@ impl ProviderBuilder {
         self.sdk_builder.build()
     }
 
-    /// Build OTLP exporter from options. It will prepare the headers, build the TLS configuration, and build the appropriate exporter based on the protocol.
     pub async fn with_otlp_exporter(self, options: OtlpExportOptions) -> Result<Self, OtlpError> {
-        debug!(
-            event.name = "exporter.otlp.started",
-            "starting otlp exporter"
-        );
-
-        // Prepare headers (merge user + auth headers)
         let (options, headers) = Self::prepare_headers(options)?;
 
-        // Parse endpoint and determine TLS requirements
         let endpoint = options.endpoint.clone();
         let uri: Uri = endpoint.parse().map_err(|e| {
             OtlpError::invalid_endpoint(&endpoint, format!("failed to parse as uri: {e}"))
@@ -194,11 +182,6 @@ impl ProviderBuilder {
             )?,
         };
 
-        debug!(
-            event.name = "exporter.otlp.build_success",
-            "otlp exporter built successfully"
-        );
-
         let batch_config = BatchConfigBuilder::default()
             .with_max_export_batch_size(options.max_batch_size)
             .with_scheduled_delay(options.max_batch_interval)
@@ -225,7 +208,6 @@ impl ProviderBuilder {
         })
     }
 
-    /// Build stdout exporter from batch configuration. It will wrap the exporter in a metrics exporter and configure the batch processor.
     pub fn with_stdout_exporter(
         self,
         max_batch_size: usize,
@@ -235,7 +217,6 @@ impl ProviderBuilder {
         max_export_timeout: std::time::Duration,
     ) -> ProviderBuilder {
         let exporter = opentelemetry_stdout::SpanExporter::default();
-        // Wrap exporter to observe batch sizes
         let wrapped_exporter = MetricsSpanExporter::new(exporter, ExporterName::Stdout);
 
         let batch_config = BatchConfigBuilder::default()
@@ -254,7 +235,6 @@ impl ProviderBuilder {
         }
     }
 
-    // Build TLS configuration from TLS options.
     fn build_tls_config(
         is_https: bool,
         tls_opts: Option<&TlsOptions>,
@@ -265,7 +245,6 @@ impl ProviderBuilder {
             .and_then(|t| t.insecure_skip_verify)
             .unwrap_or(false);
 
-        // No TLS needed for plain HTTP without explicit TLS options
         if !is_https && tls_opts.is_none() {
             return Ok(None);
         }
@@ -301,11 +280,6 @@ impl ProviderBuilder {
             && let (Some(client_cert_path), Some(client_key_path)) =
                 (&tls_opts.client_cert, &tls_opts.client_key)
         {
-            debug!(
-                "loading client certificate for mutual tls from: {}",
-                client_cert_path
-            );
-
             let client_certs = load_certs_from_pem(client_cert_path).map_err(|e| {
                 let error_msg = e.to_string();
                 if error_msg.contains("failed to open certificate file") {
@@ -338,17 +312,13 @@ impl ProviderBuilder {
         Ok(Some(config_builder.with_no_client_auth()))
     }
 
-    // Build gRPC exporter from URI, TLS configuration, and headers.
     fn build_grpc_exporter(
         uri: Uri,
         tls_config: Option<&ClientConfig>,
         headers: Option<&HashMap<String, String>>,
     ) -> Result<opentelemetry_otlp::SpanExporter, OtlpError> {
         let channel = match tls_config {
-            None => {
-                debug!("using plain http connection");
-                Channel::builder(uri).connect_lazy()
-            }
+            None => Channel::builder(uri).connect_lazy(),
             Some(tls_config) => {
                 let mut http = HttpConnector::new();
                 http.enforce_http(false);
@@ -378,7 +348,6 @@ impl ProviderBuilder {
         })
     }
 
-    // Build HTTP exporter from endpoint, TLS configuration, headers, and timeout.
     fn build_http_exporter(
         endpoint: String,
         tls_config: Option<&ClientConfig>,
@@ -413,7 +382,6 @@ impl ProviderBuilder {
         })
     }
 
-    // Build root certificate store from TLS options.
     fn build_root_cert_store(
         is_https: bool,
         tls_opts: Option<&TlsOptions>,
@@ -421,7 +389,6 @@ impl ProviderBuilder {
         let mut root_store = RootCertStore::empty();
 
         if is_https {
-            debug!("detected https:// endpoint, loading system root certificates");
             let native_certs = rustls_native_certs::load_native_certs();
 
             if let Some(err) = native_certs.errors.first() {
@@ -438,7 +405,6 @@ impl ProviderBuilder {
         if let Some(tls_opts) = tls_opts
             && let Some(ca_cert_path) = &tls_opts.ca_cert
         {
-            debug!("loading custom ca certificate from: {}", ca_cert_path);
             let ca_certs = load_certs_from_pem(ca_cert_path)?;
 
             if ca_certs.is_empty() {
@@ -467,7 +433,6 @@ impl ProviderBuilder {
         Ok(root_store)
     }
 
-    // Validate TLS options, returning an error if the options are invalid.
     fn validate_tls_options(tls_opts: Option<&TlsOptions>) -> Result<(), OtlpError> {
         let Some(tls_opts) = tls_opts else {
             return Ok(());
@@ -492,7 +457,6 @@ impl ProviderBuilder {
         Ok(())
     }
 
-    // Convert headers to gRPC metadata.
     fn headers_to_grpc_metadata(
         headers: &HashMap<String, String>,
     ) -> Result<MetadataMap, OtlpError> {
@@ -515,7 +479,6 @@ impl ProviderBuilder {
         Ok(MetadataMap::from_headers(header_map))
     }
 
-    // Prepare headers by merging user and auth headers, returning an error if there is a collision.
     fn prepare_headers(
         mut options: OtlpExportOptions,
     ) -> Result<(OtlpExportOptions, Option<HashMap<String, String>>), OtlpError> {
@@ -540,7 +503,6 @@ impl ProviderBuilder {
         Ok((options, headers))
     }
 
-    // Merge user and auth headers, returning an error if there is a collision.
     fn merge_headers(
         mut user: HashMap<String, String>,
         auth: HashMap<String, String>,

--- a/mermin/src/otlp/resource.rs
+++ b/mermin/src/otlp/resource.rs
@@ -167,7 +167,6 @@ fn host_interface_ips() -> Vec<String> {
 
     addrs
         .filter_map(|iface| {
-            // Skip loopback interfaces and interfaces that are not up.
             if iface
                 .flags
                 .intersects(InterfaceFlags::IFF_LOOPBACK | InterfaceFlags::IFF_POINTOPOINT)
@@ -180,7 +179,6 @@ fn host_interface_ips() -> Vec<String> {
                 .as_sockaddr_in()
                 .map(|s| IpAddr::V4(s.ip()))
                 .or_else(|| sock_addr.as_sockaddr_in6().map(|s| IpAddr::V6(s.ip())))?;
-            // Exclude loopback and link-local addresses.
             if addr.is_loopback() || is_link_local(addr) {
                 return None;
             }

--- a/mermin/src/otlp/trace.rs
+++ b/mermin/src/otlp/trace.rs
@@ -26,10 +26,7 @@ impl TraceExporterAdapter {
         Self { provider, tracer }
     }
 
-    /// Explicitly shutdown the OpenTelemetry provider with a timeout
     pub fn shutdown(&self) -> OTelSdkResult {
-        // The OpenTelemetry SDK provider has a shutdown method that should be called
-        // to gracefully flush remaining spans and close connections
         self.provider.shutdown()
     }
 }
@@ -96,20 +93,14 @@ impl TraceableExporter for TraceExporterAdapter {
         let tracer = &self.tracer;
         let name = traceable.name().unwrap_or_else(|| "flow".to_string());
 
-        let mut span = if let Some(trace_id) = traceable.trace_id() {
-            tracer
-                .span_builder(name.clone())
-                .with_kind(traceable.span_kind())
-                .with_start_time(traceable.start_time())
-                .with_trace_id(trace_id)
-                .start_with_context(tracer, &opentelemetry::Context::new())
-        } else {
-            tracer
-                .span_builder(name.clone())
-                .with_kind(traceable.span_kind())
-                .with_start_time(traceable.start_time())
-                .start_with_context(tracer, &opentelemetry::Context::new())
-        };
+        let mut builder = tracer
+            .span_builder(name)
+            .with_kind(traceable.span_kind())
+            .with_start_time(traceable.start_time());
+        if let Some(trace_id) = traceable.trace_id() {
+            builder = builder.with_trace_id(trace_id);
+        }
+        let mut span = builder.start_with_context(tracer, &opentelemetry::Context::new());
         span = traceable.record(span);
         opentelemetry::trace::Span::end_with_timestamp(&mut span, traceable.end_time());
     }


### PR DESCRIPTION
## Changes

- remove 7 unused OtlpError variants and all #[allow(dead_code)] attrs
- drop debug! logs that fired during exporter initialization with no operator value (otlp started, build success, plain http connection, loading certs/ca, https endpoint detection)
- remove inline comments that restate private method names and obvious code intent across provider.rs
- remove StdoutFmt commented-out variants (Text, Json, JsonIndent) and corresponding dead match arms in as_str() and From<String>
- trim # Fields doc sections that duplicated field-level documentation
- collapse duplicate span_builder branches in trace.rs export(); removes name.clone() call