### PR TITLE
fix(ci): Increase TTL for the GCP AR token

### DIFF
--- a/.github/workflows/release_mermin.yaml
+++ b/.github/workflows/release_mermin.yaml
@@ -162,7 +162,7 @@ jobs:
           project_id: "pub-artifacts-j8rjbu"
           workload_identity_provider: "projects/701687754822/locations/global/workloadIdentityPools/github-actions/providers/github-actions"
           service_account: "gha-registry-writer@pub-artifacts-j8rjbu.iam.gserviceaccount.com"
-          access_token_lifetime: 5400s
+          access_token_lifetime: 7200s
       - name: Login to GCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:

--- a/.github/workflows/release_mermin.yaml
+++ b/.github/workflows/release_mermin.yaml
@@ -139,6 +139,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      artifact-metadata: write
       attestations: write
       id-token: write
     strategy:


### PR DESCRIPTION
Increase TTL for the GCP AR token in order to push cache for slow builds

<!-- Briefly describe the change this PR introduces and why -->

## Changes

<!-- List the sum of your commit message bodies here -->

Fixes #(issue)

## Testing

<!-- How did you test this? What environment? -->

## Proof it works

<!-- Logs, screenshots, or test output -->
