### PR TITLE
refactor: remove verbose logs and redundant comments across runtime modules

### DIFF
--- a/mermin/src/runtime/capabilities.rs
+++ b/mermin/src/runtime/capabilities.rs
@@ -10,7 +10,7 @@
 
 use std::fs;
 
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::error::{MerminError, Result};
 
@@ -58,7 +58,6 @@ fn has_capability(cap: Capability) -> Result<bool> {
 
     for line in status.lines() {
         if let Some(caps_hex) = line.strip_prefix("CapEff:").map(str::trim) {
-            // Parse the hex string as u64 (capabilities bitmask)
             let caps = u64::from_str_radix(caps_hex, 16).map_err(|e| {
                 MerminError::internal(format!("failed to parse capability mask '{caps_hex}': {e}"))
             })?;
@@ -88,23 +87,10 @@ pub fn check_required_capabilities() -> Result<()> {
     let mut missing_caps = Vec::new();
 
     for cap in &required_caps {
-        debug!(
-            event.name = "capabilities.checking",
-            capability = cap.name(),
-            "checking for required capability"
-        );
-
         match has_capability(*cap) {
-            Ok(true) => {
-                debug!(
-                    event.name = "capabilities.present",
-                    capability = cap.name(),
-                    "capability is present"
-                );
-            }
+            Ok(true) => {}
             Ok(false) => {
-                // CAP_PERFMON and CAP_BPF were added in kernel 5.8
-                // On older kernels, CAP_SYS_ADMIN provides similar functionality
+                // CAP_PERFMON and CAP_BPF were added in kernel 5.8; CAP_SYS_ADMIN covers them on older kernels.
                 if matches!(cap, Capability::Perfmon | Capability::Bpf) {
                     warn!(
                         event.name = "capabilities.missing_fallback",
@@ -157,10 +143,7 @@ mod tests {
     #[test]
     #[ignore] // Only works when running with appropriate capabilities
     fn test_check_capabilities() {
-        // This test will fail if not running with required capabilities
-        let result = check_required_capabilities();
-        // Just verify it doesn't panic - actual result depends on execution environment
-        let _ = result;
+        let _ = check_required_capabilities();
     }
 
     #[test]

--- a/mermin/src/runtime/commands/bpf.rs
+++ b/mermin/src/runtime/commands/bpf.rs
@@ -42,15 +42,6 @@ impl InterfaceTestResult {
     }
 }
 
-/// Filter interfaces based on patterns and skip patterns
-fn matches_pattern(name: &str, patterns: &[String]) -> bool {
-    if patterns.is_empty() {
-        return true; // No patterns means match all
-    }
-    IfaceController::matches_pattern(name, patterns)
-}
-
-/// Check if interface matches any skip pattern
 fn matches_skip_pattern(name: &str, skip_patterns: &[String]) -> bool {
     skip_patterns
         .iter()
@@ -59,7 +50,6 @@ fn matches_skip_pattern(name: &str, skip_patterns: &[String]) -> bool {
 
 /// Execute the BPF diagnostic command
 pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String]) -> Result<()> {
-    // Initialize minimal tracing FIRST so all logs are captured
     let log_level = std::env::var("MERMIN_LOG_LEVEL")
         .unwrap_or_else(|_| "info".to_string())
         .parse::<tracing::Level>()
@@ -89,31 +79,15 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
         .init();
 
     let interfaces_to_test: Vec<String> = if let Some(iface) = interface {
-        // Single interface mode - explicit interface specified
         vec![iface.to_string()]
     } else {
-        // Multi-interface mode (default) - discover and filter all interfaces
         let all_interfaces: Vec<_> = datalink::interfaces()
             .into_iter()
             .filter(|iface| {
-                // Skip loopback interfaces
                 if iface.is_loopback() {
-                    debug!(
-                        event.name = "diagnose.bpf.interface_skipped",
-                        network.interface.name = %iface.name,
-                        reason = "loopback",
-                        "skipping loopback interface"
-                    );
                     return false;
                 }
-                // Skip DOWN interfaces
                 if !iface.is_up() {
-                    debug!(
-                        event.name = "diagnose.bpf.interface_skipped",
-                        network.interface.name = %iface.name,
-                        reason = "down",
-                        "skipping DOWN interface"
-                    );
                     return false;
                 }
                 true
@@ -133,17 +107,9 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
         } else {
             all_interfaces
                 .into_iter()
-                .filter(|iface| matches_pattern(iface, pattern))
+                .filter(|iface| IfaceController::matches_pattern(iface, pattern))
                 .collect()
         };
-
-        info!(
-            event.name = "diagnose.bpf.pattern_filter_applied",
-            pattern_count = pattern.len(),
-            patterns = ?pattern,
-            filtered_count = pattern_filtered.len(),
-            "applied pattern filter"
-        );
 
         let final_interfaces: Vec<String> = if skip.is_empty() {
             pattern_filtered
@@ -153,15 +119,6 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
                 .filter(|iface| !matches_skip_pattern(iface, skip))
                 .collect()
         };
-
-        info!(
-            event.name = "diagnose.bpf.skip_filter_applied",
-            skip_count = skip.len(),
-            skip_patterns = ?skip,
-            final_count = final_interfaces.len(),
-            interfaces = ?final_interfaces,
-            "applied skip filter"
-        );
 
         if final_interfaces.is_empty() {
             return Err(MerminError::internal(
@@ -179,17 +136,8 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
         "starting BPF filesystem and attach/detach tests"
     );
 
-    info!(
-        event.name = "diagnose.bpf.checking_capabilities",
-        "checking required capabilities"
-    );
     capabilities::check_required_capabilities()?;
-    info!(
-        event.name = "diagnose.bpf.capabilities_ok",
-        "all required capabilities present"
-    );
 
-    // Bump memlock rlimit
     let rlim = libc::rlimit {
         rlim_cur: libc::RLIM_INFINITY,
         rlim_max: libc::RLIM_INFINITY,
@@ -202,17 +150,8 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
             error.code = ret,
             "failed to remove limit on locked memory"
         );
-    } else {
-        info!(
-            event.name = "diagnose.bpf.rlimit_set",
-            "memlock rlimit set successfully"
-        );
     }
 
-    info!(
-        event.name = "diagnose.bpf.loading_ebpf",
-        "loading eBPF program"
-    );
     let mut ebpf = aya::EbpfLoader::new()
         .set_max_entries("FLOW_STATS_MAP", 1000)
         .load(aya::include_bytes_aligned!(concat!(
@@ -229,42 +168,24 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
         "kernel version determined"
     );
 
-    info!(
-        event.name = "diagnose.bpf.testing_bpf_fs",
-        "testing /sys/fs/bpf writeability"
-    );
     let bpf_fs_writable = use_tcx && {
         let test_pin_path = "/sys/fs/bpf/mermin_test_map";
         let test_result = ebpf
             .maps()
             .next()
             .and_then(|(_, map)| match map.pin(test_pin_path) {
-                Ok(_) => {
-                    info!(
-                        event.name = "diagnose.bpf.bpf_fs_pin_success",
-                        test_path = %test_pin_path,
-                        "successfully pinned test map to BPF filesystem"
-                    );
-                    match std::fs::remove_file(test_pin_path) {
-                        Ok(_) => {
-                            info!(
-                                event.name = "diagnose.bpf.bpf_fs_cleanup_success",
-                                test_path = %test_pin_path,
-                                "successfully cleaned up test pin"
-                            );
-                            Some(())
-                        }
-                        Err(e) => {
-                            warn!(
-                                event.name = "diagnose.bpf.bpf_fs_cleanup_failed",
-                                error = %e,
-                                test_path = %test_pin_path,
-                                "failed to cleanup test pin, but /sys/fs/bpf is writable"
-                            );
-                            Some(())
-                        }
+                Ok(_) => match std::fs::remove_file(test_pin_path) {
+                    Ok(_) => Some(()),
+                    Err(e) => {
+                        warn!(
+                            event.name = "diagnose.bpf.bpf_fs_cleanup_failed",
+                            error = %e,
+                            test_path = %test_pin_path,
+                            "failed to cleanup test pin, but /sys/fs/bpf is writable"
+                        );
+                        Some(())
                     }
-                }
+                },
                 Err(e) => {
                     warn!(
                         event.name = "diagnose.bpf.bpf_fs_pin_failed",
@@ -289,26 +210,6 @@ pub async fn execute(interface: Option<&str>, pattern: &[String], skip: &[String
         event.name = "diagnose.bpf.program_loaded",
         "eBPF program loaded successfully"
     );
-
-    if use_tcx {
-        if bpf_fs_writable {
-            info!(
-                event.name = "diagnose.bpf.bpf_fs_writable",
-                "✓ /sys/fs/bpf is writable - TCX link pinning will work"
-            );
-        } else {
-            warn!(
-                event.name = "diagnose.bpf.bpf_fs_not_writable",
-                "✗ /sys/fs/bpf is not writable - TCX link pinning will fail, mount as hostPath for orphan cleanup"
-            );
-        }
-    } else {
-        info!(
-            event.name = "diagnose.bpf.bpf_fs_check_skipped",
-            reason = "netlink_mode",
-            "BPF filesystem check skipped (not using TCX mode)"
-        );
-    }
 
     let mut results: Vec<InterfaceTestResult> = Vec::new();
 
@@ -341,20 +242,7 @@ fn test_single_interface(
     let mut pin_success: Option<bool> = None;
     let mut link_id: Option<SchedClassifierLinkId> = None;
 
-    info!(
-        event.name = "diagnose.bpf.attach_starting",
-        network.interface.name = %interface,
-        "starting attach test"
-    );
-
-    // TCX mode: kernel >= 6.6, attach with ordering
     if use_tcx {
-        info!(
-            event.name = "diagnose.bpf.attaching_tcx",
-            network.interface.name = %interface,
-            "attaching eBPF program with TCX (order=last)"
-        );
-
         let options = TcAttachOptions::TcxOrder(LinkOrder::last());
         match ingress_program.attach_with_options(interface, TcAttachType::Ingress, options) {
             Ok(attached_id) => {
@@ -367,12 +255,6 @@ fn test_single_interface(
 
                 if bpf_fs_writable {
                     let pin_path = format!("/sys/fs/bpf/mermin_tcx_{interface}_ingress");
-                    info!(
-                        event.name = "diagnose.bpf.pinning_link",
-                        pin_path = %pin_path,
-                        "attempting to pin TCX link"
-                    );
-
                     match ingress_program.take_link(attached_id) {
                         Ok(link) => {
                             match TryInto::<aya::programs::links::FdLink>::try_into(link) {
@@ -420,7 +302,6 @@ fn test_single_interface(
                         }
                     }
                 } else {
-                    // Store link_id for standard detach test
                     link_id = Some(attached_id);
                 }
             }
@@ -434,13 +315,6 @@ fn test_single_interface(
             }
         }
     } else {
-        // Netlink mode: kernel < 6.6, use priority
-        info!(
-            event.name = "diagnose.bpf.attaching_netlink",
-            network.interface.name = %interface,
-            "attaching eBPF program with netlink (priority=50)"
-        );
-
         if let Err(e) = aya::programs::tc::qdisc_add_clsact(interface) {
             debug!(
                 event.name = "diagnose.bpf.qdisc_add_skipped",
@@ -479,50 +353,34 @@ fn test_single_interface(
     let mut detach_success = false;
 
     if attach_success {
-        info!(
-            event.name = "diagnose.bpf.detach_starting",
-            network.interface.name = %interface,
-            "starting detach test"
-        );
-
         if use_tcx {
-            // Try to unpin link first
             let pin_path = format!("/sys/fs/bpf/mermin_tcx_{interface}_ingress");
             match PinnedLink::from_pin(&pin_path) {
-                Ok(pinned_link) => {
-                    info!(
-                        event.name = "diagnose.bpf.unpinning_link",
-                        pin_path = %pin_path,
-                        "attempting to unpin TCX link"
-                    );
-                    match pinned_link.unpin() {
-                        Ok(_fd_link) => {
-                            detach_success = true;
-                            info!(
-                                event.name = "diagnose.bpf.detach_success",
-                                network.interface.name = %interface,
-                                pin_path = %pin_path,
-                                "✓ successfully detached program via unpinned link"
-                            );
-                        }
-                        Err(e) => {
-                            warn!(
-                                event.name = "diagnose.bpf.unpin_failed",
-                                pin_path = %pin_path,
-                                error = %e,
-                                "✗ failed to unpin link, trying standard detach"
-                            );
-                            // Fall through to standard detach
-                        }
+                Ok(pinned_link) => match pinned_link.unpin() {
+                    Ok(_fd_link) => {
+                        detach_success = true;
+                        info!(
+                            event.name = "diagnose.bpf.detach_success",
+                            network.interface.name = %interface,
+                            pin_path = %pin_path,
+                            "✓ successfully detached program via unpinned link"
+                        );
                     }
-                }
+                    Err(e) => {
+                        warn!(
+                            event.name = "diagnose.bpf.unpin_failed",
+                            pin_path = %pin_path,
+                            error = %e,
+                            "✗ failed to unpin link, trying standard detach"
+                        );
+                    }
+                },
                 Err(_e) => {
                     debug!(
                         event.name = "diagnose.bpf.pin_not_found",
                         pin_path = %pin_path,
                         "pinned link not found, using standard detach"
                     );
-                    // Fall through to standard detach
                 }
             }
 
@@ -555,35 +413,32 @@ fn test_single_interface(
                     );
                 }
             }
-        } else {
-            // Netlink mode: standard detach
-            if let Some(id) = link_id {
-                match ingress_program.detach(id) {
-                    Ok(_) => {
-                        detach_success = true;
-                        info!(
-                            event.name = "diagnose.bpf.detach_success",
-                            network.interface.name = %interface,
-                            "✓ successfully detached program (netlink mode)"
-                        );
-                    }
-                    Err(e) => {
-                        error!(
-                            event.name = "diagnose.bpf.detach_failed",
-                            network.interface.name = %interface,
-                            error = %e,
-                            "✗ failed to detach program"
-                        );
-                    }
+        } else if let Some(id) = link_id {
+            match ingress_program.detach(id) {
+                Ok(_) => {
+                    detach_success = true;
+                    info!(
+                        event.name = "diagnose.bpf.detach_success",
+                        network.interface.name = %interface,
+                        "✓ successfully detached program (netlink mode)"
+                    );
                 }
-            } else {
-                warn!(
-                    event.name = "diagnose.bpf.detach_skipped",
-                    network.interface.name = %interface,
-                    reason = "no_link_id",
-                    "skipping detach test - no link ID available"
-                );
+                Err(e) => {
+                    error!(
+                        event.name = "diagnose.bpf.detach_failed",
+                        network.interface.name = %interface,
+                        error = %e,
+                        "✗ failed to detach program"
+                    );
+                }
             }
+        } else {
+            warn!(
+                event.name = "diagnose.bpf.detach_skipped",
+                network.interface.name = %interface,
+                reason = "no_link_id",
+                "skipping detach test - no link ID available"
+            );
         }
     } else {
         warn!(
@@ -668,7 +523,6 @@ fn print_test_results(
             println!("       Mount /sys/fs/bpf as hostPath for orphan cleanup on pod restart.");
         }
     } else {
-        // Single interface mode - use original format
         let result = &results[0];
         println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         println!("BPF Test Results Summary");

--- a/mermin/src/runtime/commands/diagnose.rs
+++ b/mermin/src/runtime/commands/diagnose.rs
@@ -8,7 +8,6 @@ use crate::{
     runtime::{cli::DiagnoseCommand, commands},
 };
 
-/// Execute a diagnose subcommand
 pub async fn execute(command: &DiagnoseCommand) -> Result<()> {
     match command {
         DiagnoseCommand::Bpf {

--- a/mermin/src/runtime/component/handle.rs
+++ b/mermin/src/runtime/component/handle.rs
@@ -10,7 +10,6 @@ use tokio::task::JoinHandle;
 use tracing::error;
 
 /// RAII wrapper for eventfd used to signal shutdown to OS threads.
-/// Automatically closes the eventfd when dropped.
 pub struct ShutdownEventFd(RawFd);
 
 impl ShutdownEventFd {
@@ -74,7 +73,6 @@ pub enum Handle {
 }
 
 impl Handle {
-    /// Create a handle for an async tokio task.
     pub fn async_task(name: impl Into<String>, join: JoinHandle<()>) -> Self {
         Handle::Async {
             name: name.into(),
@@ -82,7 +80,6 @@ impl Handle {
         }
     }
 
-    /// Create a handle for an OS thread without a dedicated shutdown signal.
     pub fn thread(name: impl Into<String>, join: thread::JoinHandle<()>) -> Self {
         Handle::Thread {
             name: name.into(),
@@ -91,7 +88,6 @@ impl Handle {
         }
     }
 
-    /// Create a handle for an OS thread with an eventfd-based shutdown signal.
     pub fn thread_with_shutdown(
         name: impl Into<String>,
         join: thread::JoinHandle<()>,
@@ -104,7 +100,6 @@ impl Handle {
         }
     }
 
-    /// Returns the name of this component.
     pub fn name(&self) -> &str {
         match self {
             Handle::Async { name, .. } => name,

--- a/mermin/src/runtime/component/manager.rs
+++ b/mermin/src/runtime/component/manager.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use tokio::{sync::broadcast, time::Instant};
-use tracing::{trace, warn};
+use tracing::warn;
 
 use super::{
     error::{JoinError, ShutdownResult},
@@ -19,7 +19,6 @@ pub struct ComponentManager {
 }
 
 impl ComponentManager {
-    /// Create a new `ComponentManager`.
     pub fn new() -> Self {
         Self::default()
     }
@@ -46,11 +45,6 @@ impl ComponentManager {
     /// Register a component handle. Components are shut down in reverse
     /// registration order.
     pub fn register(&mut self, handle: Handle) {
-        trace!(
-            event.name = "component.registered",
-            component.name = %handle.name(),
-            "registered component"
-        );
         self.handles.push(handle);
     }
 
@@ -62,21 +56,10 @@ impl ComponentManager {
     ///    each component gets whatever time remains in the budget.
     pub async fn shutdown(self, config: ShutdownConfig) -> ShutdownResult {
         let shutdown_start = Instant::now();
-        let component_count = self.handles.len();
 
-        trace!(
-            event.name = "component_manager.shutdown.started",
-            timeout_seconds = config.timeout.as_secs(),
-            component_count = component_count,
-            "starting component shutdown sequence"
-        );
-
-        // Broadcast shutdown signal to all subscribers
         let _ = self.shutdown_tx.send(());
         let mut components_completed: usize = 0;
         let mut failed_names: Vec<String> = Vec::new();
-
-        // Shut down in reverse registration order
         let handles: Vec<Handle> = self.handles.into_iter().rev().collect();
 
         for handle in handles {
@@ -228,7 +211,6 @@ mod tests {
             let join = tokio::spawn(async move {
                 let _ = shutdown_rx.recv().await;
                 count.fetch_add(1, Ordering::SeqCst);
-                let _ = i;
             });
             mgr.register(Handle::async_task(format!("task-{i}"), join));
         }
@@ -294,7 +276,6 @@ mod tests {
         let completed_clone = completed.clone();
 
         let handle = std::thread::spawn(move || {
-            // Simulate some work
             std::thread::sleep(Duration::from_millis(10));
             completed_clone.store(true, Ordering::SeqCst);
         });

--- a/mermin/src/runtime/conf.rs
+++ b/mermin/src/runtime/conf.rs
@@ -69,28 +69,14 @@ fn env_func(args: FuncArgs) -> Result<Value, String> {
     };
 
     match std::env::var(var_name) {
-        Ok(value) => {
-            debug!(event.name = "hcl.func.env.call", variable.name = %var_name);
-            Ok(Value::String(value))
-        }
+        Ok(value) => Ok(Value::String(value)),
         Err(_) => {
-            if args.len() == 2 {
-                warn!(
-                    event.name = "hcl.func.env.fallback",
-                    variable.name = %var_name,
-                    fallback.reason = "environment_variable_not_set",
-                    fallback.value = %default_value,
-                    "environment variable not found, using provided default value"
-                );
-            } else {
-                warn!(
-                    event.name = "hcl.func.env.fallback",
-                    variable.name = %var_name,
-                    fallback.reason = "environment_variable_not_set",
-                    fallback.value = "",
-                    "environment variable not found, using empty string as default"
-                );
-            }
+            warn!(
+                event.name = "hcl.func.env.fallback",
+                variable.name = %var_name,
+                fallback.value = %default_value,
+                "environment variable not set"
+            );
             Ok(Value::String(default_value))
         }
     }
@@ -99,7 +85,6 @@ fn env_func(args: FuncArgs) -> Result<Value, String> {
 impl Format for Hcl {
     type Error = hcl::Error;
 
-    // Constant to name the format in error messages.
     const NAME: &'static str = "HCL";
 
     fn from_str<T: serde::de::DeserializeOwned>(string: &str) -> Result<T, Self::Error> {
@@ -227,7 +212,6 @@ impl Conf {
         };
         conf.config_path = config_path_to_store;
 
-        // Validate discovery.instrument configuration
         conf.discovery
             .instrument
             .validate()
@@ -277,7 +261,6 @@ impl Conf {
         };
         conf.config_path = self.config_path.clone();
 
-        // Validate discovery.instrument configuration
         conf.discovery
             .instrument
             .validate()
@@ -326,7 +309,6 @@ impl Conf {
             "configuration loaded"
         );
 
-        // Filter configuration
         if let Some(ref filters) = self.filter {
             for (filter_name, filter_opts) in filters {
                 debug!(
@@ -403,7 +385,6 @@ impl Conf {
             );
         }
 
-        // Discovery configuration
         debug!(
             event.name = "config.discovery",
             interfaces = ?self.discovery.instrument.interfaces,
@@ -413,7 +394,6 @@ impl Conf {
             "discovery configuration"
         );
 
-        // Parser configuration
         debug!(
             event.name = "config.parser",
             geneve.port = self.parser.geneve_port,
@@ -422,7 +402,6 @@ impl Conf {
             "parser configuration"
         );
 
-        // Attributes configuration
         if let Some(ref attributes) = self.attributes {
             debug!(
                 event.name = "config.attributes",
@@ -585,28 +564,19 @@ pub mod defaults {
 /// - `ConfigError::InvalidConfigPath` - If the path points to a directory.
 /// - `ConfigError::InvalidExtension` - If the file extension is not `yaml`, `yml`, or `hcl`.
 pub fn validate_config_path(path: &Path) -> Result<(), ConfError> {
-    // 1. First, check that the path points to a file. The `is_file()` method
-    // conveniently returns false if the path doesn't exist or if it's not a file.
     if !path.is_file() {
-        // If it's not a file, distinguish between "doesn't exist" and "is a directory".
         if path.exists() {
-            // Path exists but is not a file (it's a directory).
             return Err(ConfError::InvalidConfigPath(
                 path.to_string_lossy().into_owned(),
             ));
         } else {
-            // Path does not exist at all.
             return Err(ConfError::NoConfigFile);
         }
     }
 
-    // 2. If it's a file, check the extension.
     match path.extension().and_then(|s| s.to_str()) {
-        // Allowed extensions
         Some("yaml") | Some("yml") | Some("hcl") => Ok(()),
-        // An unsupported extension was found
         Some(ext) => Err(ConfError::InvalidExtension(ext.to_string())),
-        // No extension was found
         None => Err(ConfError::InvalidExtension("none".to_string())),
     }
 }
@@ -977,10 +947,7 @@ impl PipelineOptions {
         let flow_event_size = size_of::<FlowEvent>() as u64;
         let flow_stats_size = size_of::<FlowStats>() as u64;
 
-        // FlowSpan with baseline info
         let span_undecorated_size = size_of::<FlowSpan>() as u64 + 256;
-
-        // Flow span with k8s metadata
         let span_decorated_size = size_of::<FlowSpan>() as u64 + 2048;
 
         let capture_bytes = {
@@ -1411,7 +1378,6 @@ discovery:
             );
             assert_eq!(cfg.config_path, Some(path.parse().unwrap()));
 
-            // Update the config file
             jail.create_file(
                 path,
                 r#"
@@ -1470,11 +1436,9 @@ internal:
                 "#,
             )?;
 
-            // The rest of the test logic remains the same
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load from yaml file");
 
-            // Assert that all the custom values from the file were loaded correctly
             assert_eq!(
                 cfg.discovery.instrument.interfaces,
                 Vec::from(["eth1".to_string()])
@@ -1588,7 +1552,6 @@ log_level = "debug"
         })
     }
 
-    // MODIFICATION: Corrected the assertion to match the actual error flow.
     #[test]
     fn hcl_parse_error_handling() {
         Jail::expect_with(|jail| {
@@ -1650,7 +1613,6 @@ internal {
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load from HCL file");
 
-            // Assert that all the custom values from the file were loaded correctly
             assert_eq!(
                 cfg.discovery.instrument.interfaces,
                 Vec::from(["eth1".to_string()])
@@ -1951,7 +1913,6 @@ auto_reload: false
             ]);
             let cfg = Conf::new(cli).expect("config should load");
 
-            // CLI args should override file config
             assert_eq!(cfg.log_level, Level::WARN);
             assert_eq!(cfg.auto_reload, true);
 
@@ -1977,10 +1938,8 @@ discovery:
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load");
 
-            // Overridden value
             assert_eq!(cfg.discovery.instrument.interfaces, vec!["custom0"]);
 
-            // Default values should be preserved
             assert_eq!(cfg.log_level, Level::INFO);
             assert_eq!(cfg.auto_reload, false);
             assert_eq!(cfg.shutdown_timeout, Duration::from_secs(28));
@@ -2009,7 +1968,6 @@ discovery:
             assert_eq!(cfg.span.udp_timeout, Duration::from_secs(60));
             assert_eq!(cfg.span.trace_id_timeout, Duration::from_secs(86400));
             assert!(cfg.export.traces.stdout.is_none());
-            // OTLP should not be configured unless explicitly set
             assert!(cfg.export.traces.otlp.is_none());
 
             Ok(())
@@ -2165,8 +2123,6 @@ shutdown_timeout: 2min
 
     #[test]
     fn minimal_config_uses_defaults() {
-        // Test that when loading from a minimal config file,
-        // unspecified fields get their default values
         Jail::expect_with(|jail| {
             let path = "minimal_config.yaml";
             jail.create_file(
@@ -2183,8 +2139,6 @@ discovery:
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load");
 
-            // Verify that defaults are applied for unspecified fields
-            // Note: export.traces.otlp is None by default (not configured unless explicitly set)
             assert!(
                 cfg.export.traces.otlp.is_none(),
                 "export OTLP should not be configured unless explicitly set in config"
@@ -2194,7 +2148,6 @@ discovery:
                 "export stdout should not be enabled unless explicitly set"
             );
 
-            // Other defaults should be applied
             assert_eq!(cfg.log_level, Level::INFO);
             assert_eq!(cfg.pipeline.flow_producer.worker_queue_capacity, 1024);
             assert_eq!(cfg.pipeline.flow_producer.flow_span_queue_capacity, 4096);
@@ -2203,7 +2156,6 @@ discovery:
                 8192
             );
 
-            // Verify all span defaults
             assert_eq!(cfg.span.max_record_interval, Duration::from_secs(60));
             assert_eq!(cfg.span.generic_timeout, Duration::from_secs(30));
             assert_eq!(cfg.span.icmp_timeout, Duration::from_secs(10));
@@ -2219,7 +2171,6 @@ discovery:
 
     #[test]
     fn export_both_stdout_and_otlp_can_be_set() {
-        // Both exporters can be configured simultaneously if desired
         Jail::expect_with(|jail| {
             let path = "export_both.yaml";
             jail.create_file(
@@ -2249,7 +2200,6 @@ export:
 
     #[test]
     fn export_empty_block_has_no_exporters() {
-        // Empty export.traces block means no exporters configured
         Jail::expect_with(|jail| {
             let path = "export_empty.yaml";
             jail.create_file(
@@ -2263,7 +2213,6 @@ export:
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load");
 
-            // Empty export block should result in no exporters configured
             assert!(cfg.export.traces.otlp.is_none());
             assert!(cfg.export.traces.stdout.is_none());
 
@@ -2275,7 +2224,6 @@ export:
     fn default_internal_options_has_expected_values() {
         let internal = InternalOptions::default();
 
-        // Check default trace options
         assert!(
             matches!(
                 internal.traces.span_fmt,
@@ -2455,7 +2403,6 @@ export:
 
     #[test]
     fn export_stdout_empty_format_rejected() {
-        // Empty string for stdout format should be rejected
         Jail::expect_with(|jail| {
             let path = "export_stdout_empty.yaml";
             jail.create_file(
@@ -3067,7 +3014,6 @@ discovery:
 
     #[test]
     fn test_tc_priority_validation_safe_range() {
-        // Test that values in safe range don't error
         for priority in [30, 50, 100, 1000, 32767] {
             let conf = InstrumentOptions {
                 tc_priority: priority,
@@ -3093,7 +3039,6 @@ discovery:
 
     #[test]
     fn test_tc_priority_boundary_values() {
-        // Test edge cases around the boundaries
         let valid_priorities = [1, 2, 29, 30, 31, 49, 50, 51, 32766, 32767];
         for priority in valid_priorities {
             let conf = InstrumentOptions {
@@ -3107,7 +3052,6 @@ discovery:
             );
         }
 
-        // Test invalid values
         let invalid_priorities = [0u16, 32768u16, 65535u16];
         for priority in invalid_priorities {
             let conf = InstrumentOptions {
@@ -3124,7 +3068,6 @@ discovery:
 
     #[test]
     fn test_trace_id_timeout_duration_formats() {
-        // Test various duration formats for trace_id_timeout
         Jail::expect_with(|jail| {
             let path = "trace_timeout.yaml";
             jail.create_file(
@@ -3180,7 +3123,6 @@ span {
 
     #[test]
     fn test_trace_id_timeout_defaults_when_not_specified() {
-        // Verify trace_id_timeout gets default value when not in config
         Jail::expect_with(|jail| {
             let path = "minimal_span.yaml";
             jail.create_file(
@@ -3194,9 +3136,7 @@ span:
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load");
 
-            // Should use default 24h even though not specified
             assert_eq!(cfg.span.trace_id_timeout, Duration::from_secs(86400));
-            // But custom tcp_timeout should be applied
             assert_eq!(cfg.span.tcp_timeout, Duration::from_secs(25));
 
             Ok(())
@@ -3242,7 +3182,6 @@ internal {
             let cli = Cli::parse_from(["mermin", "--config", path.into()]);
             let cfg = Conf::new(cli).expect("config should load with env function");
 
-            // Verify env function results
             assert_eq!(cfg.discovery.instrument.interfaces, vec!["test_value"]);
             assert_eq!(cfg.log_level, Level::INFO);
             assert_eq!(cfg.auto_reload, true);

--- a/mermin/src/runtime/ebpf_log.rs
+++ b/mermin/src/runtime/ebpf_log.rs
@@ -38,11 +38,6 @@ pub async fn run_log_consumer(
     loop {
         tokio::select! {
             _ = shutdown_rx.recv() => {
-                trace!(
-                    event.name = "task.stopped",
-                    task.name = "ebpf_log_consumer",
-                    "ebpf log consumer stopping gracefully"
-                );
                 break;
             }
             result = async_fd.readable() => {
@@ -80,13 +75,11 @@ pub async fn run_log_consumer(
     let _ = log_events_return.send(log_events);
 }
 
-/// Convert a LogEntry to a tracing event at the appropriate log level.
 fn emit_log_entry(entry: &LogEntry) {
     let error_str = LogErrorCode::try_from(entry.error_code)
         .map(|e| e.as_str())
         .unwrap_or("unknown");
 
-    // Direction: 0=Egress, 1=Ingress (matches Direction enum discriminants)
     let direction_str = if entry.direction == 0 {
         "egress"
     } else {

--- a/mermin/src/runtime/memory.rs
+++ b/mermin/src/runtime/memory.rs
@@ -94,12 +94,10 @@ impl ShrinkPolicy {
     /// assert_eq!(policy.should_shrink(100_000, 90_000), false);
     /// ```
     pub const fn should_shrink(&self, capacity: usize, entries: usize) -> bool {
-        // Check minimum capacity threshold
         if capacity <= self.min_capacity {
             return false;
         }
 
-        // Check waste ratio: capacity > entries * (numerator / denominator)
         // Use integer math to avoid float: capacity * denominator > entries * numerator
         capacity * self.waste_ratio_denominator >= entries * self.waste_ratio_numerator
     }

--- a/mermin/src/runtime/opts.rs
+++ b/mermin/src/runtime/opts.rs
@@ -38,14 +38,7 @@ impl Default for ServerConf {
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
 pub struct InternalTraceOptions {
-    /// The level of span events to record. The current default is `FmtSpan::FULL`,
-    /// which records all events (enter, exit, close) for all spans. The level can also be
-    /// one of the following:
-    /// - `SpanFmt::Full`: Records all span events (enter, exit, close).
-    /// - `FmtSpan::ENTER`: Only span enter events are recorded.
-    /// - `FmtSpan::EXIT`: Only span exit events are recorded.
-    /// - `FmtSpan::CLOSE`: Only span close events are recorded.
-    /// - `FmtSpan::ACTIVE`: Only span events for spans that are active (i.e., not closed) are recorded.
+    /// The level of span events to record.
     pub span_fmt: SpanFmt,
 
     /// Stdout exporter configuration options.
@@ -71,10 +64,7 @@ impl From<SpanFmt> for tracing_subscriber::fmt::format::FmtSpan {
 }
 
 impl From<String> for SpanFmt {
-    fn from(s: String) -> Self {
-        match s.to_lowercase().as_str() {
-            "plain" => SpanFmt::Full,
-            _ => SpanFmt::Full,
-        }
+    fn from(_: String) -> Self {
+        SpanFmt::Full
     }
 }

--- a/mermin/src/runtime/pipeline.rs
+++ b/mermin/src/runtime/pipeline.rs
@@ -194,7 +194,6 @@ impl Pipeline {
         // signal because it listens on a crossbeam channel, not the broadcast.
         let _ = self.cmd_tx.send(ControllerCommand::Shutdown);
 
-        // Shut down all components (broadcast + reverse-order join).
         let shutdown_result = self.manager.shutdown(component_config).await;
 
         // Collect eBPF resources. The sends happen inside each component body as

--- a/mermin/src/runtime/reload.rs
+++ b/mermin/src/runtime/reload.rs
@@ -30,16 +30,12 @@ use tracing::{error, info, trace, warn};
 /// those bursts into a single reload.
 const FILE_CHANGE_DEBOUNCE_MS: u64 = 1000;
 
-/// The source that triggered a configuration reload.
 #[derive(Debug, Clone)]
 pub enum ReloadTrigger {
-    /// A SIGHUP signal was received.
     Sighup,
-    /// The config file at the given path was modified.
     FileChanged(PathBuf),
 }
 
-/// Watches for configuration reload triggers (SIGHUP and/or file changes).
 pub struct ConfigWatcher {
     rx: mpsc::Receiver<ReloadTrigger>,
     // Hold the watcher so it isn't dropped (which would stop watching)
@@ -47,19 +43,7 @@ pub struct ConfigWatcher {
 }
 
 impl ConfigWatcher {
-    /// Create a new `ConfigWatcher`.
-    ///
-    /// Must be called from within an active Tokio runtime (e.g. inside an async
-    /// context that runs on the main runtime), since it spawns a task for SIGHUP.
-    ///
-    /// - Always listens for SIGHUP on Unix.
-    /// - If `config_path` is `Some`, also watches the config file for changes
-    ///   via the `notify` crate (watches the parent directory for reliability).
-    ///
-    /// On non-Unix platforms only file watching is available (no SIGHUP).
     pub fn new(config_path: Option<&Path>) -> Result<Self, Box<dyn std::error::Error>> {
-        // Capacity is small, we only need to buffer a few triggers before
-        // the main loop processes them.
         let (tx, rx) = mpsc::channel::<ReloadTrigger>(4);
 
         #[cfg(unix)]
@@ -79,7 +63,6 @@ impl ConfigWatcher {
                 };
                 loop {
                     if sighup.recv().await.is_none() {
-                        // Runtime is shutting down; stop the listener.
                         break;
                     }
                     info!(
@@ -87,7 +70,6 @@ impl ConfigWatcher {
                         "received sighup, triggering config reload"
                     );
                     if sighup_tx.send(ReloadTrigger::Sighup).await.is_err() {
-                        // Receiver dropped, stop listening
                         break;
                     }
                 }
@@ -113,18 +95,10 @@ impl ConfigWatcher {
         })
     }
 
-    /// Wait for the next reload trigger.
     pub async fn next(&mut self) -> Option<ReloadTrigger> {
         self.rx.recv().await
     }
 
-    /// Start a file watcher on the parent directory of the config file.
-    ///
-    /// The `notify` crate works more reliably when watching directories
-    /// rather than individual files (editors often delete + recreate files).
-    ///
-    /// A debounce window of [`FILE_CHANGE_DEBOUNCE_MS`] prevents duplicate
-    /// triggers from editor save sequences (write temp + rename).
     fn start_file_watcher(
         config_path: &Path,
         tx: mpsc::Sender<ReloadTrigger>,
@@ -139,73 +113,65 @@ impl ConfigWatcher {
             .ok_or("config path has no parent directory")?
             .to_path_buf();
 
-        // Shared with the watcher callback for debouncing.
         let last_trigger_ms = Arc::new(AtomicU64::new(0));
 
         let mut watcher: notify::RecommendedWatcher = notify::recommended_watcher(
-            move |res: Result<notify::Event, notify::Error>| {
-                match res {
-                    Ok(event) => {
-                        // Only react to data modifications and file creations
-                        // (editors may delete + recreate instead of modifying in place)
-                        let is_write_event = matches!(
-                            event.kind,
-                            EventKind::Modify(ModifyKind::Data(
-                                DataChange::Any | DataChange::Content
-                            )) | EventKind::Create(_)
-                        );
-                        if !is_write_event {
-                            return;
+            move |res: Result<notify::Event, notify::Error>| match res {
+                Ok(event) => {
+                    let is_write_event = matches!(
+                        event.kind,
+                        EventKind::Modify(ModifyKind::Data(DataChange::Any | DataChange::Content))
+                            | EventKind::Create(_)
+                    );
+                    if !is_write_event {
+                        return;
+                    }
+
+                    let is_our_file = event
+                        .paths
+                        .iter()
+                        .any(|p| p.file_name().map(|f| f == config_filename).unwrap_or(false));
+                    if !is_our_file {
+                        return;
+                    }
+
+                    let now_ms = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64;
+                    let prev_ms = last_trigger_ms.swap(now_ms, Ordering::Relaxed);
+                    if now_ms.saturating_sub(prev_ms) < FILE_CHANGE_DEBOUNCE_MS {
+                        return;
+                    }
+
+                    info!(
+                        event.name = "reload.file_changed",
+                        path = %config_path.display(),
+                        "config file changed, triggering reload"
+                    );
+
+                    match tx.try_send(ReloadTrigger::FileChanged(config_path.clone())) {
+                        Ok(()) => {}
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                            warn!(
+                                event.name = "reload.channel_closed",
+                                "reload channel closed, file watcher stopping"
+                            );
                         }
-
-                        let is_our_file = event
-                            .paths
-                            .iter()
-                            .any(|p| p.file_name().map(|f| f == config_filename).unwrap_or(false));
-                        if !is_our_file {
-                            return;
-                        }
-
-                        // Editors emit multiple rapid events per save (write temp + rename);
-                        // coalesce them so we only reload once per actual user action.
-                        let now_ms = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_millis() as u64;
-                        let prev_ms = last_trigger_ms.swap(now_ms, Ordering::Relaxed);
-                        if now_ms.saturating_sub(prev_ms) < FILE_CHANGE_DEBOUNCE_MS {
-                            return;
-                        }
-
-                        info!(
-                            event.name = "reload.file_changed",
-                            path = %config_path.display(),
-                            "config file changed, triggering reload"
-                        );
-
-                        match tx.try_send(ReloadTrigger::FileChanged(config_path.clone())) {
-                            Ok(()) => {}
-                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                warn!(
-                                    event.name = "reload.channel_closed",
-                                    "reload channel closed, file watcher stopping"
-                                );
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                trace!(
-                                    event.name = "reload.channel_full",
-                                    "reload channel full, dropping file-change trigger; next change will retry"
-                                );
-                            }
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            trace!(
+                                event.name = "reload.channel_full",
+                                "reload channel full, dropping file-change trigger; next change will retry"
+                            );
                         }
                     }
-                    Err(e) => {
-                        warn!(
-                            event.name = "reload.watcher_error",
-                            error.message = %e,
-                            "file watcher error"
-                        );
-                    }
+                }
+                Err(e) => {
+                    warn!(
+                        event.name = "reload.watcher_error",
+                        error.message = %e,
+                        "file watcher error"
+                    );
                 }
             },
         )?;


### PR DESCRIPTION
## Changes

- remove noisy debug/trace/info log calls from capabilities, bpf commands, component manager, and ebpf log consumer
- consolidate env_func warn into a single message regardless of whether a default was provided
- inline matches_pattern wrapper into its call site in bpf command
- condense or remove doc comments in handle, reload, and opts modules
- flatten closure nesting in config file watcher
- simplify SpanFmt::from(String) to always return SpanFmt::Full