### PR TITLE
fix: reduce per-export heap allocations in otlp span recording

### DIFF
--- a/docs/deployment/examples/local-otel/config.hcl
+++ b/docs/deployment/examples/local-otel/config.hcl
@@ -1,5 +1,3 @@
-# OTLP exporter configuration
-# See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
   otlp = {
     endpoint = "https://otel-collector:4317"

--- a/docs/deployment/examples/local/config.example.hcl
+++ b/docs/deployment/examples/local/config.example.hcl
@@ -1,12 +1,10 @@
-# OTLP exporter configuration
-# See OBI export concepts: https://opentelemetry.io/docs/zero-code/obi/configure/export-data/
 export "traces" {
   stdout = {
-    format = "text_indent" // text, text_indent(*new), json, json_indent
+    format = "text_indent" # text, text_indent(*new), json, json_indent
   }
 
   # otlp = {
-  #   endpoint               = "http://otelcol:4317" # Use `https` for TLS encrypted OTLP receivers
+  #   endpoint = "http://otel-collector:4317" # Uncomment to export to an OTel Demo Collector
 
   #   # Authentication config
   #   # auth = {

--- a/docs/deployment/examples/local/values.yaml
+++ b/docs/deployment/examples/local/values.yaml
@@ -1,3 +1,4 @@
 image:
   repository: mermin
   tag: latest
+  # pullPolicy: Never # Uncomment to build the image locally

--- a/mermin/src/k8s/decorator.rs
+++ b/mermin/src/k8s/decorator.rs
@@ -6,7 +6,7 @@
 //! - Support for Pods, Nodes, key workload types (Deployments, StatefulSets, etc.).
 //! - Network-related resources like Services, Ingresses and NetworkPolicies.
 
-use std::{collections::HashMap, net::IpAddr};
+use std::{collections::HashMap, net::IpAddr, sync::Arc};
 
 use k8s_openapi::api::core::v1::Pod;
 use tracing::debug;
@@ -179,12 +179,17 @@ impl<'a> Decorator<'a> {
         }
 
         if extract_namespace && self.should_extract(kind, "namespace", is_source) {
-            self.set_k8s_attr_opt(flow_span, "namespace.name", &meta.namespace, is_source);
+            self.set_k8s_attr_opt(
+                flow_span,
+                "namespace.name",
+                meta.namespace.as_deref(),
+                is_source,
+            );
         }
 
         if self.should_extract(kind, "uid", is_source) {
             let attr_key = format!("{kind}.uid");
-            self.set_k8s_attr_opt(flow_span, &attr_key, &meta.uid, is_source);
+            self.set_k8s_attr_opt(flow_span, &attr_key, meta.uid.as_deref(), is_source);
         }
 
         if self.should_extract(kind, "annotations", is_source) {
@@ -213,7 +218,7 @@ impl<'a> Decorator<'a> {
                 self.populate_common_meta(flow_span, "pod", pod_meta, is_source, true);
 
                 if self.should_extract("pod", "node_name", is_source) {
-                    self.set_k8s_attr_opt(flow_span, "node.name", node_name, is_source);
+                    self.set_k8s_attr_opt(flow_span, "node.name", node_name.as_deref(), is_source);
                 }
 
                 if let Some((container_name, container_image)) =
@@ -249,7 +254,12 @@ impl<'a> Decorator<'a> {
             }
             DecorationInfo::EndpointSlice { slice } => {
                 if self.should_extract("endpointslice", "namespace", is_source) {
-                    self.set_k8s_attr_opt(flow_span, "namespace.name", &slice.namespace, is_source);
+                    self.set_k8s_attr_opt(
+                        flow_span,
+                        "namespace.name",
+                        slice.namespace.as_deref(),
+                        is_source,
+                    );
                 }
 
                 if self.should_extract("endpointslice", "annotations", is_source) {
@@ -334,14 +344,14 @@ impl<'a> Decorator<'a> {
         value: &str,
         is_source: bool,
     ) {
-        self.set_k8s_attr_opt(flow_span, attr_name, &Some(value.to_string()), is_source);
+        self.set_k8s_attr_opt(flow_span, attr_name, Some(value), is_source);
     }
 
     fn set_k8s_attr_opt(
         &self,
         flow_span: &mut FlowSpan,
         attr_name: &str,
-        value: &Option<String>,
+        value: Option<&str>,
         is_source: bool,
     ) {
         let attrs = flow_span.attrs_mut();
@@ -374,7 +384,7 @@ impl<'a> Decorator<'a> {
             ("service.name", source_k8s_service_name, destination_k8s_service_name),
         };
 
-        *field = value.clone();
+        *field = value.map(Arc::from);
     }
 
     fn set_k8s_map_attr(
@@ -384,54 +394,49 @@ impl<'a> Decorator<'a> {
         value: &Option<HashMap<String, String>>,
         is_source: bool,
     ) {
+        let converted = value.as_ref().map(|m| {
+            m.iter()
+                .map(|(k, v)| (k.clone(), Arc::from(v.as_str())))
+                .collect::<HashMap<String, Arc<str>>>()
+        });
         let attrs = flow_span.attrs_mut();
         match (is_source, attr_name) {
-            (true, "pod.annotations") => attrs.source_k8s_pod_annotations = value.clone(),
-            (false, "pod.annotations") => attrs.destination_k8s_pod_annotations = value.clone(),
+            (true, "pod.annotations") => attrs.source_k8s_pod_annotations = converted,
+            (false, "pod.annotations") => attrs.destination_k8s_pod_annotations = converted,
 
-            (true, "node.annotations") => attrs.source_k8s_node_annotations = value.clone(),
-            (false, "node.annotations") => attrs.destination_k8s_node_annotations = value.clone(),
+            (true, "node.annotations") => attrs.source_k8s_node_annotations = converted,
+            (false, "node.annotations") => attrs.destination_k8s_node_annotations = converted,
 
-            (true, "service.annotations") => attrs.source_k8s_service_annotations = value.clone(),
-            (false, "service.annotations") => {
-                attrs.destination_k8s_service_annotations = value.clone()
-            }
+            (true, "service.annotations") => attrs.source_k8s_service_annotations = converted,
+            (false, "service.annotations") => attrs.destination_k8s_service_annotations = converted,
 
-            (true, "deployment.annotations") => {
-                attrs.source_k8s_deployment_annotations = value.clone()
-            }
+            (true, "deployment.annotations") => attrs.source_k8s_deployment_annotations = converted,
             (false, "deployment.annotations") => {
-                attrs.destination_k8s_deployment_annotations = value.clone()
+                attrs.destination_k8s_deployment_annotations = converted
             }
 
-            (true, "daemonset.annotations") => {
-                attrs.source_k8s_daemonset_annotations = value.clone()
-            }
+            (true, "daemonset.annotations") => attrs.source_k8s_daemonset_annotations = converted,
             (false, "daemonset.annotations") => {
-                attrs.destination_k8s_daemonset_annotations = value.clone()
+                attrs.destination_k8s_daemonset_annotations = converted
             }
 
-            (true, "replicaset.annotations") => {
-                attrs.source_k8s_replicaset_annotations = value.clone()
-            }
+            (true, "replicaset.annotations") => attrs.source_k8s_replicaset_annotations = converted,
             (false, "replicaset.annotations") => {
-                attrs.destination_k8s_replicaset_annotations = value.clone()
+                attrs.destination_k8s_replicaset_annotations = converted
             }
 
             (true, "statefulset.annotations") => {
-                attrs.source_k8s_statefulset_annotations = value.clone()
+                attrs.source_k8s_statefulset_annotations = converted
             }
             (false, "statefulset.annotations") => {
-                attrs.destination_k8s_statefulset_annotations = value.clone()
+                attrs.destination_k8s_statefulset_annotations = converted
             }
 
-            (true, "job.annotations") => attrs.source_k8s_job_annotations = value.clone(),
-            (false, "job.annotations") => attrs.destination_k8s_job_annotations = value.clone(),
+            (true, "job.annotations") => attrs.source_k8s_job_annotations = converted,
+            (false, "job.annotations") => attrs.destination_k8s_job_annotations = converted,
 
-            (true, "cronjob.annotations") => attrs.source_k8s_cronjob_annotations = value.clone(),
-            (false, "cronjob.annotations") => {
-                attrs.destination_k8s_cronjob_annotations = value.clone()
-            }
+            (true, "cronjob.annotations") => attrs.source_k8s_cronjob_annotations = converted,
+            (false, "cronjob.annotations") => attrs.destination_k8s_cronjob_annotations = converted,
             _ => {}
         }
     }

--- a/mermin/src/otlp/trace.rs
+++ b/mermin/src/otlp/trace.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, sync::Arc, time::SystemTime};
+use std::{any::Any, borrow::Cow, sync::Arc, time::SystemTime};
 
 use async_trait::async_trait;
 use opentelemetry::{
@@ -36,47 +36,22 @@ pub type TraceableRecord = Arc<dyn Traceable + Send + Sync + 'static>;
 /// Defines a common interface for data structures that can be represented as an
 /// OpenTelemetry trace span.
 pub trait Traceable {
-    /// Returns the logical start time of the event represented by this record.
-    ///
-    /// This timestamp will be used as the `start_time_unix_nano` for the
-    /// resulting OpenTelemetry `Span`.
+    /// The logical start time of the event represented by this record.
     fn start_time(&self) -> SystemTime;
 
-    /// Returns the logical end time of the event represented by this record.
-    ///
-    /// This timestamp will be used as the `end_time_unix_nano` for the
-    /// resulting OpenTelemetry `Span`.
+    /// The logical end time of the event represented by this record.
     fn end_time(&self) -> SystemTime;
 
-    /// Returns a specific name for the span, if applicable.
-    ///
-    /// If `Some(String)` is returned, it will be used as the `Span` name. If `None` is
-    /// returned, the exporter is expected to use a default or generic name.
-    fn name(&self) -> Option<String>;
+    /// A specific name for the span, if applicable.
+    fn name(&self) -> Option<Cow<'static, str>>;
 
-    /// Returns a custom trace ID for this span, if available.
-    ///
-    /// If `Some(TraceId)` is returned, it will be used as the trace ID for this span,
-    /// enabling correlation of multiple spans under the same trace. If `None` is returned,
-    /// OpenTelemetry will generate a new random trace ID.
+    /// A custom trace ID for this span, if available.
     fn trace_id(&self) -> Option<TraceId>;
 
-    /// Returns the OpenTelemetry span kind for this record.
-    ///
-    /// The span kind indicates the role of the span in the trace (e.g., Client, Server, Internal).
-    /// For network flows, this is determined by direction inference based on listening ports,
-    /// TCP handshake patterns, and port number heuristics.
+    /// The OpenTelemetry span kind for this record.
     fn span_kind(&self) -> SpanKind;
 
     /// Populates a pre-configured `Span` with the record's specific attributes.
-    ///
-    /// This is the core method where the implementing type is responsible for mapping
-    /// its internal fields to the key-value attributes of an OpenTelemetry `Span`.
-    ///
-    /// ### Important
-    /// For performance reasons within the export pipeline, this method is designed to
-    /// be called **only once** per record. The implementation should be efficient and
-    /// perform all necessary attribute-setting within this single call.
     fn record(&self, span: opentelemetry_sdk::trace::Span) -> opentelemetry_sdk::trace::Span;
 }
 
@@ -91,7 +66,7 @@ pub trait TraceableExporter: Send + Sync {
 impl TraceableExporter for TraceExporterAdapter {
     async fn export(&self, traceable: TraceableRecord) {
         let tracer = &self.tracer;
-        let name = traceable.name().unwrap_or_else(|| "flow".to_string());
+        let name = traceable.name().unwrap_or(Cow::Borrowed("flow"));
 
         let mut builder = tracer
             .span_builder(name)

--- a/mermin/src/span/community_id.rs
+++ b/mermin/src/span/community_id.rs
@@ -4,6 +4,23 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use mermin_common::ip::IpProto;
 use sha1::{Digest, Sha1};
 
+/// Stack-allocated byte representation of an IP address, preserving the
+/// original byte count (4 for IPv4, 16 for IPv6) to maintain Community ID
+/// hash compatibility with the community-id spec.
+enum IpBytes {
+    V4([u8; 4]),
+    V6([u8; 16]),
+}
+
+impl IpBytes {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            IpBytes::V4(b) => b,
+            IpBytes::V6(b) => b,
+        }
+    }
+}
+
 /// Community ID generator with configurable seed
 #[derive(Debug, Default, Clone)]
 pub struct CommunityIdGenerator {
@@ -58,8 +75,8 @@ impl CommunityIdGenerator {
         );
         let mut hasher = Sha1::new();
         hasher.update(seed_bytes);
-        hasher.update(&first_addr);
-        hasher.update(&second_addr);
+        hasher.update(first_addr.as_slice());
+        hasher.update(second_addr.as_slice());
         hasher.update([proto, 0]);
         hasher.update(first_port);
         hasher.update(second_port);
@@ -67,21 +84,21 @@ impl CommunityIdGenerator {
         format!("1:{}", BASE64.encode(hasher.finalize()))
     }
 
-    fn ip_addr_to_bytes(&self, addr: IpAddr) -> Vec<u8> {
+    fn ip_addr_to_bytes(&self, addr: IpAddr) -> IpBytes {
         match addr {
-            IpAddr::V4(ipv4) => ipv4.octets().to_vec(),
-            IpAddr::V6(ipv6) => ipv6.octets().to_vec(),
+            IpAddr::V4(ipv4) => IpBytes::V4(ipv4.octets()),
+            IpAddr::V6(ipv6) => IpBytes::V6(ipv6.octets()),
         }
     }
 
     fn order_endpoints(
         &self,
-        src_addr: Vec<u8>,
-        dst_addr: Vec<u8>,
+        src_addr: IpBytes,
+        dst_addr: IpBytes,
         src_port: [u8; 2],
         dst_port: [u8; 2],
-    ) -> (Vec<u8>, Vec<u8>, [u8; 2], [u8; 2]) {
-        match src_addr.cmp(&dst_addr) {
+    ) -> (IpBytes, IpBytes, [u8; 2], [u8; 2]) {
+        match src_addr.as_slice().cmp(dst_addr.as_slice()) {
             std::cmp::Ordering::Less => (src_addr, dst_addr, src_port, dst_port),
             std::cmp::Ordering::Greater => (dst_addr, src_addr, dst_port, src_port),
             std::cmp::Ordering::Equal => match src_port.cmp(&dst_port) {

--- a/mermin/src/span/flow.rs
+++ b/mermin/src/span/flow.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::HashMap,
     net::IpAddr,
     sync::Arc,
@@ -133,17 +134,23 @@ pub struct SpanAttributes {
 
     // L2-L4 Attributes
     pub source_address: IpAddr,
+    /// Pre-formatted string representation of `source_address`, cached at construction
+    /// time so that per-export calls to `record()` can clone the `Arc` cheaply instead
+    /// of re-formatting the IP on every export.  Must remain in sync with `source_address`.
+    pub source_address_str: Arc<str>,
     pub source_port: u16,
     pub destination_address: IpAddr,
+    /// Pre-formatted string representation of `destination_address`. Same caching
+    /// rationale as `source_address_str`.
+    pub destination_address_str: Arc<str>,
     pub destination_port: u16,
     #[serde(serialize_with = "serialize_ip_proto")]
     pub network_transport: IpProto,
     #[serde(serialize_with = "serialize_ether_type")]
     pub network_type: EtherType,
     pub network_interface_index: Option<u32>,
-    pub network_interface_name: Option<String>,
-    #[serde(serialize_with = "serialize_option_mac_addr")]
-    pub network_interface_mac: Option<pnet::datalink::MacAddr>,
+    pub network_interface_name: Option<Arc<str>>,
+    pub network_interface_mac: Option<Arc<str>>,
     pub flow_ip_dscp_id: Option<u8>,
     pub flow_ip_dscp_name: Option<&'static str>,
     pub flow_ip_ecn_id: Option<u8>,
@@ -179,7 +186,7 @@ pub struct SpanAttributes {
     /// PID of the process that created/owns this flow (None if unknown)
     pub process_pid: Option<u32>,
     /// Executable name of the process (TASK_COMM_LEN, None if unknown)
-    pub process_executable_name: Option<String>,
+    pub process_executable_name: Option<Arc<str>>,
 
     // Flow Metrics
     pub flow_bytes_delta: i64,
@@ -203,98 +210,97 @@ pub struct SpanAttributes {
     pub ipip_network_type: Option<EtherType>,
     #[serde(serialize_with = "serialize_option_ip_proto")]
     pub ipip_network_transport: Option<IpProto>,
-    pub ipip_source_address: Option<IpAddr>,
-    pub ipip_destination_address: Option<IpAddr>,
+    pub ipip_source_address: Option<Arc<str>>,
+    pub ipip_destination_address: Option<Arc<str>>,
 
     // Tunnel Attributes
     #[serde(serialize_with = "serialize_option_tunnel_type")]
     pub tunnel_type: Option<TunnelType>,
-    #[serde(serialize_with = "serialize_option_mac_addr")]
-    pub tunnel_network_interface_mac: Option<pnet::datalink::MacAddr>,
+    pub tunnel_network_interface_mac: Option<Arc<str>>,
     #[serde(serialize_with = "serialize_option_ether_type")]
     pub tunnel_network_type: Option<EtherType>,
     #[serde(serialize_with = "serialize_option_ip_proto")]
     pub tunnel_network_transport: Option<IpProto>,
-    pub tunnel_source_address: Option<IpAddr>,
+    pub tunnel_source_address: Option<Arc<str>>,
     pub tunnel_source_port: Option<u16>,
-    pub tunnel_destination_address: Option<IpAddr>,
+    pub tunnel_destination_address: Option<Arc<str>>,
     pub tunnel_destination_port: Option<u16>,
     pub tunnel_id: Option<u32>,
     pub tunnel_ipsec_ah_spi: Option<u32>,
 
     // Kubernetes & Application Attributes
-    pub source_k8s_cluster_name: Option<String>,
-    pub source_k8s_cluster_uid: Option<String>,
-    pub source_k8s_node_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_node_name: Option<String>,
-    pub source_k8s_node_uid: Option<String>,
-    pub source_k8s_namespace_name: Option<String>,
-    pub source_k8s_pod_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_pod_name: Option<String>,
-    pub source_k8s_pod_uid: Option<String>,
-    pub source_k8s_container_name: Option<String>,
-    pub source_k8s_deployment_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_deployment_name: Option<String>,
-    pub source_k8s_deployment_uid: Option<String>,
-    pub source_k8s_replicaset_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_replicaset_name: Option<String>,
-    pub source_k8s_replicaset_uid: Option<String>,
-    pub source_k8s_statefulset_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_statefulset_name: Option<String>,
-    pub source_k8s_statefulset_uid: Option<String>,
-    pub source_k8s_daemonset_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_daemonset_name: Option<String>,
-    pub source_k8s_daemonset_uid: Option<String>,
-    pub source_k8s_job_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_job_name: Option<String>,
-    pub source_k8s_job_uid: Option<String>,
-    pub source_k8s_cronjob_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_cronjob_name: Option<String>,
-    pub source_k8s_cronjob_uid: Option<String>,
-    pub source_k8s_service_annotations: Option<HashMap<String, String>>,
-    pub source_k8s_service_name: Option<String>,
-    pub source_k8s_service_uid: Option<String>,
-    pub destination_k8s_cluster_name: Option<String>,
-    pub destination_k8s_cluster_uid: Option<String>,
-    pub destination_k8s_node_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_node_name: Option<String>,
-    pub destination_k8s_node_uid: Option<String>,
-    pub destination_k8s_namespace_name: Option<String>,
-    pub destination_k8s_pod_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_pod_name: Option<String>,
-    pub destination_k8s_pod_uid: Option<String>,
-    pub destination_k8s_container_name: Option<String>,
-    pub destination_k8s_deployment_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_deployment_name: Option<String>,
-    pub destination_k8s_deployment_uid: Option<String>,
-    pub destination_k8s_replicaset_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_replicaset_name: Option<String>,
-    pub destination_k8s_replicaset_uid: Option<String>,
-    pub destination_k8s_statefulset_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_statefulset_name: Option<String>,
-    pub destination_k8s_statefulset_uid: Option<String>,
-    pub destination_k8s_daemonset_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_daemonset_name: Option<String>,
-    pub destination_k8s_daemonset_uid: Option<String>,
-    pub destination_k8s_job_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_job_name: Option<String>,
-    pub destination_k8s_job_uid: Option<String>,
-    pub destination_k8s_cronjob_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_cronjob_name: Option<String>,
-    pub destination_k8s_cronjob_uid: Option<String>,
-    pub destination_k8s_service_annotations: Option<HashMap<String, String>>,
-    pub destination_k8s_service_name: Option<String>,
-    pub destination_k8s_service_uid: Option<String>,
+    pub source_k8s_cluster_name: Option<Arc<str>>,
+    pub source_k8s_cluster_uid: Option<Arc<str>>,
+    pub source_k8s_node_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_node_name: Option<Arc<str>>,
+    pub source_k8s_node_uid: Option<Arc<str>>,
+    pub source_k8s_namespace_name: Option<Arc<str>>,
+    pub source_k8s_pod_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_pod_name: Option<Arc<str>>,
+    pub source_k8s_pod_uid: Option<Arc<str>>,
+    pub source_k8s_container_name: Option<Arc<str>>,
+    pub source_k8s_deployment_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_deployment_name: Option<Arc<str>>,
+    pub source_k8s_deployment_uid: Option<Arc<str>>,
+    pub source_k8s_replicaset_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_replicaset_name: Option<Arc<str>>,
+    pub source_k8s_replicaset_uid: Option<Arc<str>>,
+    pub source_k8s_statefulset_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_statefulset_name: Option<Arc<str>>,
+    pub source_k8s_statefulset_uid: Option<Arc<str>>,
+    pub source_k8s_daemonset_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_daemonset_name: Option<Arc<str>>,
+    pub source_k8s_daemonset_uid: Option<Arc<str>>,
+    pub source_k8s_job_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_job_name: Option<Arc<str>>,
+    pub source_k8s_job_uid: Option<Arc<str>>,
+    pub source_k8s_cronjob_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_cronjob_name: Option<Arc<str>>,
+    pub source_k8s_cronjob_uid: Option<Arc<str>>,
+    pub source_k8s_service_annotations: Option<HashMap<String, Arc<str>>>,
+    pub source_k8s_service_name: Option<Arc<str>>,
+    pub source_k8s_service_uid: Option<Arc<str>>,
+    pub destination_k8s_cluster_name: Option<Arc<str>>,
+    pub destination_k8s_cluster_uid: Option<Arc<str>>,
+    pub destination_k8s_node_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_node_name: Option<Arc<str>>,
+    pub destination_k8s_node_uid: Option<Arc<str>>,
+    pub destination_k8s_namespace_name: Option<Arc<str>>,
+    pub destination_k8s_pod_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_pod_name: Option<Arc<str>>,
+    pub destination_k8s_pod_uid: Option<Arc<str>>,
+    pub destination_k8s_container_name: Option<Arc<str>>,
+    pub destination_k8s_deployment_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_deployment_name: Option<Arc<str>>,
+    pub destination_k8s_deployment_uid: Option<Arc<str>>,
+    pub destination_k8s_replicaset_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_replicaset_name: Option<Arc<str>>,
+    pub destination_k8s_replicaset_uid: Option<Arc<str>>,
+    pub destination_k8s_statefulset_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_statefulset_name: Option<Arc<str>>,
+    pub destination_k8s_statefulset_uid: Option<Arc<str>>,
+    pub destination_k8s_daemonset_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_daemonset_name: Option<Arc<str>>,
+    pub destination_k8s_daemonset_uid: Option<Arc<str>>,
+    pub destination_k8s_job_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_job_name: Option<Arc<str>>,
+    pub destination_k8s_job_uid: Option<Arc<str>>,
+    pub destination_k8s_cronjob_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_cronjob_name: Option<Arc<str>>,
+    pub destination_k8s_cronjob_uid: Option<Arc<str>>,
+    pub destination_k8s_service_annotations: Option<HashMap<String, Arc<str>>>,
+    pub destination_k8s_service_name: Option<Arc<str>>,
+    pub destination_k8s_service_uid: Option<Arc<str>>,
     pub network_policies_ingress: Option<Vec<String>>,
     pub network_policies_egress: Option<Vec<String>>,
     /// Container runtime name for source (e.g., from Docker/containerd).
     /// Distinct from source_k8s_container_name which comes from Pod spec.
-    pub source_container_name: Option<String>,
-    pub source_container_image_name: Option<String>,
+    pub source_container_name: Option<Arc<str>>,
+    pub source_container_image_name: Option<Arc<str>>,
     /// Container runtime name for destination (e.g., from Docker/containerd).
     /// Distinct from destination_k8s_container_name which comes from Pod spec.
-    pub destination_container_name: Option<String>,
-    pub destination_container_image_name: Option<String>,
+    pub destination_container_name: Option<Arc<str>>,
+    pub destination_container_image_name: Option<Arc<str>>,
 }
 
 impl Default for SpanAttributes {
@@ -305,8 +311,10 @@ impl Default for SpanAttributes {
             flow_connection_state: None,
             flow_end_reason: None,
             source_address: IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            source_address_str: Arc::from("0.0.0.0"),
             source_port: 0,
             destination_address: IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED),
+            destination_address_str: Arc::from("0.0.0.0"),
             destination_port: 0,
             network_transport: IpProto::default(),
             network_type: EtherType::default(),
@@ -455,12 +463,36 @@ impl Traceable for FlowSpan {
         self.end_time
     }
 
-    fn name(&self) -> Option<String> {
-        Some(format!(
-            "flow_{}_{}",
-            self.attributes.network_type.as_str(),
-            self.attributes.network_transport.as_str()
-        ))
+    fn name(&self) -> Option<Cow<'static, str>> {
+        let s = match (
+            self.attributes.network_type,
+            self.attributes.network_transport,
+        ) {
+            (EtherType::Ipv4, IpProto::Tcp) => "flow_ipv4_tcp",
+            (EtherType::Ipv4, IpProto::Udp) => "flow_ipv4_udp",
+            (EtherType::Ipv4, IpProto::Icmp) => "flow_ipv4_icmp",
+            (EtherType::Ipv4, IpProto::Sctp) => "flow_ipv4_sctp",
+            (EtherType::Ipv4, IpProto::Gre) => "flow_ipv4_gre",
+            (EtherType::Ipv4, IpProto::Esp) => "flow_ipv4_esp",
+            (EtherType::Ipv4, IpProto::Ah) => "flow_ipv4_ah",
+            (EtherType::Ipv4, IpProto::Rsvp) => "flow_ipv4_rsvp",
+            (EtherType::Ipv6, IpProto::Tcp) => "flow_ipv6_tcp",
+            (EtherType::Ipv6, IpProto::Udp) => "flow_ipv6_udp",
+            (EtherType::Ipv6, IpProto::Ipv6Icmp) => "flow_ipv6_icmpv6",
+            (EtherType::Ipv6, IpProto::Sctp) => "flow_ipv6_sctp",
+            (EtherType::Ipv6, IpProto::Gre) => "flow_ipv6_gre",
+            (EtherType::Ipv6, IpProto::Esp) => "flow_ipv6_esp",
+            (EtherType::Ipv6, IpProto::Ah) => "flow_ipv6_ah",
+            (EtherType::Arp, _) => "flow_arp",
+            _ => {
+                return Some(Cow::Owned(format!(
+                    "flow_{}_{}",
+                    self.attributes.network_type.as_str(),
+                    self.attributes.network_transport.as_str(),
+                )));
+            }
+        };
+        Some(Cow::Borrowed(s))
     }
 
     fn span_kind(&self) -> opentelemetry::trace::SpanKind {
@@ -475,7 +507,7 @@ impl Traceable for FlowSpan {
                 if let Some(ref map) = $map {
                     for (key, value) in map {
                         let attr_key = format!("{}.{}", $prefix, key);
-                        kvs.push(KeyValue::new(attr_key, value.to_owned()));
+                        kvs.push(KeyValue::new(attr_key, Arc::clone(value)));
                     }
                 }
             };
@@ -491,15 +523,15 @@ impl Traceable for FlowSpan {
         ));
         kvs.push(KeyValue::new(
             "network.type",
-            self.attributes.network_type.to_owned().as_str(),
+            self.attributes.network_type.as_str(),
         ));
         kvs.push(KeyValue::new(
             "network.transport",
-            self.attributes.network_transport.to_owned().as_str(),
+            self.attributes.network_transport.as_str(),
         ));
         kvs.push(KeyValue::new(
             "source.address",
-            self.attributes.source_address.to_string(),
+            Arc::clone(&self.attributes.source_address_str),
         ));
         kvs.push(KeyValue::new(
             "source.port",
@@ -507,7 +539,7 @@ impl Traceable for FlowSpan {
         ));
         kvs.push(KeyValue::new(
             "destination.address",
-            self.attributes.destination_address.to_string(),
+            Arc::clone(&self.attributes.destination_address_str),
         ));
         kvs.push(KeyValue::new(
             "destination.port",
@@ -555,10 +587,10 @@ impl Traceable for FlowSpan {
             kvs.push(KeyValue::new("network.interface.index", value as i64));
         }
         if let Some(ref value) = self.attributes.network_interface_name {
-            kvs.push(KeyValue::new("network.interface.name", value.to_owned()));
+            kvs.push(KeyValue::new("network.interface.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.network_interface_mac {
-            kvs.push(KeyValue::new("network.interface.mac", value.to_string()));
+            kvs.push(KeyValue::new("network.interface.mac", Arc::clone(value)));
         }
         if let Some(value) = self.attributes.flow_ip_dscp_id {
             kvs.push(KeyValue::new("flow.ip.dscp.id", value as i64));
@@ -620,7 +652,7 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.flow_tcp_flags_tags {
             let flag_values: Vec<StringValue> = value
                 .iter()
-                .map(|f| StringValue::from(f.to_string()))
+                .map(|f| StringValue::from(f.as_str()))
                 .collect();
             kvs.push(KeyValue::new(
                 "flow.tcp.flags.tags",
@@ -633,7 +665,7 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.flow_reverse_tcp_flags_tags {
             let flag_values: Vec<StringValue> = value
                 .iter()
-                .map(|f| StringValue::from(f.to_string()))
+                .map(|f| StringValue::from(f.as_str()))
                 .collect();
             kvs.push(KeyValue::new(
                 "flow.reverse.tcp.flags.tags",
@@ -671,13 +703,13 @@ impl Traceable for FlowSpan {
             kvs.push(KeyValue::new("ipip.network.type", value.as_str()));
         }
         if let Some(ref value) = self.attributes.ipip_network_transport {
-            kvs.push(KeyValue::new("ipip.network.transport", value.to_string()));
+            kvs.push(KeyValue::new("ipip.network.transport", value.as_str()));
         }
         if let Some(ref value) = self.attributes.ipip_source_address {
-            kvs.push(KeyValue::new("ipip.source.address", value.to_string()));
+            kvs.push(KeyValue::new("ipip.source.address", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.ipip_destination_address {
-            kvs.push(KeyValue::new("ipip.destination.address", value.to_string()));
+            kvs.push(KeyValue::new("ipip.destination.address", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.tunnel_type {
             kvs.push(KeyValue::new("tunnel.type", value.as_str()));
@@ -685,28 +717,25 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.tunnel_network_interface_mac {
             kvs.push(KeyValue::new(
                 "tunnel.network.interface.mac",
-                value.to_string(),
+                Arc::clone(value),
             ));
         }
         if let Some(value) = self.attributes.tunnel_network_type {
-            kvs.push(KeyValue::new(
-                "tunnel.network.type",
-                value.as_str().to_string(),
-            ));
+            kvs.push(KeyValue::new("tunnel.network.type", value.as_str()));
         }
         if let Some(value) = self.attributes.tunnel_network_transport {
-            kvs.push(KeyValue::new("tunnel.network.transport", value.to_string()));
+            kvs.push(KeyValue::new("tunnel.network.transport", value.as_str()));
         }
-        if let Some(value) = self.attributes.tunnel_source_address {
-            kvs.push(KeyValue::new("tunnel.source.address", value.to_string()));
+        if let Some(ref value) = self.attributes.tunnel_source_address {
+            kvs.push(KeyValue::new("tunnel.source.address", Arc::clone(value)));
         }
         if let Some(value) = self.attributes.tunnel_source_port {
             kvs.push(KeyValue::new("tunnel.source.port", value as i64));
         }
-        if let Some(value) = self.attributes.tunnel_destination_address {
+        if let Some(ref value) = self.attributes.tunnel_destination_address {
             kvs.push(KeyValue::new(
                 "tunnel.destination.address",
-                value.to_string(),
+                Arc::clone(value),
             ));
         }
         if let Some(value) = self.attributes.tunnel_destination_port {
@@ -719,36 +748,42 @@ impl Traceable for FlowSpan {
             kvs.push(KeyValue::new("tunnel.ipsec.ah.spi", value as i64));
         }
         if let Some(ref value) = self.attributes.source_k8s_cluster_name {
-            kvs.push(KeyValue::new("source.k8s.cluster.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.cluster.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_cluster_uid {
-            kvs.push(KeyValue::new("source.k8s.cluster.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.cluster.uid", Arc::clone(value)));
         }
         flatten_annotations!(
             "source.k8s.node.annotations",
             self.attributes.source_k8s_node_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_node_name {
-            kvs.push(KeyValue::new("source.k8s.node.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.node.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_node_uid {
-            kvs.push(KeyValue::new("source.k8s.node.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.node.uid", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_namespace_name {
-            kvs.push(KeyValue::new("source.k8s.namespace.name", value.to_owned()));
+            kvs.push(KeyValue::new(
+                "source.k8s.namespace.name",
+                Arc::clone(value),
+            ));
         }
         flatten_annotations!(
             "source.k8s.pod.annotations",
             self.attributes.source_k8s_pod_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_pod_name {
-            kvs.push(KeyValue::new("source.k8s.pod.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.pod.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_pod_uid {
-            kvs.push(KeyValue::new("source.k8s.pod.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.pod.uid", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_container_name {
-            kvs.push(KeyValue::new("source.k8s.container.name", value.to_owned()));
+            kvs.push(KeyValue::new(
+                "source.k8s.container.name",
+                Arc::clone(value),
+            ));
         }
         flatten_annotations!(
             "source.k8s.deployment.annotations",
@@ -757,11 +792,14 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.source_k8s_deployment_name {
             kvs.push(KeyValue::new(
                 "source.k8s.deployment.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.source_k8s_deployment_uid {
-            kvs.push(KeyValue::new("source.k8s.deployment.uid", value.to_owned()));
+            kvs.push(KeyValue::new(
+                "source.k8s.deployment.uid",
+                Arc::clone(value),
+            ));
         }
         flatten_annotations!(
             "source.k8s.replicaset.annotations",
@@ -770,11 +808,14 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.source_k8s_replicaset_name {
             kvs.push(KeyValue::new(
                 "source.k8s.replicaset.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.source_k8s_replicaset_uid {
-            kvs.push(KeyValue::new("source.k8s.replicaset.uid", value.to_owned()));
+            kvs.push(KeyValue::new(
+                "source.k8s.replicaset.uid",
+                Arc::clone(value),
+            ));
         }
         flatten_annotations!(
             "source.k8s.statefulset.annotations",
@@ -783,13 +824,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.source_k8s_statefulset_name {
             kvs.push(KeyValue::new(
                 "source.k8s.statefulset.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.source_k8s_statefulset_uid {
             kvs.push(KeyValue::new(
                 "source.k8s.statefulset.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -797,51 +838,54 @@ impl Traceable for FlowSpan {
             self.attributes.source_k8s_daemonset_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_daemonset_name {
-            kvs.push(KeyValue::new("source.k8s.daemonset.name", value.to_owned()));
+            kvs.push(KeyValue::new(
+                "source.k8s.daemonset.name",
+                Arc::clone(value),
+            ));
         }
         if let Some(ref value) = self.attributes.source_k8s_daemonset_uid {
-            kvs.push(KeyValue::new("source.k8s.daemonset.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.daemonset.uid", Arc::clone(value)));
         }
         flatten_annotations!(
             "source.k8s.job.annotations",
             self.attributes.source_k8s_job_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_job_name {
-            kvs.push(KeyValue::new("source.k8s.job.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.job.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_job_uid {
-            kvs.push(KeyValue::new("source.k8s.job.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.job.uid", Arc::clone(value)));
         }
         flatten_annotations!(
             "source.k8s.cronjob.annotations",
             self.attributes.source_k8s_cronjob_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_cronjob_name {
-            kvs.push(KeyValue::new("source.k8s.cronjob.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.cronjob.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_cronjob_uid {
-            kvs.push(KeyValue::new("source.k8s.cronjob.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.cronjob.uid", Arc::clone(value)));
         }
         flatten_annotations!(
             "source.k8s.service.annotations",
             self.attributes.source_k8s_service_annotations
         );
         if let Some(ref value) = self.attributes.source_k8s_service_name {
-            kvs.push(KeyValue::new("source.k8s.service.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.service.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_k8s_service_uid {
-            kvs.push(KeyValue::new("source.k8s.service.uid", value.to_owned()));
+            kvs.push(KeyValue::new("source.k8s.service.uid", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.destination_k8s_cluster_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.cluster.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_cluster_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.cluster.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -849,15 +893,18 @@ impl Traceable for FlowSpan {
             self.attributes.destination_k8s_node_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_node_name {
-            kvs.push(KeyValue::new("destination.k8s.node.name", value.to_owned()));
+            kvs.push(KeyValue::new(
+                "destination.k8s.node.name",
+                Arc::clone(value),
+            ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_node_uid {
-            kvs.push(KeyValue::new("destination.k8s.node.uid", value.to_owned()));
+            kvs.push(KeyValue::new("destination.k8s.node.uid", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.destination_k8s_namespace_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.namespace.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -865,15 +912,15 @@ impl Traceable for FlowSpan {
             self.attributes.destination_k8s_pod_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_pod_name {
-            kvs.push(KeyValue::new("destination.k8s.pod.name", value.to_owned()));
+            kvs.push(KeyValue::new("destination.k8s.pod.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.destination_k8s_pod_uid {
-            kvs.push(KeyValue::new("destination.k8s.pod.uid", value.to_owned()));
+            kvs.push(KeyValue::new("destination.k8s.pod.uid", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.destination_k8s_container_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.container.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -883,13 +930,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.destination_k8s_deployment_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.deployment.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_deployment_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.deployment.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -899,13 +946,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.destination_k8s_replicaset_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.replicaset.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_replicaset_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.replicaset.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -915,13 +962,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.destination_k8s_statefulset_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.statefulset.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_statefulset_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.statefulset.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -931,13 +978,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.destination_k8s_daemonset_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.daemonset.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_daemonset_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.daemonset.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -945,10 +992,10 @@ impl Traceable for FlowSpan {
             self.attributes.destination_k8s_job_annotations
         );
         if let Some(ref value) = self.attributes.destination_k8s_job_name {
-            kvs.push(KeyValue::new("destination.k8s.job.name", value.to_owned()));
+            kvs.push(KeyValue::new("destination.k8s.job.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.destination_k8s_job_uid {
-            kvs.push(KeyValue::new("destination.k8s.job.uid", value.to_owned()));
+            kvs.push(KeyValue::new("destination.k8s.job.uid", Arc::clone(value)));
         }
         flatten_annotations!(
             "destination.k8s.cronjob.annotations",
@@ -957,13 +1004,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.destination_k8s_cronjob_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.cronjob.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_cronjob_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.cronjob.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         flatten_annotations!(
@@ -973,13 +1020,13 @@ impl Traceable for FlowSpan {
         if let Some(ref value) = self.attributes.destination_k8s_service_name {
             kvs.push(KeyValue::new(
                 "destination.k8s.service.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_k8s_service_uid {
             kvs.push(KeyValue::new(
                 "destination.k8s.service.uid",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.network_policies_ingress {
@@ -992,27 +1039,27 @@ impl Traceable for FlowSpan {
             kvs.push(KeyValue::new("process.pid", value as i64));
         }
         if let Some(ref value) = self.attributes.process_executable_name {
-            kvs.push(KeyValue::new("process.executable.name", value.to_owned()));
+            kvs.push(KeyValue::new("process.executable.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_container_name {
-            kvs.push(KeyValue::new("source.container.name", value.to_owned()));
+            kvs.push(KeyValue::new("source.container.name", Arc::clone(value)));
         }
         if let Some(ref value) = self.attributes.source_container_image_name {
             kvs.push(KeyValue::new(
                 "source.container.image.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_container_name {
             kvs.push(KeyValue::new(
                 "destination.container.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         if let Some(ref value) = self.attributes.destination_container_image_name {
             kvs.push(KeyValue::new(
                 "destination.container.image.name",
-                value.to_owned(),
+                Arc::clone(value),
             ));
         }
         span.set_attributes(kvs);
@@ -1100,19 +1147,6 @@ where
 {
     match trace_id {
         Some(id) => serializer.serialize_str(&id.to_string()),
-        None => serializer.serialize_none(),
-    }
-}
-
-fn serialize_option_mac_addr<S>(
-    mac_addr: &Option<pnet::datalink::MacAddr>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match mac_addr {
-        Some(addr) => serializer.serialize_str(&addr.to_string()),
         None => serializer.serialize_none(),
     }
 }
@@ -1302,7 +1336,7 @@ mod tests {
         flow_span.attrs_mut().network_transport = IpProto::Tcp;
 
         let name = flow_span.name();
-        assert_eq!(name, Some("flow_ipv4_tcp".to_string()));
+        assert_eq!(name.as_deref(), Some("flow_ipv4_tcp"));
     }
 
     #[test]
@@ -1327,7 +1361,7 @@ mod tests {
         flow_span.attrs_mut().network_transport = IpProto::Udp;
 
         let name = flow_span.name();
-        assert_eq!(name, Some("flow_ipv6_udp".to_string()));
+        assert_eq!(name.as_deref(), Some("flow_ipv6_udp"));
     }
 
     #[test]
@@ -1544,18 +1578,18 @@ mod tests {
     #[test]
     fn test_span_attributes_with_k8s_metadata() {
         let mut attrs = SpanAttributes::default();
-        attrs.source_k8s_pod_name = Some("test-pod".to_string());
-        attrs.source_k8s_namespace_name = Some("test-namespace".to_string());
-        attrs.destination_k8s_service_name = Some("test-service".to_string());
+        attrs.source_k8s_pod_name = Some(Arc::from("test-pod"));
+        attrs.source_k8s_namespace_name = Some(Arc::from("test-namespace"));
+        attrs.destination_k8s_service_name = Some(Arc::from("test-service"));
 
-        assert_eq!(attrs.source_k8s_pod_name, Some("test-pod".to_string()));
+        assert_eq!(attrs.source_k8s_pod_name.as_deref(), Some("test-pod"));
         assert_eq!(
-            attrs.source_k8s_namespace_name,
-            Some("test-namespace".to_string())
+            attrs.source_k8s_namespace_name.as_deref(),
+            Some("test-namespace")
         );
         assert_eq!(
-            attrs.destination_k8s_service_name,
-            Some("test-service".to_string())
+            attrs.destination_k8s_service_name.as_deref(),
+            Some("test-service")
         );
     }
 
@@ -1604,17 +1638,15 @@ mod tests {
 
     #[test]
     fn test_serialize_option_mac_addr() {
-        use pnet::datalink::MacAddr;
         use serde_json;
 
         #[derive(Serialize)]
         struct TestStruct {
-            #[serde(serialize_with = "serialize_option_mac_addr")]
-            mac: Option<MacAddr>,
+            mac: Option<Arc<str>>,
         }
 
         let test = TestStruct {
-            mac: Some(MacAddr::new(0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff)),
+            mac: Some(Arc::from("aa:bb:cc:dd:ee:ff")),
         };
 
         let json = serde_json::to_string(&test).unwrap();

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -732,18 +732,17 @@ impl FlowWorker {
                     .inc();
             }
 
-            let iface_name = self
-                .iface_map
-                .load()
+            let iface_guard = self.iface_map.load();
+            let iface_name = iface_guard
                 .get(&stats.ifindex)
-                .cloned()
-                .unwrap_or_else(|| "unknown".to_string());
+                .map(|s| s.as_str())
+                .unwrap_or("unknown");
             metrics::registry::PROCESSING_TOTAL
                 .with_label_values(&[FlowSpanProducerStatus::Dropped.as_str()])
                 .inc();
             if metrics::registry::debug_enabled() {
                 metrics::registry::FLOW_PRODUCER_FLOW_SPANS_BY_INTERFACE_TOTAL
-                    .with_label_values(&[&iface_name, FlowSpanProducerStatus::Dropped.as_str()])
+                    .with_label_values(&[iface_name, FlowSpanProducerStatus::Dropped.as_str()])
                     .inc();
             }
 
@@ -872,7 +871,11 @@ impl FlowWorker {
         let is_icmpv6 = stats.protocol == IpProto::Ipv6Icmp;
         let start_time_nanos = stats.first_seen_ns + self.boot_time_offset_nanos;
         let end_time_nanos = stats.last_seen_ns + self.boot_time_offset_nanos;
-        let iface_name = self.iface_map.load().get(&stats.ifindex).cloned();
+        let iface_name: Option<Arc<str>> = self
+            .iface_map
+            .load()
+            .get(&stats.ifindex)
+            .map(|s| Arc::from(s.as_str()));
         let (src_addr, dst_addr) = flow_key_to_ip_addrs(flow_key)?;
         let timeout = self.calculate_timeout(stats);
         let span_kind = self
@@ -896,15 +899,17 @@ impl FlowWorker {
                 flow_end_reason: None,
 
                 source_address: src_addr,
+                source_address_str: Arc::from(src_addr.to_string()),
                 source_port: flow_key.src_port,
                 destination_address: dst_addr,
+                destination_address_str: Arc::from(dst_addr.to_string()),
                 destination_port: flow_key.dst_port,
 
                 network_transport: flow_key.protocol,
                 network_type: stats.ether_type,
                 network_interface_index: Some(stats.ifindex),
                 network_interface_name: iface_name.clone(),
-                network_interface_mac: Some(MacAddr::from(stats.src_mac)),
+                network_interface_mac: Some(Arc::from(MacAddr::from(stats.src_mac).to_string())),
 
                 flow_ip_dscp_id: is_ip_flow.then_some(stats.ip_dscp),
                 flow_ip_dscp_name: is_ip_flow.then_some(
@@ -971,9 +976,8 @@ impl FlowWorker {
 
                 process_pid: (stats.pid != 0).then_some(stats.pid),
                 process_executable_name: (stats.pid != 0).then(|| {
-                    String::from_utf8_lossy(&stats.comm)
-                        .trim_end_matches('\0')
-                        .to_string()
+                    let lossy = String::from_utf8_lossy(&stats.comm);
+                    Arc::from(lossy.trim_end_matches('\0'))
                 }),
 
                 flow_icmp_type_id: (is_icmp || is_icmpv6).then_some(stats.icmp_type),
@@ -1097,16 +1101,15 @@ impl FlowWorker {
         flow_span.last_activity_time = flow_span.end_time;
         flow_span.timeout_duration = timeout;
 
-        let iface_name = flow_span
+        let iface_name: Arc<str> = flow_span
             .attributes
             .network_interface_name
-            .as_deref()
-            .unwrap_or("unknown")
-            .to_string();
+            .clone()
+            .unwrap_or_else(|| Arc::from("unknown"));
         metrics::registry::FLOW_SPANS_CREATED_TOTAL.inc();
         if metrics::registry::debug_enabled() {
             metrics::registry::FLOWS_CREATED_BY_INTERFACE_TOTAL
-                .with_label_values(&[&iface_name])
+                .with_label_values(&[&*iface_name])
                 .inc();
         }
 
@@ -1119,7 +1122,7 @@ impl FlowWorker {
                 metrics::registry::FLOW_SPANS_ACTIVE_TOTAL.inc();
                 if metrics::registry::debug_enabled() {
                     metrics::registry::FLOWS_ACTIVE_BY_INTERFACE_TOTAL
-                        .with_label_values(&[&iface_name])
+                        .with_label_values(&[&*iface_name])
                         .inc();
                 }
             }
@@ -1129,20 +1132,19 @@ impl FlowWorker {
                     .attributes
                     .network_interface_name
                     .as_deref()
-                    .unwrap_or("unknown")
-                    .to_string();
+                    .unwrap_or("unknown");
 
-                if old_iface != iface_name {
+                if old_iface != &*iface_name {
                     metrics::registry::FLOW_SPANS_ACTIVE_TOTAL.dec();
                     if metrics::registry::debug_enabled() {
                         metrics::registry::FLOWS_ACTIVE_BY_INTERFACE_TOTAL
-                            .with_label_values(&[&old_iface])
+                            .with_label_values(&[old_iface])
                             .dec();
                     }
                     metrics::registry::FLOW_SPANS_ACTIVE_TOTAL.inc();
                     if metrics::registry::debug_enabled() {
                         metrics::registry::FLOWS_ACTIVE_BY_INTERFACE_TOTAL
-                            .with_label_values(&[&iface_name])
+                            .with_label_values(&[&*iface_name])
                             .inc();
                     }
                 }
@@ -1618,23 +1620,16 @@ async fn record_flow(
     }
 
     if delta_packets > 0 || delta_reverse_packets > 0 {
-        let interface_name_for_metrics = flow_store
+        let interface_name_arc = flow_store
             .get(community_id)
-            .and_then(|entry| {
-                entry
-                    .flow_span
-                    .attributes
-                    .network_interface_name
-                    .as_deref()
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+            .and_then(|entry| entry.flow_span.attributes.network_interface_name.clone());
+        let interface_name_for_metrics = interface_name_arc.as_deref().unwrap_or("unknown");
 
         if delta_packets > 0 {
             metrics::registry::PACKETS_TOTAL.inc_by(delta_packets);
             if metrics::registry::debug_enabled() {
                 metrics::registry::PACKETS_BY_INTERFACE_TOTAL
-                    .with_label_values(&[&interface_name_for_metrics, stats.direction.as_str()])
+                    .with_label_values(&[interface_name_for_metrics, stats.direction.as_str()])
                     .inc_by(delta_packets);
             }
         }
@@ -1642,7 +1637,7 @@ async fn record_flow(
             metrics::registry::BYTES_TOTAL.inc_by(delta_bytes);
             if metrics::registry::debug_enabled() {
                 metrics::registry::BYTES_BY_INTERFACE_TOTAL
-                    .with_label_values(&[&interface_name_for_metrics, stats.direction.as_str()])
+                    .with_label_values(&[interface_name_for_metrics, stats.direction.as_str()])
                     .inc_by(delta_bytes);
             }
         }
@@ -1651,7 +1646,7 @@ async fn record_flow(
             metrics::registry::PACKETS_TOTAL.inc_by(delta_reverse_packets);
             if metrics::registry::debug_enabled() {
                 metrics::registry::PACKETS_BY_INTERFACE_TOTAL
-                    .with_label_values(&[&interface_name_for_metrics, reverse_direction.as_str()])
+                    .with_label_values(&[interface_name_for_metrics, reverse_direction.as_str()])
                     .inc_by(delta_reverse_packets);
             }
         }
@@ -1660,7 +1655,7 @@ async fn record_flow(
             metrics::registry::BYTES_TOTAL.inc_by(delta_reverse_bytes);
             if metrics::registry::debug_enabled() {
                 metrics::registry::BYTES_BY_INTERFACE_TOTAL
-                    .with_label_values(&[&interface_name_for_metrics, reverse_direction.as_str()])
+                    .with_label_values(&[interface_name_for_metrics, reverse_direction.as_str()])
                     .inc_by(delta_reverse_bytes);
             }
         }
@@ -1861,11 +1856,11 @@ pub async fn timeout_and_remove_flow(
     // Pre-capture interface name before the eBPF lock scope: flow_span may be
     // consumed by try_send inside that block, but the name is needed for the
     // unconditional metrics emitted after the block.
-    let iface_name_owned = flow_span
+    let iface_name_owned: Arc<str> = flow_span
         .attributes
         .network_interface_name
         .clone()
-        .unwrap_or_else(|| "unknown".to_string());
+        .unwrap_or_else(|| Arc::from("unknown"));
 
     // Single lock hold: read final stats, emit the span, and remove the eBPF entry.
     // try_send is non-blocking so it is safe to call while holding the mutex.
@@ -1989,7 +1984,7 @@ pub async fn timeout_and_remove_flow(
         drop(map);
     }
 
-    let iface_name = iface_name_owned.as_str();
+    let iface_name: &str = &iface_name_owned;
     metrics::registry::PROCESSING_TOTAL
         .with_label_values(&[FlowSpanProducerStatus::Idled.as_str()])
         .inc();

--- a/mermin/tests/e2e/cni/test.sh
+++ b/mermin/tests/e2e/cni/test.sh
@@ -81,7 +81,7 @@ verify_agent_logs() {
       local counter=0
       while [ $counter -lt 60 ]; do
         # examples: https://regex101.com/r/rYbX7m/1
-        if kubectl logs -n "${NAMESPACE}" "$pod" --tail=10000 2>/dev/null | grep --color=never -E '(source\.k8s\.pod\.name.*String\(Owned\("(pinger|ping-receiver)"\)|destination\.k8s\.pod\.name.*String\(Owned\("(pinger|ping-receiver)"\))' >/dev/null; then
+        if kubectl logs -n "${NAMESPACE}" "$pod" --tail=10000 2>/dev/null | grep --color=never -E '(source\.k8s\.pod\.name.*String\((Owned|Static|RefCounted)\("(pinger|ping-receiver)"\)|destination\.k8s\.pod\.name.*String\((Owned|Static|RefCounted)\("(pinger|ping-receiver)"\))' >/dev/null; then
           exit 0
         fi
         counter=$((counter + 1))


### PR DESCRIPTION
Every time a flow span is exported, `record()` in `span/flow.rs` was
allocating dozens of heap strings for attribute values that don't change
after flow creation. This PR eliminates those allocations across the hot
path.

## Changes
- `Traceable::name()` now returns `Option<Cow<'static, str>>`. `FlowSpan::name()`
  uses a static match table for the 15 most common `(EtherType, IpProto)` pairs,
  returning a borrowed `&'static str` with zero allocation. Rare combos fall
  back to `format!`.
- `SpanAttributes` now stores `source_address_str` and `destination_address_str`
  as `Arc<str>`, formatted once at flow creation. MAC address and IPIP/tunnel
  address fields likewise changed from `MacAddr`/`IpAddr` to `Arc<str>`.
  `record()` calls `Arc::clone()` (refcount bump) instead of `.to_string()`.
- ~40 K8s name/uid fields, `network_interface_name`, `process_executable_name`,
  container name fields, and annotation map values changed from `Option<String>` /
  `HashMap<String, String>` to `Option<Arc<str>>` / `HashMap<String, Arc<str>>`.
  One allocation at decoration time, amortized over all exports. `record()` uses
  `Arc::clone()` instead of `.to_owned()`.
- Removed redundant `.to_owned()` before `.as_str()` on `Copy` enums (`EtherType`,
  `IpProto`). `TcpFlag` array now uses `f.as_str()` — all resolve to `&'static str`,
  zero allocation.
- `ip_addr_to_bytes()` in `community_id.rs` now returns a stack-allocated `IpBytes`
  enum (`V4([u8; 4])` | `V6([u8; 16])`) instead of `Vec<u8>`.
Per-export allocations eliminated: 1 span name + 2 IP addresses + 1 MAC + N TCP
flags + up to ~40 K8s fields + 3–5 static enum strings.

## Proof it works

Local testing reduced CPU usage by ~5%.
