### PR TITLE
refactor(k8s): enhance extraction rule handling in k8s decoration

### DIFF
--- a/mermin/src/k8s/attributor.rs
+++ b/mermin/src/k8s/attributor.rs
@@ -235,25 +235,54 @@ pub struct K8sObjectMeta {
     pub annotations: Option<HashMap<String, String>>,
 }
 
+impl K8sObjectMeta {
+    pub fn from_resource<T>(resource: &T, extract_fn: impl Fn(&str, &str) -> bool) -> Self
+    where
+        T: Resource<DynamicType = ()>,
+    {
+        let kind = T::kind(&()).to_string();
+        let kind_lower = kind.to_lowercase();
+
+        let name = resource.name_any();
+        let namespace = resource.namespace();
+        let uid = if extract_fn(&kind_lower, "uid") {
+            resource.uid()
+        } else {
+            None
+        };
+
+        let labels = if extract_fn(&kind_lower, "labels") && !resource.labels().is_empty() {
+            Some(resource.labels().clone().into_iter().collect())
+        } else {
+            None
+        };
+
+        let annotations =
+            if extract_fn(&kind_lower, "annotations") && !resource.annotations().is_empty() {
+                Some(resource.annotations().clone().into_iter().collect())
+            } else {
+                None
+            };
+
+        Self {
+            kind,
+            kind_lower,
+            name,
+            uid,
+            namespace,
+            labels,
+            annotations,
+        }
+    }
+}
+
 /// Generic implementation to convert any Kubernetes Resource into our K8sObjectMeta.
 impl<T> From<&T> for K8sObjectMeta
 where
     T: Resource<DynamicType = ()>,
 {
     fn from(resource: &T) -> Self {
-        let kind = T::kind(&()).to_string();
-        let kind_lower = kind.to_lowercase();
-        Self {
-            kind,
-            kind_lower,
-            name: resource.name_any(),
-            uid: resource.uid(),
-            namespace: resource.namespace(),
-            labels: (!resource.labels().is_empty())
-                .then(|| resource.labels().clone().into_iter().collect()),
-            annotations: (!resource.annotations().is_empty())
-                .then(|| resource.annotations().clone().into_iter().collect()),
-        }
+        Self::from_resource(resource, |_, _| true)
     }
 }
 
