### PR TITLE
fix(ci): Bump the `create-pull-request` GHA

### DIFF
--- a/.github/workflows/release_mermin.yaml
+++ b/.github/workflows/release_mermin.yaml
@@ -73,7 +73,7 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"${{ steps.prepare_release.outputs.new_release_version }}\"/" mermin/Cargo.toml
       - name: Create Pull Request
         if: ${{ fromJson(steps.prepare_release.outputs.new_release_published) }}
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: "${{ github.ref_name }}"

--- a/.github/workflows/reusable_release_chart.yaml
+++ b/.github/workflows/reusable_release_chart.yaml
@@ -93,7 +93,7 @@ jobs:
           bump_version_yaml_key: "${{ inputs.chart_yaml_version_keys }}"
       - name: Create Pull Request
         if: ${{ fromJson(steps.prepare_release.outputs.new_release_published) }}
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: "${{ github.ref_name }}"


### PR DESCRIPTION
Bump the `create-pull-request` GHA to `8.1.0`
- resolve `400` status code on PR creation
- resolve deprecated Node.js 20

## Testing

N/A

## Proof it works

N/A
