### PR TITLE
fix: eliminate string heap allocations in flow creation and recording

### DIFF
--- a/mermin/src/span/flow.rs
+++ b/mermin/src/span/flow.rs
@@ -123,7 +123,7 @@ impl FlowSpan {
 #[derive(Debug, Clone, Serialize)]
 pub struct SpanAttributes {
     // General Flow Attribute
-    pub flow_community_id: String,
+    pub flow_community_id: Arc<str>,
     #[serde(serialize_with = "serialize_flow_direction")]
     pub flow_direction: FlowDirection,
     #[serde(serialize_with = "serialize_connection_state")]
@@ -145,25 +145,25 @@ pub struct SpanAttributes {
     #[serde(serialize_with = "serialize_option_mac_addr")]
     pub network_interface_mac: Option<pnet::datalink::MacAddr>,
     pub flow_ip_dscp_id: Option<u8>,
-    pub flow_ip_dscp_name: Option<String>,
+    pub flow_ip_dscp_name: Option<&'static str>,
     pub flow_ip_ecn_id: Option<u8>,
-    pub flow_ip_ecn_name: Option<String>,
+    pub flow_ip_ecn_name: Option<&'static str>,
     pub flow_ip_ttl: Option<u8>,
     pub flow_ip_flow_label: Option<u32>,
     pub flow_reverse_ip_dscp_id: Option<u8>,
-    pub flow_reverse_ip_dscp_name: Option<String>,
+    pub flow_reverse_ip_dscp_name: Option<&'static str>,
     pub flow_reverse_ip_ecn_id: Option<u8>,
-    pub flow_reverse_ip_ecn_name: Option<String>,
+    pub flow_reverse_ip_ecn_name: Option<&'static str>,
     pub flow_reverse_ip_ttl: Option<u8>,
     pub flow_reverse_ip_flow_label: Option<u32>,
     pub flow_icmp_type_id: Option<u8>,
-    pub flow_icmp_type_name: Option<String>,
+    pub flow_icmp_type_name: Option<&'static str>,
     pub flow_icmp_code_id: Option<u8>,
-    pub flow_icmp_code_name: Option<String>,
+    pub flow_icmp_code_name: Option<&'static str>,
     pub flow_reverse_icmp_type_id: Option<u8>,
-    pub flow_reverse_icmp_type_name: Option<String>,
+    pub flow_reverse_icmp_type_name: Option<&'static str>,
     pub flow_reverse_icmp_code_id: Option<u8>,
-    pub flow_reverse_icmp_code_name: Option<String>,
+    pub flow_reverse_icmp_code_name: Option<&'static str>,
     pub flow_tcp_flags_bits: Option<u8>,
     #[serde(serialize_with = "serialize_option_tcp_flags")]
     pub flow_tcp_flags_tags: Option<Vec<TcpFlag>>,
@@ -300,7 +300,7 @@ pub struct SpanAttributes {
 impl Default for SpanAttributes {
     fn default() -> Self {
         Self {
-            flow_community_id: String::new(),
+            flow_community_id: Arc::from(""),
             flow_direction: FlowDirection::Unknown,
             flow_connection_state: None,
             flow_end_reason: None,
@@ -459,7 +459,7 @@ impl Traceable for FlowSpan {
         Some(format!(
             "flow_{}_{}",
             self.attributes.network_type.as_str(),
-            self.attributes.network_transport.to_string().as_str()
+            self.attributes.network_transport.as_str()
         ))
     }
 
@@ -483,7 +483,7 @@ impl Traceable for FlowSpan {
 
         kvs.push(KeyValue::new(
             "flow.community_id",
-            self.attributes.flow_community_id.to_string(),
+            self.attributes.flow_community_id.clone(),
         ));
         kvs.push(KeyValue::new(
             "flow.direction",
@@ -563,14 +563,14 @@ impl Traceable for FlowSpan {
         if let Some(value) = self.attributes.flow_ip_dscp_id {
             kvs.push(KeyValue::new("flow.ip.dscp.id", value as i64));
         }
-        if let Some(ref value) = self.attributes.flow_ip_dscp_name {
-            kvs.push(KeyValue::new("flow.ip.dscp.name", value.to_owned()));
+        if let Some(value) = self.attributes.flow_ip_dscp_name {
+            kvs.push(KeyValue::new("flow.ip.dscp.name", value));
         }
         if let Some(value) = self.attributes.flow_ip_ecn_id {
             kvs.push(KeyValue::new("flow.ip.ecn.id", value as i64));
         }
-        if let Some(ref value) = self.attributes.flow_ip_ecn_name {
-            kvs.push(KeyValue::new("flow.ip.ecn.name", value.to_owned()));
+        if let Some(value) = self.attributes.flow_ip_ecn_name {
+            kvs.push(KeyValue::new("flow.ip.ecn.name", value));
         }
         if let Some(value) = self.attributes.flow_ip_ttl {
             kvs.push(KeyValue::new("flow.ip.ttl", value as i64));
@@ -593,32 +593,26 @@ impl Traceable for FlowSpan {
         if let Some(value) = self.attributes.flow_icmp_type_id {
             kvs.push(KeyValue::new("flow.icmp.type.id", value as i64));
         }
-        if let Some(ref value) = self.attributes.flow_icmp_type_name {
-            kvs.push(KeyValue::new("flow.icmp.type.name", value.to_owned()));
+        if let Some(value) = self.attributes.flow_icmp_type_name {
+            kvs.push(KeyValue::new("flow.icmp.type.name", value));
         }
         if let Some(value) = self.attributes.flow_icmp_code_id {
             kvs.push(KeyValue::new("flow.icmp.code.id", value as i64));
         }
-        if let Some(ref value) = self.attributes.flow_icmp_code_name {
-            kvs.push(KeyValue::new("flow.icmp.code.name", value.to_owned()));
+        if let Some(value) = self.attributes.flow_icmp_code_name {
+            kvs.push(KeyValue::new("flow.icmp.code.name", value));
         }
         if let Some(value) = self.attributes.flow_reverse_icmp_type_id {
             kvs.push(KeyValue::new("flow.reverse.icmp.type.id", value as i64));
         }
-        if let Some(ref value) = self.attributes.flow_reverse_icmp_type_name {
-            kvs.push(KeyValue::new(
-                "flow.reverse.icmp.type.name",
-                value.to_owned(),
-            ));
+        if let Some(value) = self.attributes.flow_reverse_icmp_type_name {
+            kvs.push(KeyValue::new("flow.reverse.icmp.type.name", value));
         }
         if let Some(value) = self.attributes.flow_reverse_icmp_code_id {
             kvs.push(KeyValue::new("flow.reverse.icmp.code.id", value as i64));
         }
-        if let Some(ref value) = self.attributes.flow_reverse_icmp_code_name {
-            kvs.push(KeyValue::new(
-                "flow.reverse.icmp.code.name",
-                value.to_owned(),
-            ));
+        if let Some(value) = self.attributes.flow_reverse_icmp_code_name {
+            kvs.push(KeyValue::new("flow.reverse.icmp.code.name", value));
         }
         if let Some(value) = self.attributes.flow_tcp_flags_bits {
             kvs.push(KeyValue::new("flow.tcp.flags.bits", value as i64));
@@ -1340,7 +1334,7 @@ mod tests {
     fn test_span_attributes_default() {
         let attrs = SpanAttributes::default();
 
-        assert_eq!(attrs.flow_community_id, String::new());
+        assert_eq!(&*attrs.flow_community_id, "");
         assert_eq!(attrs.flow_connection_state, None);
         assert_eq!(attrs.flow_end_reason, None);
         assert_eq!(attrs.source_port, 0);

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -766,7 +766,7 @@ impl FlowWorker {
             )
             .into();
 
-        self.create_flow_span(&community_id, &event.flow_key, &stats)
+        self.create_flow_span(community_id, &event.flow_key, &stats)
             .await?;
 
         guard.keep();
@@ -861,7 +861,7 @@ impl FlowWorker {
     /// Create a FlowSpan from eBPF FlowStats
     async fn create_flow_span(
         &self,
-        community_id: &str,
+        community_id: Arc<str>,
         flow_key: &FlowKey,
         stats: &FlowStats,
     ) -> Result<(), Error> {
@@ -890,7 +890,7 @@ impl FlowWorker {
             end_time: UNIX_EPOCH + Duration::from_nanos(end_time_nanos),
             span_kind,
             attributes: Arc::new(SpanAttributes {
-                flow_community_id: community_id.to_string(),
+                flow_community_id: community_id.clone(),
                 flow_direction,
                 flow_connection_state: is_tcp.then_some(stats.tcp_state),
                 flow_end_reason: None,
@@ -910,15 +910,13 @@ impl FlowWorker {
                 flow_ip_dscp_name: is_ip_flow.then_some(
                     IpDscp::try_from_u8(stats.ip_dscp)
                         .unwrap_or_default()
-                        .as_str()
-                        .to_string(),
+                        .as_str(),
                 ),
                 flow_ip_ecn_id: is_ip_flow.then_some(stats.ip_ecn),
                 flow_ip_ecn_name: is_ip_flow.then_some(
                     IpEcn::try_from_u8(stats.ip_ecn)
                         .unwrap_or_default()
-                        .as_str()
-                        .to_string(),
+                        .as_str(),
                 ),
                 flow_ip_ttl: is_ip_flow.then_some(stats.ip_ttl),
                 flow_ip_flow_label: is_ipv6.then_some(stats.ip_flow_label),
@@ -927,15 +925,13 @@ impl FlowWorker {
                 flow_reverse_ip_dscp_name: is_ip_flow.then_some(
                     IpDscp::try_from_u8(stats.reverse_ip_dscp)
                         .unwrap_or_default()
-                        .as_str()
-                        .to_string(),
+                        .as_str(),
                 ),
                 flow_reverse_ip_ecn_id: is_ip_flow.then_some(stats.reverse_ip_ecn),
                 flow_reverse_ip_ecn_name: is_ip_flow.then_some(
                     IpEcn::try_from_u8(stats.reverse_ip_ecn)
                         .unwrap_or_default()
-                        .as_str()
-                        .to_string(),
+                        .as_str(),
                 ),
                 flow_reverse_ip_ttl: is_ip_flow.then_some(stats.reverse_ip_ttl),
                 flow_reverse_ip_flow_label: is_ipv6.then_some(stats.reverse_ip_flow_label),
@@ -1027,7 +1023,7 @@ impl FlowWorker {
             timeout_duration: Duration::from_secs(0),
         };
 
-        self.insert_flow(Arc::from(community_id), span, timeout);
+        self.insert_flow(community_id, span, timeout);
 
         let interface_name = iface_name.as_deref().unwrap_or("unknown");
         metrics::registry::PROCESSING_TOTAL
@@ -1453,11 +1449,11 @@ impl std::error::Error for BootTimeError {
 /// Resolve an ICMP type value to its human-readable name for the given IP version.
 ///
 /// Returns `None` for non-ICMP protocols or unknown type values.
-fn icmp_type_name(is_icmp: bool, is_icmpv6: bool, icmp_type: u8) -> Option<String> {
+fn icmp_type_name(is_icmp: bool, is_icmpv6: bool, icmp_type: u8) -> Option<&'static str> {
     if is_icmp {
-        mermin_common::icmp::get_icmpv4_type_name(icmp_type).map(String::from)
+        mermin_common::icmp::get_icmpv4_type_name(icmp_type)
     } else if is_icmpv6 {
-        mermin_common::icmp::get_icmpv6_type_name(icmp_type).map(String::from)
+        mermin_common::icmp::get_icmpv6_type_name(icmp_type)
     } else {
         None
     }
@@ -1466,11 +1462,16 @@ fn icmp_type_name(is_icmp: bool, is_icmpv6: bool, icmp_type: u8) -> Option<Strin
 /// Resolve an ICMP type+code pair to the human-readable code name for the given IP version.
 ///
 /// Returns `None` for non-ICMP protocols or unknown type/code combinations.
-fn icmp_code_name(is_icmp: bool, is_icmpv6: bool, icmp_type: u8, icmp_code: u8) -> Option<String> {
+fn icmp_code_name(
+    is_icmp: bool,
+    is_icmpv6: bool,
+    icmp_type: u8,
+    icmp_code: u8,
+) -> Option<&'static str> {
     if is_icmp {
-        mermin_common::icmp::get_icmpv4_code_name(icmp_type, icmp_code).map(String::from)
+        mermin_common::icmp::get_icmpv4_code_name(icmp_type, icmp_code)
     } else if is_icmpv6 {
-        mermin_common::icmp::get_icmpv6_code_name(icmp_type, icmp_code).map(String::from)
+        mermin_common::icmp::get_icmpv6_code_name(icmp_type, icmp_code)
     } else {
         None
     }
@@ -1757,15 +1758,13 @@ async fn record_flow(
         attrs.flow_ip_dscp_name = Some(
             IpDscp::try_from_u8(stats.ip_dscp)
                 .unwrap_or_default()
-                .as_str()
-                .to_string(),
+                .as_str(),
         );
         attrs.flow_ip_ecn_id = Some(stats.ip_ecn);
         attrs.flow_ip_ecn_name = Some(
             IpEcn::try_from_u8(stats.ip_ecn)
                 .unwrap_or_default()
-                .as_str()
-                .to_string(),
+                .as_str(),
         );
         attrs.flow_ip_ttl = Some(stats.ip_ttl);
 
@@ -1773,15 +1772,13 @@ async fn record_flow(
         attrs.flow_reverse_ip_dscp_name = Some(
             IpDscp::try_from_u8(stats.reverse_ip_dscp)
                 .unwrap_or_default()
-                .as_str()
-                .to_string(),
+                .as_str(),
         );
         attrs.flow_reverse_ip_ecn_id = Some(stats.reverse_ip_ecn);
         attrs.flow_reverse_ip_ecn_name = Some(
             IpEcn::try_from_u8(stats.reverse_ip_ecn)
                 .unwrap_or_default()
-                .as_str()
-                .to_string(),
+                .as_str(),
         );
         attrs.flow_reverse_ip_ttl = Some(stats.reverse_ip_ttl);
     }


### PR DESCRIPTION
`mermin-common` ICMP, DSCP, and ECN lookups already return `&'static str`, but
the span layer was converting them to owned `String`s on every flow creation and
again on every recording interval. This change removes those unnecessary
allocations throughout the hot path.

## Changes
- Change `flow_community_id` from `String` to `Arc<str>`; per-recording clone is
  now a refcount bump instead of a heap allocation
- Change 8 `SpanAttributes` name fields (icmp type/code, dscp, ecn — forward and
  reverse) from `Option<String>` to `Option<&'static str>`
- Remove `.map(String::from)` from `icmp_type_name` and `icmp_code_name`;
  return `Option<&'static str>` directly from the common library
- Drop `.to_string()` from DSCP/ECN `.as_str()` call chains in both
  `create_flow` and `record_flow` (highest-frequency allocation site)
- Remove `.to_owned()` from `record()` call sites for the 8 static str fields;
  pass `&'static str` directly to `KeyValue::new`
- Remove spurious `network_transport.to_string().as_str()` in `name()`;
  use `.as_str()` directly since `IpProto::as_str()` returns `&'static str`

## Proof it works

Locally, CPU usage is reduced by 1-2%.