### PR TITLE
fix(ci): Bump the `Cargo.lock` when releasing Mermin

### DIFF
--- a/.github/workflows/release_mermin.yaml
+++ b/.github/workflows/release_mermin.yaml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ fromJson(steps.prepare_release.outputs.new_release_published) }}
         run: |
           sed -i "s/^version = \".*\"/version = \"${{ steps.prepare_release.outputs.new_release_version }}\"/" mermin/Cargo.toml
-          cargo update mermin
+          cargo update -v mermin
       - name: Create Pull Request
         if: ${{ fromJson(steps.prepare_release.outputs.new_release_published) }}
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0


### PR DESCRIPTION
Currently, on release, only the `mermin/Cargo.toml` version is bumped; however, the Mermin version in `Cargo.lock` is unchanged.

## Testing

Locally with `cargo update -v mermin`

## Proof it works

<!-- Logs, screenshots, or test output -->
