### PR TITLE
fix: correctly assign resource annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "mermin"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/mermin/src/span/flow.rs
+++ b/mermin/src/span/flow.rs
@@ -746,7 +746,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "source.k8s.deployment.annotations",
-            self.attributes.source_k8s_service_annotations
+            self.attributes.source_k8s_deployment_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_deployment_name {
             kvs.push(KeyValue::new(
@@ -759,7 +759,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "source.k8s.replicaset.annotations",
-            self.attributes.source_k8s_service_annotations
+            self.attributes.source_k8s_replicaset_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_replicaset_name {
             kvs.push(KeyValue::new(
@@ -772,7 +772,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "source.k8s.statefulset.annotations",
-            self.attributes.source_k8s_service_annotations
+            self.attributes.source_k8s_statefulset_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_statefulset_name {
             kvs.push(KeyValue::new(
@@ -788,7 +788,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "source.k8s.daemonset.annotations",
-            self.attributes.source_k8s_service_annotations
+            self.attributes.source_k8s_daemonset_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_daemonset_name {
             kvs.push(KeyValue::new("source.k8s.daemonset.name", value.to_owned()));
@@ -798,7 +798,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "source.k8s.job.annotations",
-            self.attributes.source_k8s_service_annotations
+            self.attributes.source_k8s_job_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_job_name {
             kvs.push(KeyValue::new("source.k8s.job.name", value.to_owned()));
@@ -808,7 +808,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "source.k8s.cronjob.annotations",
-            self.attributes.source_k8s_service_annotations
+            self.attributes.source_k8s_cronjob_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_cronjob_name {
             kvs.push(KeyValue::new("source.k8s.cronjob.name", value.to_owned()));
@@ -840,7 +840,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.node.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_node_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_node_name {
             kvs.push(KeyValue::new("destination.k8s.node.name", value.to_owned()));
@@ -872,7 +872,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.deployment.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_deployment_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_deployment_name {
             kvs.push(KeyValue::new(
@@ -888,7 +888,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.replicaset.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_replicaset_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_replicaset_name {
             kvs.push(KeyValue::new(
@@ -904,7 +904,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.statefulset.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_statefulset_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_statefulset_name {
             kvs.push(KeyValue::new(
@@ -920,7 +920,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.daemonset.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_daemonset_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_daemonset_name {
             kvs.push(KeyValue::new(
@@ -936,7 +936,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.job.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_job_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_job_name {
             kvs.push(KeyValue::new("destination.k8s.job.name", value.to_owned()));
@@ -946,7 +946,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.cronjob.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_cronjob_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_cronjob_name {
             kvs.push(KeyValue::new(
@@ -962,7 +962,7 @@ impl Traceable for FlowSpan {
         }
         flatten_annotations!(
             "destination.k8s.service.annotations",
-            self.attributes.destination_k8s_pod_annotations
+            self.attributes.destination_k8s_service_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_service_name {
             kvs.push(KeyValue::new(


### PR DESCRIPTION
This PR fixes 14 incorrect usages of the `flatten_annotations!` macro in `mermin/src/span/flow.rs`. Previously, several Kubernetes resource types (Deployment, ReplicaSet, StatefulSet, DaemonSet, Job, CronJob, and Node) were incorrectly using annotations from `source_k8s_service_annotations` or `destination_k8s_pod_annotations`, leading to incorrect metadata labeling in exported spans.

## Changes

- Corrected 6 source-side `flatten_annotations!` calls:
    - `source.k8s.deployment.annotations` now uses `source_k8s_deployment_annotations`.
    - `source.k8s.replicaset.annotations` now uses `source_k8s_replicaset_annotations`.
    - `source.k8s.statefulset.annotations` now uses `source_k8s_statefulset_annotations`.
    - `source.k8s.daemonset.annotations` now uses `source_k8s_daemonset_annotations`.
    - `source.k8s.job.annotations` now uses `source_k8s_job_annotations`.
    - `source.k8s.cronjob.annotations` now uses `source_k8s_cronjob_annotations`.
- Corrected 8 destination-side `flatten_annotations!` calls:
    - `destination.k8s.node.annotations` now uses `destination_k8s_node_annotations`.
    - `destination.k8s.deployment.annotations` now uses `destination_k8s_deployment_annotations`.
    - `destination.k8s.replicaset.annotations` now uses `destination_k8s_replicaset_annotations`.
    - `destination.k8s.statefulset.annotations` now uses `destination_k8s_statefulset_annotations`.
    - `destination.k8s.daemonset.annotations` now uses `destination_k8s_daemonset_annotations`.
    - `destination.k8s.job.annotations` now uses `destination_k8s_job_annotations`.
    - `destination.k8s.cronjob.annotations` now uses `destination_k8s_cronjob_annotations`.
    - `destination.k8s.service.annotations` now uses `destination_k8s_service_annotations`.

## Testing

- Manual Verification: Cross-referenced each corrected macro call with the `SpanAttributes` struct definition in `mermin/src/span/flow.rs` to ensure the correct attribute was being accessed.


## Proof it works

<img width="755" height="370" alt="Screenshot 2026-03-16 at 3 46 45 PM" src="https://github.com/user-attachments/assets/d1235797-a52f-4cb4-b5e4-adabaf065dd0" />
<img width="955" height="738" alt="Screenshot 2026-03-16 at 3 47 45 PM" src="https://github.com/user-attachments/assets/580b3f75-5070-4bdb-af00-5a5c00fb4651" />

