### PR TITLE
fix(ci): Workaround build timeout

### DIFF
--- a/.github/workflows/release_mermin.yaml
+++ b/.github/workflows/release_mermin.yaml
@@ -135,7 +135,7 @@ jobs:
     needs: [release]
     if: ${{ fromJson(needs.release.outputs.new_release_published) }}
     runs-on: ubuntu-latest-8c
-    timeout-minutes: 90
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
ARM builds may take really long time when fully rebuilding, as a workaround increase timeout to 2h

<!-- Briefly describe the change this PR introduces and why -->

## Changes

<!-- List the sum of your commit message bodies here -->

Fixes #(issue)

## Testing

<!-- How did you test this? What environment? -->

## Proof it works

<!-- Logs, screenshots, or test output -->