@@ -767,21 +796,29 @@ impl Attributor {
     /// the owner_relations configuration.
     ///
     /// Walks the chain up to max_depth and filters based on include/exclude rules.
-    pub fn get_owners(&self, pod: &Pod) -> Option<Vec<WorkloadOwner>> {
+    pub fn get_owners(
+        &self,
+        pod: &Pod,
+        extract_fn: impl Fn(&str, &str) -> bool,
+    ) -> Option<Vec<WorkloadOwner>> {
         self.owner_relations_manager
-            .get_owners(pod, &self.resource_store)
+            .get_owners(pod, &self.resource_store, extract_fn)
     }
 
     /// Given a Pod object, returns metadata for all resources that have selectors matching
     /// the pod's labels (e.g., NetworkPolicies, Services).
     ///
     /// Returns None if selector_relations is not configured or no matches are found.
-    pub fn get_selector_based_metadata(&self, pod: &Pod) -> Option<Vec<K8sObjectMeta>> {
+    pub fn get_selector_based_metadata(
+        &self,
+        pod: &Pod,
+        extract_fn: impl Fn(&str, &str) -> bool,
+    ) -> Option<Vec<K8sObjectMeta>> {
         let manager = self.selector_relations_manager.as_ref()?;
         let pod_labels = pod.labels();
         let pod_namespace = pod.namespace().unwrap_or_default();
 
-        manager.get_related_resources(pod_labels, &pod_namespace, &self.resource_store)
+        manager.get_related_resources(pod_labels, &pod_namespace, &self.resource_store, extract_fn)
     }
 
     /// Shared IP lookup implementation used by filtered and unfiltered callers.
@@ -2002,7 +2039,7 @@ mod tests {
         // Instead, we'll manually construct the parts we need and test them directly
 
         // Test Owner Relations
-        let owners = owner_relations_manager.get_owners(&pod, &resource_store);
+        let owners = owner_relations_manager.get_owners(&pod, &resource_store, |_, _| true);
         assert!(owners.is_some(), "Owner relations should return results");
         let owners = owners.unwrap();
 
@@ -2037,8 +2074,12 @@ mod tests {
         let pod_labels = pod.labels();
         let pod_namespace = pod.namespace().unwrap_or_default();
 
-        let selector_matches =
-            selector_manager.get_related_resources(pod_labels, &pod_namespace, &resource_store);
+        let selector_matches = selector_manager.get_related_resources(
+            pod_labels,
+            &pod_namespace,
+            &resource_store,
+            |_, _| true,
+        );
 
         assert!(
             selector_matches.is_some(),

--- a/mermin/src/k8s/decorator.rs
+++ b/mermin/src/k8s/decorator.rs
@@ -33,20 +33,25 @@ pub struct NetworkPolicy {
 /// Expand a list of extract rules into a compiled lookup structure.
 ///
 /// Returns `(specific, wildcards)`:
-/// - `specific`: fully-qualified `"resource.metadata.field"` keys (e.g. `"pod.metadata.name"`)
-///   for rules that name a concrete resource type.
+/// - `specific`: a nested map where the key is the resource kind (e.g., `"pod"`)
+///   and the value is a set of fields to extract (e.g., `"name"`, `"namespace"`).
 /// - `wildcards`: bare field names (e.g. `"name"`) extracted from `[*].metadata.<field>` rules.
 ///   A wildcard entry matches *any* resource kind, preserving the original `[*]` semantics.
 ///
 /// Both lookups are O(1) at runtime with no allocation in `should_extract`.
-fn expand_extract_rules(rules: Vec<String>) -> (HashSet<String>, HashSet<String>) {
-    let mut specific = HashSet::with_capacity(rules.len());
+fn expand_extract_rules(rules: Vec<String>) -> (HashMap<String, HashSet<String>>, HashSet<String>) {
+    let mut specific: HashMap<String, HashSet<String>> = HashMap::with_capacity(rules.len());
     let mut wildcards = HashSet::new();
     for rule in rules {
         if let Some(field) = rule.strip_prefix("[*].metadata.") {
             wildcards.insert(field.to_owned());
-        } else {
-            specific.insert(rule);
+        } else if let Some(meta_idx) = rule.find(".metadata.") {
+            let resource = &rule[..meta_idx];
+            let field = &rule[meta_idx + ".metadata.".len()..];
+            specific
+                .entry(resource.to_owned())
+                .or_default()
+                .insert(field.to_owned());
         }
     }
     (specific, wildcards)
@@ -56,14 +61,17 @@ fn expand_extract_rules(rules: Vec<String>) -> (HashSet<String>, HashSet<String>
 /// to produce enriched flow attributes containing resource information.
 pub struct Decorator<'a> {
     attributor: &'a Attributor,
-    /// Pre-compiled set of `"resource.metadata.field"` keys for source-side extraction.
-    source_extract_set: HashSet<String>,
+    /// Pre-compiled nested map of extraction rules for source-side extraction.
+    /// Keyed by resource kind (e.g., "pod").
+    source_extract_map: HashMap<String, HashSet<String>>,
     /// Field names matched by source-side `[*].metadata.<field>` wildcard rules.
     /// A hit here means the field is extracted regardless of resource kind.
     source_wildcard_fields: HashSet<String>,
-    /// Pre-compiled set of `"resource.metadata.field"` keys for dest-side extraction.
-    dest_extract_set: HashSet<String>,
+    /// Pre-compiled nested map of extraction rules for dest-side extraction.
+    /// Keyed by resource kind (e.g., "pod").
+    dest_extract_map: HashMap<String, HashSet<String>>,
     /// Field names matched by dest-side `[*].metadata.<field>` wildcard rules.
+    /// A hit here means the field is extracted regardless of resource kind.
     dest_wildcard_fields: HashSet<String>,
 }
 
@@ -73,14 +81,14 @@ impl<'a> Decorator<'a> {
         source_extract_rules: Vec<String>,
         dest_extract_rules: Vec<String>,
     ) -> Self {
-        let (source_extract_set, source_wildcard_fields) =
+        let (source_extract_map, source_wildcard_fields) =
             expand_extract_rules(source_extract_rules);
-        let (dest_extract_set, dest_wildcard_fields) = expand_extract_rules(dest_extract_rules);
+        let (dest_extract_map, dest_wildcard_fields) = expand_extract_rules(dest_extract_rules);
         Self {
             attributor,
-            source_extract_set,
+            source_extract_map,
             source_wildcard_fields,
-            dest_extract_set,
+            dest_extract_map,
             dest_wildcard_fields,
         }
     }
@@ -192,16 +200,18 @@ impl<'a> Decorator<'a> {
     /// Returns `true` if the operator configured either a concrete `resource.metadata.field`
     /// rule or a `[*].metadata.field` wildcard that matches any resource kind.
     ///
-    /// The wildcard check is O(1) with no allocation (uses `field` directly as a `&str` key).
-    /// The specific check allocates one `String` for the key and does a single `HashSet` lookup.
+    /// Both checks are O(1) with no allocation.
     fn should_extract(&self, resource: &str, field: &str, is_source: bool) -> bool {
-        let (set, wildcards) = if is_source {
-            (&self.source_extract_set, &self.source_wildcard_fields)
+        let (map, wildcards) = if is_source {
+            (&self.source_extract_map, &self.source_wildcard_fields)
         } else {
-            (&self.dest_extract_set, &self.dest_wildcard_fields)
+            (&self.dest_extract_map, &self.dest_wildcard_fields)
         };
 
-        wildcards.contains(field) || set.contains(format!("{resource}.metadata.{field}").as_str())
+        wildcards.contains(field)
+            || map
+                .get(resource)
+                .is_some_and(|fields| fields.contains(field))
     }
 
     /// Shared helper to populate standard Kubernetes metadata (Name, UID, Annotations, Namespace).
@@ -576,7 +586,75 @@ pub fn resolve_pod_container_by_port(pod: &Pod, port: u16) -> Option<(String, St
 mod tests {
     use k8s_openapi::api::core::v1::{Container, ContainerPort, Pod, PodSpec};
 
-    use super::resolve_pod_container_by_port;
+    use super::{expand_extract_rules, resolve_pod_container_by_port};
+
+    #[test]
+    fn test_expand_extract_rules() {
+        let rules = vec![
+            "[*].metadata.name".to_string(),
+            "[*].metadata.namespace".to_string(),
+            "pod.metadata.uid".to_string(),
+            "node.metadata.name".to_string(),
+            "invalid_rule".to_string(),
+        ];
+
+        let (specific, wildcards) = expand_extract_rules(rules);
+
+        assert_eq!(wildcards.len(), 2);
+        assert!(wildcards.contains("name"));
+        assert!(wildcards.contains("namespace"));
+
+        assert_eq!(specific.len(), 2);
+        assert_eq!(specific.get("pod").unwrap().len(), 1);
+        assert!(specific.get("pod").unwrap().contains("uid"));
+        assert_eq!(specific.get("node").unwrap().len(), 1);
+        assert!(specific.get("node").unwrap().contains("name"));
+    }
+
+    #[test]
+    fn test_should_extract() {
+        let rules = vec![
+            "pod.metadata.name".to_string(),
+            "[*].metadata.uid".to_string(),
+        ];
+        let (map, wildcards) = expand_extract_rules(rules);
+
+        let check = |kind: &str, field: &str| {
+            wildcards.contains(field) || map.get(kind).is_some_and(|fields| fields.contains(field))
+        };
+
+        assert!(check("pod", "name"));
+        assert!(check("pod", "uid"));
+        assert!(check("node", "uid"));
+        assert!(!check("node", "name"));
+    }
+
+    #[test]
+    fn test_should_extract_with_uncommon_resources() {
+        let rules = vec![
+            "[*].metadata.uid".to_string(),
+            "service.metadata.name".to_string(),
+            "deployment.metadata.labels".to_string(),
+            "mycustomresource.metadata.version".to_string(),
+        ];
+        let (map, wildcards) = expand_extract_rules(rules);
+
+        let check = |kind: &str, field: &str| {
+            wildcards.contains(field) || map.get(kind).is_some_and(|fields| fields.contains(field))
+        };
+
+        assert!(check("service", "name"));
+        assert!(check("service", "uid"));
+
+        assert!(check("deployment", "labels"));
+        assert!(check("deployment", "uid"));
+
+        assert!(check("mycustomresource", "version"));
+        assert!(check("mycustomresource", "uid"));
+
+        assert!(!check("pod", "name"));
+        assert!(!check("service", "labels"));
+    }
 
     /// Helper to create a container with optional ports and image
     fn create_container(name: &str, image: Option<&str>, ports: Option<Vec<i32>>) -> Container {

--- a/mermin/src/k8s/decorator.rs
+++ b/mermin/src/k8s/decorator.rs
@@ -124,7 +124,7 @@ impl<'a> Decorator<'a> {
         let src_port = flow_span.attributes.source_port;
         let dst_port = flow_span.attributes.destination_port;
 
-        let src_info = self.enrich(ctx.src_pod.as_deref(), ctx.src_ip).await;
+        let src_info = self.enrich(ctx.src_pod.as_deref(), ctx.src_ip, true).await;
         if let Some(info) = &src_info {
             self.populate_k8s_attributes(
                 &mut flow_span,
@@ -135,7 +135,7 @@ impl<'a> Decorator<'a> {
             );
         }
 
-        let dst_info = self.enrich(ctx.dst_pod.as_deref(), ctx.dst_ip).await;
+        let dst_info = self.enrich(ctx.dst_pod.as_deref(), ctx.dst_ip, false).await;
         if let Some(info) = &dst_info {
             self.populate_k8s_attributes(
                 &mut flow_span,
@@ -157,12 +157,19 @@ impl<'a> Decorator<'a> {
 
     /// Resolves a pod and IP address to Kubernetes resource decoration information.
     /// Returns Pod decoration if available, otherwise attempts IP-based fallback resolution.
-    async fn enrich(&self, pod: Option<&Pod>, ip: IpAddr) -> Option<DecorationInfo> {
+    async fn enrich(
+        &self,
+        pod: Option<&Pod>,
+        ip: IpAddr,
+        is_source: bool,
+    ) -> Option<DecorationInfo> {
+        let extract_fn = |kind: &str, field: &str| self.should_extract(kind, field, is_source);
+
         if let Some(pod) = pod {
-            let pod_meta = K8sObjectMeta::from(pod);
-            let node_name = pod.spec.as_ref()?.node_name.clone();
-            let owners = self.attributor.get_owners(pod);
-            let selector_relations = self.attributor.get_selector_based_metadata(pod);
+            let pod_meta = K8sObjectMeta::from_resource(pod, extract_fn);
+            let node_name = pod.spec.as_ref().and_then(|s| s.node_name.clone());
+            let owners = self.attributor.get_owners(pod, extract_fn);
+            let selector_relations = self.attributor.get_selector_based_metadata(pod, extract_fn);
             return Some(DecorationInfo::Pod {
                 pod: pod_meta,
                 node_name,
@@ -173,19 +180,19 @@ impl<'a> Decorator<'a> {
 
         if let Some(service) = self.attributor.get_service_by_ip(ip).await {
             return Some(DecorationInfo::Service {
-                service: K8sObjectMeta::from(service.as_ref()),
+                service: K8sObjectMeta::from_resource(service.as_ref(), extract_fn),
             });
         }
 
         if let Some(node) = self.attributor.get_node_by_ip(ip).await {
             return Some(DecorationInfo::Node {
-                node: K8sObjectMeta::from(node.as_ref()),
+                node: K8sObjectMeta::from_resource(node.as_ref(), extract_fn),
             });
         }
 
         if let Some(slice) = self.attributor.get_endpointslice_by_ip(ip).await {
             return Some(DecorationInfo::EndpointSlice {
-                slice: K8sObjectMeta::from(slice.as_ref()),
+                slice: K8sObjectMeta::from_resource(slice.as_ref(), extract_fn),
             });
         }
 
@@ -654,6 +661,25 @@ mod tests {
 
         assert!(!check("pod", "name"));
         assert!(!check("service", "labels"));
+    }
+
+    #[test]
+    fn test_should_extract_with_wildcards() {
+        let rules = vec![
+            "[*].metadata.name".to_string(),
+            "[*].metadata.namespace".to_string(),
+        ];
+        let (map, wildcards) = expand_extract_rules(rules);
+
+        let check = |kind: &str, field: &str| {
+            wildcards.contains(field) || map.get(kind).is_some_and(|fields| fields.contains(field))
+        };
+
+        assert!(check("pod", "name"));
+        assert!(check("pod", "namespace"));
+        assert!(check("service", "name"));
+        assert!(check("node", "name"));
+        assert!(!check("pod", "uid"));
     }
 
     /// Helper to create a container with optional ports and image

--- a/mermin/src/k8s/owner_relations.rs
+++ b/mermin/src/k8s/owner_relations.rs
@@ -79,8 +79,13 @@ impl OwnerRelationsManager {
     /// Returns the filtered list of WorkloadOwners that should be included in
     /// flow metadata. Returns None if no owners are found or all are filtered out.
     #[must_use]
-    pub fn get_owners(&self, pod: &Pod, store: &ResourceStore) -> Option<Vec<WorkloadOwner>> {
-        let all_owners = self.walk_owner_chain(pod, store);
+    pub fn get_owners(
+        &self,
+        pod: &Pod,
+        store: &ResourceStore,
+        extract_fn: impl Fn(&str, &str) -> bool,
+    ) -> Option<Vec<WorkloadOwner>> {
+        let all_owners = self.walk_owner_chain(pod, store, &extract_fn);
 
         if all_owners.is_empty() {
             return None;
@@ -95,7 +100,12 @@ impl OwnerRelationsManager {
         }
     }
 
-    fn walk_owner_chain(&self, pod: &Pod, store: &ResourceStore) -> Vec<WorkloadOwner> {
+    fn walk_owner_chain(
+        &self,
+        pod: &Pod,
+        store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
+    ) -> Vec<WorkloadOwner> {
         let mut all_owners = Vec::with_capacity(self.max_depth.min(8));
         let mut current_owners = pod.owner_references().to_vec();
         let mut namespace = pod.namespace().unwrap_or_default();
@@ -108,7 +118,7 @@ impl OwnerRelationsManager {
 
             for owner_ref in current_owners {
                 if let Some((owner, next_owners_opt)) =
-                    self.lookup_owner(&owner_ref, &namespace, store)
+                    self.lookup_owner(&owner_ref, &namespace, store, extract_fn)
                 {
                     all_owners.push(owner.clone());
 
@@ -180,6 +190,7 @@ impl OwnerRelationsManager {
         owner_ref: &OwnerReference,
         namespace: &str,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Option<(WorkloadOwner, Option<Vec<OwnerReference>>)> {
         let name = &owner_ref.name;
 
@@ -190,7 +201,7 @@ impl OwnerRelationsManager {
                     .into_iter()
                     .find(|obj| obj.name_any() == *name)
                     .map(|obj| {
-                        let meta = K8sObjectMeta::from(obj.as_ref());
+                        let meta = K8sObjectMeta::from_resource(obj.as_ref(), extract_fn);
                         let next_owners = obj.meta().owner_references.clone();
                         (WorkloadOwner::$variant(meta), next_owners)
                     })

--- a/mermin/src/k8s/selector_relations.rs
+++ b/mermin/src/k8s/selector_relations.rs
@@ -85,6 +85,7 @@ impl SelectorRelationsManager {
         pod_labels: &BTreeMap<String, String>,
         pod_namespace: &str,
         store: &ResourceStore,
+        extract_fn: impl Fn(&str, &str) -> bool,
     ) -> Option<Vec<K8sObjectMeta>> {
         let mut related = Vec::new();
 
@@ -101,6 +102,7 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 "service" => {
@@ -109,6 +111,7 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 "replicaset" => {
@@ -117,6 +120,7 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 "deployment" => {
@@ -125,6 +129,7 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 "statefulset" => {
@@ -133,6 +138,7 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 "daemonset" => {
@@ -141,10 +147,17 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 "job" => {
-                    related.extend(self.find_matching_jobs(pod_labels, pod_namespace, rule, store));
+                    related.extend(self.find_matching_jobs(
+                        pod_labels,
+                        pod_namespace,
+                        rule,
+                        store,
+                        &extract_fn,
+                    ));
                 }
                 "cronjob" => {
                     related.extend(self.find_matching_cronjobs(
@@ -152,6 +165,7 @@ impl SelectorRelationsManager {
                         pod_namespace,
                         rule,
                         store,
+                        &extract_fn,
                     ));
                 }
                 _ => {
@@ -177,6 +191,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<NetworkPolicy>(pod_namespace)
@@ -184,7 +199,7 @@ impl SelectorRelationsManager {
             .filter_map(|policy| {
                 let selector = self.extract_selector_from_network_policy(policy, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(policy.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(policy.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -195,6 +210,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<Service>(pod_namespace)
@@ -202,7 +218,7 @@ impl SelectorRelationsManager {
             .filter_map(|service| {
                 let selector = self.extract_selector_from_service(service, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(service.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(service.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -250,6 +266,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<ReplicaSet>(pod_namespace)
@@ -257,7 +274,7 @@ impl SelectorRelationsManager {
             .filter_map(|rs| {
                 let selector = self.extract_selector_from_replicaset(rs, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(rs.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(rs.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -281,6 +298,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<Deployment>(pod_namespace)
@@ -288,7 +306,7 @@ impl SelectorRelationsManager {
             .filter_map(|deployment| {
                 let selector = self.extract_selector_from_deployment(deployment, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(deployment.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(deployment.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -312,6 +330,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<StatefulSet>(pod_namespace)
@@ -319,7 +338,7 @@ impl SelectorRelationsManager {
             .filter_map(|sts| {
                 let selector = self.extract_selector_from_statefulset(sts, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(sts.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(sts.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -343,6 +362,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<DaemonSet>(pod_namespace)
@@ -350,7 +370,7 @@ impl SelectorRelationsManager {
             .filter_map(|ds| {
                 let selector = self.extract_selector_from_daemonset(ds, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(ds.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(ds.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -374,6 +394,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<Job>(pod_namespace)
@@ -381,7 +402,7 @@ impl SelectorRelationsManager {
             .filter_map(|job| {
                 let selector = self.extract_selector_from_job(job, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(job.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(job.as_ref(), extract_fn))
             })
             .collect()
     }
@@ -401,6 +422,7 @@ impl SelectorRelationsManager {
         pod_namespace: &str,
         rule: &NormalizedRule,
         store: &ResourceStore,
+        extract_fn: &impl Fn(&str, &str) -> bool,
     ) -> Vec<K8sObjectMeta> {
         store
             .get_by_namespace::<CronJob>(pod_namespace)
@@ -408,7 +430,7 @@ impl SelectorRelationsManager {
             .filter_map(|cronjob| {
                 let selector = self.extract_selector_from_cronjob(cronjob, rule)?;
                 self.selector_matches(&selector, pod_labels)
-                    .then(|| K8sObjectMeta::from(cronjob.as_ref()))
+                    .then(|| K8sObjectMeta::from_resource(cronjob.as_ref(), extract_fn))
             })
             .collect()
     }


### PR DESCRIPTION
#### Description
This PR introduces the necessary changes for the Kubernetes decoration optimization plan. The primary goal is to eliminate expensive dynamic string formatting and memory allocations in the flow decoration's "hot path" by refactoring how Kubernetes metadata extraction rules are stored and queried.

Previously, `should_extract` performed `format!("{resource}.metadata.{field}")` for every check, leading to significant overhead. This change replaces the flat `HashSet` with a nested `HashMap<String, HashSet<String>>`, allowing for O(1) lookups without transient string allocations.

#### Changes
- **Refactored `expand_extract_rules`**: Now returns a nested `HashMap<String, HashSet<String>>` for resource-specific rules (e.g., `"pod" -> {"name", "uid"}`) and a separate `HashSet` for wildcard rules (`[*].metadata.field`).
- **Optimized `Decorator` Struct**: Updated to store these pre-compiled nested maps for both source and destination extraction.
- **Improved `should_extract`**: Replaced string formatting logic with a two-step lookup: first checking the wildcard set, then performing a keyed lookup in the resource-specific map.
- **Added Comprehensive Unit Tests**: 
    - `test_expand_extract_rules`: Verifies correct parsing and nesting of rules.
    - `test_should_extract`: Validates the lookup logic for specific and wildcard rules.
    - `test_should_extract_with_uncommon_resources`: Ensures that the optimization correctly handles Services, Deployments, and Custom Resources, maintaining full functional parity with the original implementation.


#### Testing
- **Unit Tests**: Executed all unit tests successfully.
- **Verification**: Confirmed that the new logic correctly respects both wildcard (`[*]`) and specific resource rules for all Kubernetes object types.
- **Deploy**: Verified an improvement in the duration of the decoration through a deploy in the stage environment by comparing its dashboards.

## Proof it works

### Default config in dst
<img width="1023" height="608" alt="Screenshot 2026-03-31 at 3 20 25 PM" src="https://github.com/user-attachments/assets/32b3f482-b3c5-452d-bfdd-f608d48c3040" />

### Configuration defined
<img width="1032" height="1024" alt="Screenshot 2026-04-06 at 1 15 10 PM" src="https://github.com/user-attachments/assets/3aeb14eb-3c4c-4e3b-8313-f8734c045349" />
