### PR TITLE
fix: remove deps that do not bring much value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,12 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,7 +251,7 @@ checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "libc",
  "log",
@@ -354,12 +348,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -406,12 +394,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "bytesize"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "camino"
@@ -548,7 +530,6 @@ dependencies = [
 name = "common-build"
 version = "0.1.0"
 dependencies = [
- "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
 ]
 
@@ -901,17 +882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,15 +928,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "futures"
@@ -1577,26 +1538,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ip_network"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,26 +1680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,24 +1818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libredox"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "plain",
- "redox_syscall 0.7.3",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,15 +1890,12 @@ dependencies = [
 name = "mermin"
 version = "0.3.6"
 dependencies = [
- "anyhow",
  "arc-swap",
- "arrayvec",
  "async-trait",
  "axum 0.7.9",
  "aya",
  "aya-build",
  "base64 0.21.7",
- "bytesize",
  "clap",
  "common-build",
  "crossbeam",
@@ -2015,17 +1915,12 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
- "lazy_static",
  "libc",
- "log",
  "mermin-common",
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
  "nix",
- "notify",
- "num-iter",
- "num-traits",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-stdout",
@@ -2042,7 +1937,6 @@ dependencies = [
  "sha1",
  "socket2 0.5.10",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tower-http 0.5.2",
@@ -2063,7 +1957,6 @@ version = "0.1.0"
 dependencies = [
  "aya-ebpf",
  "mermin-common",
- "which",
 ]
 
 [[package]]
@@ -2071,18 +1964,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "mio"
@@ -2127,7 +2008,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "log",
  "netlink-packet-core",
@@ -2150,7 +2031,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2164,51 +2045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
-name = "notify"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.11.0",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio 0.8.11",
- "walkdir",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -2244,7 +2086,7 @@ version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2408,7 +2250,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2538,12 +2380,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnet"
@@ -2870,16 +2706,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2988,27 +2815,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -3097,15 +2911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3159,7 +2964,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3172,7 +2977,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3469,7 +3274,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3493,7 +3298,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3579,7 +3384,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -3789,7 +3594,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "http",
  "http-body",
@@ -3807,7 +3612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -3998,16 +3803,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,7 +3922,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4154,18 +3949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "6.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
-dependencies = [
- "either",
- "home",
- "rustix 0.38.44",
- "winsafe",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,15 +3963,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -4233,27 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4274,21 +4030,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4326,12 +4067,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4344,12 +4079,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4359,12 +4088,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4392,12 +4115,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4407,12 +4124,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4428,12 +4139,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4443,12 +4148,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4470,12 +4169,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"
@@ -4535,7 +4228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,9 @@ default-members = ["mermin", "mermin-common"]
 license = "Apache-2.0"
 
 [workspace.dependencies]
-anyhow = { version = "1", default-features = false }
 aya = { version = "0.13.1", default-features = false }
 aya-build = { git = "https://github.com/aya-rs/aya", rev = "a7e3e6d4d90767d40a015a473a7d0623031ff6ee", default-features = false }
 aya-ebpf = { version = "0.1.1", default-features = false }
-clap = { version = "4.5.42", default-features = false, features = ["std"] }
-env_logger = { version = "0.11.5", default-features = false }
-libc = { version = "0.2.159", default-features = false }
-log = { version = "0.4.22", default-features = false }
-thiserror = { version = "2.0", default-features = false }
-tokio = { version = "1.40.0", default-features = false }
-toml = { version = "0.9.5", default-features = false, features = ["parse", "serde"] }
-which = { version = "6.0.0", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN useradd --create-home --shell /bin/bash poseidon \
 RUN sed -i 's/sha1.second_preimage_resistance = 2026-02-01/sha1.second_preimage_resistance = 2026-04-01/' /usr/share/apt/default-sequoia.config
 # hadolint ignore=DL3059 # multi-stage build, more RUN -> better caching
 RUN wget -q https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh && chmod +x /tmp/llvm.sh \
-    && /tmp/llvm.sh 20 all
+    && /tmp/llvm.sh 20
 
 # Install eBPF Dependencies
 # hadolint ignore=DL3059,DL3008 # multi-stage build, more RUN -> better caching, not pinning versions for now

--- a/common-build/Cargo.toml
+++ b/common-build/Cargo.toml
@@ -5,5 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-thiserror = { workspace = true }
 toml = "0.9"

--- a/common-build/src/error.rs
+++ b/common-build/src/error.rs
@@ -1,33 +1,55 @@
-use std::path::PathBuf;
-
-use thiserror::Error;
+use std::{error::Error, fmt, path::PathBuf};
 
 /// Errors that can occur during build operations
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum BuildError {
-    /// Failed to read toolchain file
-    #[error("failed to read toolchain file at {path}: {source}")]
+    /// Failed to read toolchain file.
     ToolchainFileRead {
         path: PathBuf,
-        #[source]
         source: std::io::Error,
     },
-
-    /// Failed to parse toolchain file
-    #[error("failed to parse toolchain file: {0}")]
+    /// Failed to parse toolchain file.
     ToolchainFileParse(String),
-
-    /// Missing required field in toolchain file
-    #[error("missing required field '{field}' in toolchain file")]
+    /// Missing required field in toolchain file.
     MissingToolchainField { field: String },
-
-    /// Invalid toolchain channel value
-    #[error("invalid toolchain channel value: {0}")]
+    /// Invalid toolchain channel value.
     InvalidToolchainChannel(String),
+    /// TOML deserialization error.
+    TomlParse(toml::de::Error),
+}
 
-    /// TOML parsing error
-    #[error("TOML parsing error: {0}")]
-    TomlParse(#[from] toml::de::Error),
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ToolchainFileRead { path, .. } => {
+                write!(f, "failed to read toolchain file at {}", path.display())
+            }
+            Self::ToolchainFileParse(msg) => write!(f, "failed to parse toolchain file: {msg}"),
+            Self::MissingToolchainField { field } => {
+                write!(f, "missing required field '{field}' in toolchain file")
+            }
+            Self::InvalidToolchainChannel(val) => {
+                write!(f, "invalid toolchain channel value: {val}")
+            }
+            Self::TomlParse(err) => write!(f, "TOML parsing error: {err}"),
+        }
+    }
+}
+
+impl Error for BuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ToolchainFileRead { source, .. } => Some(source),
+            Self::TomlParse(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<toml::de::Error> for BuildError {
+    fn from(err: toml::de::Error) -> Self {
+        Self::TomlParse(err)
+    }
 }
 
 impl BuildError {

--- a/mermin-ebpf/Cargo.toml
+++ b/mermin-ebpf/Cargo.toml
@@ -14,6 +14,3 @@ test = []
 
 aya-ebpf = { workspace = true }
 mermin-common = { path = "../mermin-common" }
-
-[build-dependencies]
-which = { workspace = true }

--- a/mermin-ebpf/build.rs
+++ b/mermin-ebpf/build.rs
@@ -1,17 +1,37 @@
-use which::which;
+//! Building this crate has an undeclared dependency on the `bpf-linker` binary. This would be
+//! better expressed by [artifact-dependencies][bindeps] but issues such as
+//! https://github.com/rust-lang/cargo/issues/12385 make their use impractical for the time being.
+//!
+//! This file implements an imperfect solution: it causes cargo to rebuild the crate whenever the
+//! mtime of `which bpf-linker` changes. Note that possibility that a new bpf-linker is added to
+//! $PATH ahead of the one used as the cache key still exists. Solving this in the general case
+//! would require rebuild-if-changed-env=PATH *and* rebuild-if-changed={every-directory-in-PATH}
+//! which would likely mean far too much cache invalidation.
+//!
+//! [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
 
-/// Building this crate has an undeclared dependency on the `bpf-linker` binary. This would be
-/// better expressed by [artifact-dependencies][bindeps] but issues such as
-/// https://github.com/rust-lang/cargo/issues/12385 make their use impractical for the time being.
-///
-/// This file implements an imperfect solution: it causes cargo to rebuild the crate whenever the
-/// mtime of `which bpf-linker` changes. Note that possibility that a new bpf-linker is added to
-/// $PATH ahead of the one used as the cache key still exists. Solving this in the general case
-/// would require rebuild-if-changed-env=PATH *and* rebuild-if-changed={every-directory-in-PATH}
-/// which would likely mean far too much cache invalidation.
-///
-/// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
 fn main() {
-    let bpf_linker = which("bpf-linker").unwrap();
-    println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+    let bpf_linker = std::env::var_os("PATH")
+        .and_then(|path_var| {
+            std::env::split_paths(&path_var)
+                .map(|dir| dir.join("bpf-linker"))
+                .find(|p| is_executable(p))
+        })
+        .expect("bpf-linker not found in PATH");
+
+    println!("cargo:rerun-if-changed={}", bpf_linker.display());
+}
+
+fn is_executable(path: &std::path::Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
 }

--- a/mermin/Cargo.toml
+++ b/mermin/Cargo.toml
@@ -19,8 +19,7 @@ async-trait = "0.1.88"
 axum = "0.7"
 aya = { workspace = true, features = ["async_tokio"] }
 base64 = "0.21"
-bytesize = "1.3"
-clap = { workspace = true, features = ["derive", "env", "help", "suggestions", "usage"] }
+clap = { version = "4.5.42", default-features = false, features = ["std", "derive", "env", "help", "suggestions", "usage"] }
 crossbeam = "0.8"
 dashmap = { version = "6.0", features = ["raw-api"] }
 figment = { version = "0.10", features = ["env", "test", "yaml"] }
@@ -37,17 +36,12 @@ jsonpath-rust = "1.0.4"
 k8s-openapi = { version = "0.25.0", features = ["v1_30"] }
 kube = { version = "1.1.0", features = ["runtime", "derive", "client"] }
 kube-runtime = "1.1.0"
-lazy_static = "1.4"
-libc = { workspace = true }
-log = { workspace = true }
+libc = { version = "0.2.159", default-features = false }
 mermin-common = { path = "../mermin-common", features = ["user"] }
-notify = "6.1"
 netlink-packet-core = "0.8.1"
 netlink-packet-route = "0.25.1"
 netlink-sys = "0.8.7"
-nix = { version = "0.30.1", features = ["hostname", "net", "sched"] }
-num-iter = "0.1.45"
-num-traits = "0.2.19"
+nix = { version = "0.30.1", features = ["hostname", "net", "sched", "inotify"] }
 opentelemetry = { version = "0.31.0" }
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "http-proto", "reqwest-client", "reqwest-rustls"] }
 opentelemetry-stdout = "0.31.0"
@@ -61,25 +55,22 @@ rustls-pemfile = "2.2"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = "1.0.142"
 sha1 = "0.10"
-thiserror = { workspace = true }
-tokio = { workspace = true, features = [
+tokio = { version = "1.40.0", default-features = false, features = [
     "full",
     "macros",
     "rt",
     "rt-multi-thread",
     "net",
     "signal",
-    "time"
+    "time",
 ] }
 tonic = { version = "0.14.2", features = ["transport"] }
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 http = "1.3.1"
-arrayvec = "0.7.6"
 
 [build-dependencies]
-anyhow = { workspace = true }
 aya-build = { workspace = true }
 common-build = { path = "../common-build" }
 

--- a/mermin/build.rs
+++ b/mermin/build.rs
@@ -1,25 +1,23 @@
-use anyhow::{Context as _, anyhow};
 use aya_build::{Toolchain, cargo_metadata};
 use common_build::get_toolchain_channel;
 
 const EBPF_PACKAGE_NAME: &str = "mermin-ebpf";
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let meta = cargo_metadata::MetadataCommand::new().exec()?;
     let workspace_root = &meta.workspace_root;
 
     let channel = get_toolchain_channel(workspace_root.as_ref())?;
     let toolchain = Toolchain::Custom(&channel);
 
-    let cargo_metadata::Metadata { packages, .. } = cargo_metadata::MetadataCommand::new()
-        .no_deps()
-        .exec()
-        .context("MetadataCommand::exec")?;
+    let cargo_metadata::Metadata { packages, .. } =
+        cargo_metadata::MetadataCommand::new().no_deps().exec()?;
 
     let ebpf_package = packages
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| **name == EBPF_PACKAGE_NAME)
-        .ok_or_else(|| anyhow!("mermin-ebpf package not found"))?;
+        .ok_or("mermin-ebpf package not found")?;
 
-    aya_build::build_ebpf([ebpf_package], toolchain)
+    aya_build::build_ebpf([ebpf_package], toolchain)?;
+    Ok(())
 }

--- a/mermin/src/error.rs
+++ b/mermin/src/error.rs
@@ -1,41 +1,110 @@
-use thiserror::Error;
+use std::{error::Error, fmt};
 
 use crate::{
     health::error::HealthError, k8s::K8sError, otlp::error::OtlpError, runtime::conf::ConfError,
     span::producer::BootTimeError,
 };
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum MerminError {
-    #[error("kubernetes error: {0}")]
-    K8s(#[from] K8sError),
-
-    #[error("OTLP error: {0}")]
-    Otlp(#[from] OtlpError),
-
-    #[error("health check error: {0}")]
-    Health(#[from] HealthError),
-
-    #[error("configuration error: {0}")]
-    Conf(#[from] ConfError),
-
-    #[error("boot time error: {0}")]
-    BootTime(#[from] BootTimeError),
-
-    #[error("failed to load eBPF program: {0}")]
-    EbpfLoad(#[from] aya::EbpfError),
-
-    #[error("eBPF program error: {0}")]
-    EbpfProgram(#[from] aya::programs::ProgramError),
-
-    #[error("eBPF map conversion error: {0}")]
-    EbpfMapConversion(#[from] aya::maps::MapError),
-
-    #[error("signal handling error: {0}")]
-    Signal(#[from] std::io::Error),
-
-    #[error("internal error: {0}")]
+    K8s(K8sError),
+    Otlp(OtlpError),
+    Health(HealthError),
+    Conf(ConfError),
+    BootTime(BootTimeError),
+    EbpfLoad(aya::EbpfError),
+    EbpfProgram(aya::programs::ProgramError),
+    EbpfMapConversion(aya::maps::MapError),
+    Signal(std::io::Error),
     Internal(String),
+}
+
+impl fmt::Display for MerminError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::K8s(e) => write!(f, "kubernetes error: {e}"),
+            Self::Otlp(e) => write!(f, "OTLP error: {e}"),
+            Self::Health(e) => write!(f, "health check error: {e}"),
+            Self::Conf(e) => write!(f, "configuration error: {e}"),
+            Self::BootTime(e) => write!(f, "boot time error: {e}"),
+            Self::EbpfLoad(e) => write!(f, "failed to load eBPF program: {e}"),
+            Self::EbpfProgram(e) => write!(f, "eBPF program error: {e}"),
+            Self::EbpfMapConversion(e) => write!(f, "eBPF map conversion error: {e}"),
+            Self::Signal(e) => write!(f, "signal handling error: {e}"),
+            Self::Internal(msg) => write!(f, "internal error: {msg}"),
+        }
+    }
+}
+
+impl Error for MerminError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::K8s(e) => Some(e),
+            Self::Otlp(e) => Some(e),
+            Self::Health(e) => Some(e),
+            Self::Conf(e) => Some(e),
+            Self::BootTime(e) => Some(e),
+            Self::EbpfLoad(e) => Some(e),
+            Self::EbpfProgram(e) => Some(e),
+            Self::EbpfMapConversion(e) => Some(e),
+            Self::Signal(e) => Some(e),
+            Self::Internal(_) => None,
+        }
+    }
+}
+
+impl From<K8sError> for MerminError {
+    fn from(e: K8sError) -> Self {
+        Self::K8s(e)
+    }
+}
+
+impl From<OtlpError> for MerminError {
+    fn from(e: OtlpError) -> Self {
+        Self::Otlp(e)
+    }
+}
+
+impl From<HealthError> for MerminError {
+    fn from(e: HealthError) -> Self {
+        Self::Health(e)
+    }
+}
+
+impl From<ConfError> for MerminError {
+    fn from(e: ConfError) -> Self {
+        Self::Conf(e)
+    }
+}
+
+impl From<BootTimeError> for MerminError {
+    fn from(e: BootTimeError) -> Self {
+        Self::BootTime(e)
+    }
+}
+
+impl From<aya::EbpfError> for MerminError {
+    fn from(e: aya::EbpfError) -> Self {
+        Self::EbpfLoad(e)
+    }
+}
+
+impl From<aya::programs::ProgramError> for MerminError {
+    fn from(e: aya::programs::ProgramError) -> Self {
+        Self::EbpfProgram(e)
+    }
+}
+
+impl From<aya::maps::MapError> for MerminError {
+    fn from(e: aya::maps::MapError) -> Self {
+        Self::EbpfMapConversion(e)
+    }
+}
+
+impl From<std::io::Error> for MerminError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Signal(e)
+    }
 }
 
 impl MerminError {

--- a/mermin/src/filter/source.rs
+++ b/mermin/src/filter/source.rs
@@ -21,8 +21,6 @@ use mermin_common::{
     },
     ip::{IpDscp, IpEcn, IpProto},
 };
-use num_iter::range_inclusive;
-use num_traits::PrimInt;
 use tracing::{error, warn};
 
 use crate::{
@@ -31,6 +29,38 @@ use crate::{
     runtime::conf::Conf,
     span::tcp::TcpFlags,
 };
+
+/// Private trait for integer types usable as numeric filter values.
+///
+/// Implemented for the specific widths used in filter dimensions:
+/// ports (`u16`), TTL/protocol numbers (`u8`), interface indices and flow labels (`u32`).
+trait NumericId: Copy + FromStr + std::hash::Hash + Eq + PartialOrd {
+    fn one() -> Self;
+    fn checked_add(self, rhs: Self) -> Option<Self>;
+}
+
+macro_rules! impl_numeric_id {
+    ($($t:ty),+) => {
+        $(impl NumericId for $t {
+            fn one() -> Self { 1 }
+            fn checked_add(self, rhs: Self) -> Option<Self> {
+                <$t>::checked_add(self, rhs)
+            }
+        })+
+    };
+}
+
+impl_numeric_id!(u8, u16, u32);
+
+fn range_inclusive<T: NumericId>(start: T, end: T) -> impl Iterator<Item = T> {
+    std::iter::successors(Some(start), move |&n| {
+        if n < end {
+            n.checked_add(T::one())
+        } else {
+            None
+        }
+    })
+}
 
 /// Helper macro to check if a packet/flow passes a filter rule.
 ///
@@ -81,7 +111,7 @@ impl CompiledRules {
 
         fn build_numeric_pair<T>(pair: &FilteringPair) -> CompiledRuleSet<HashSet<T>>
         where
-            T: PrimInt + FromStr + std::hash::Hash + Eq,
+            T: NumericId,
             <T as FromStr>::Err: std::fmt::Debug,
         {
             CompiledRuleSet {
@@ -186,7 +216,7 @@ fn build_ip_network_table(list: &[String]) -> IpNetworkTable<()> {
 /// with `-` (e.g. `"8000-8002"` expands to `{8000, 8001, 8002}`).
 fn build_numeric_set<T>(list: &[String]) -> HashSet<T>
 where
-    T: PrimInt + FromStr + std::hash::Hash + Eq,
+    T: NumericId,
     <T as FromStr>::Err: std::fmt::Debug,
 {
     let mut set = HashSet::new();

--- a/mermin/src/health/error.rs
+++ b/mermin/src/health/error.rs
@@ -1,38 +1,50 @@
-use thiserror::Error;
+use std::{error::Error, fmt};
 
-/// Errors that can occur during health check operations
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum HealthError {
-    /// Failed to bind API server to address
-    #[error("failed to bind API server to {address}: {source}")]
     BindAddress {
         address: String,
-        #[source]
         source: std::io::Error,
     },
-
-    /// Failed to start API server
-    #[error("failed to start API server: {0}")]
     #[allow(dead_code)]
-    ServerStart(#[source] std::io::Error),
-
-    /// Failed to serve requests
-    #[error("failed to serve requests: {0}")]
-    ServeError(#[source] std::io::Error),
-
-    /// Health check state inconsistent
-    #[error("health check state is inconsistent: {0}")]
+    ServerStart(std::io::Error),
+    ServeError(std::io::Error),
     #[allow(dead_code)]
     InconsistentState(String),
-
-    /// Router configuration error
-    #[error("failed to configure health router: {0}")]
     #[allow(dead_code)]
     RouterConfiguration(String),
 }
 
+impl fmt::Display for HealthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BindAddress { address, source } => {
+                write!(f, "failed to bind API server to {address}: {source}")
+            }
+            Self::ServerStart(e) => write!(f, "failed to start API server: {e}"),
+            Self::ServeError(e) => write!(f, "failed to serve requests: {e}"),
+            Self::InconsistentState(msg) => {
+                write!(f, "health check state is inconsistent: {msg}")
+            }
+            Self::RouterConfiguration(msg) => {
+                write!(f, "failed to configure health router: {msg}")
+            }
+        }
+    }
+}
+
+impl Error for HealthError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::BindAddress { source, .. } => Some(source),
+            Self::ServerStart(e) => Some(e),
+            Self::ServeError(e) => Some(e),
+            Self::InconsistentState(_) | Self::RouterConfiguration(_) => None,
+        }
+    }
+}
+
 impl HealthError {
-    /// Create a bind address error
     pub fn bind_address(address: impl Into<String>, source: std::io::Error) -> Self {
         Self::BindAddress {
             address: address.into(),

--- a/mermin/src/k8s/error.rs
+++ b/mermin/src/k8s/error.rs
@@ -1,24 +1,52 @@
-use std::fmt;
+use std::{error::Error, fmt};
 
-use thiserror::Error;
-
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum K8sError {
-    #[error("failed to initialize Kubernetes client: {0}")]
-    ClientInitialization(#[source] Box<kube::Error>),
-
-    #[error("failed to list {resource}: {source}")]
+    ClientInitialization(Box<kube::Error>),
     ResourceList {
         resource: String,
-        #[source]
         source: Box<kube::Error>,
     },
-
-    #[error("failed to create critical reflector for {resource}: {details}")]
-    CriticalReflectorFailure { resource: String, details: String },
-
-    #[error("failed to attribute flow with Kubernetes metadata: {0}")]
+    CriticalReflectorFailure {
+        resource: String,
+        details: String,
+    },
     Attribution(String),
+}
+
+impl fmt::Display for K8sError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ClientInitialization(e) => {
+                write!(f, "failed to initialize Kubernetes client: {e}")
+            }
+            Self::ResourceList { resource, source } => {
+                write!(f, "failed to list {resource}: {source}")
+            }
+            Self::CriticalReflectorFailure { resource, details } => {
+                write!(
+                    f,
+                    "failed to create critical reflector for {resource}: {details}"
+                )
+            }
+            Self::Attribution(msg) => {
+                write!(
+                    f,
+                    "failed to attribute flow with Kubernetes metadata: {msg}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for K8sError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ClientInitialization(e) => Some(e.as_ref()),
+            Self::ResourceList { source, .. } => Some(source.as_ref()),
+            Self::CriticalReflectorFailure { .. } | Self::Attribution(_) => None,
+        }
+    }
 }
 
 impl K8sError {

--- a/mermin/src/metrics/registry.rs
+++ b/mermin/src/metrics/registry.rs
@@ -3,9 +3,8 @@
 //! This module defines all Prometheus metrics used by Mermin and provides
 //! a centralized registry for metric collection.
 
-use std::sync::OnceLock;
+use std::sync::{LazyLock, OnceLock};
 
-use lazy_static::lazy_static;
 use prometheus::{
     Histogram, HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Opts, Registry,
 };
@@ -346,232 +345,399 @@ impl HistogramBucketConfig {
     }
 }
 
-lazy_static! {
-    /// Global Prometheus registry for all Mermin metrics (standard + debug).
-    pub static ref REGISTRY: Registry = Registry::new();
+/// Global Prometheus registry for all Mermin metrics (standard + debug).
+pub static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
-    /// Registry for standard metrics only (no high-cardinality labels).
-    pub static ref STANDARD_REGISTRY: Registry = Registry::new();
+/// Registry for standard metrics only (no high-cardinality labels).
+pub static STANDARD_REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
-    /// Registry for debug metrics only (high-cardinality labels).
-    pub static ref DEBUG_REGISTRY: Registry = Registry::new();
+/// Registry for debug metrics only (high-cardinality labels).
+pub static DEBUG_REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new);
 
-    pub static ref EBPF_MAP_SIZE: IntGaugeVec = IntGaugeVec::new(
+pub static EBPF_MAP_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
         Opts::new("map_size", "Current size of eBPF maps. For hash maps (FLOW_STATS, LISTENING_PORTS) this is the entry count. For ring buffers (FLOW_EVENTS) this is pending bytes (producer_pos - consumer_pos).")
             .namespace("mermin")
             .subsystem("ebpf"),
-        &["map", "unit"]
-    ).expect("failed to create ebpf_map_size metric");
+        &["map", "unit"],
+    )
+    .expect("failed to create ebpf_map_size metric")
+});
 
-    pub static ref EBPF_MAP_CAPACITY: IntGaugeVec = IntGaugeVec::new(
+pub static EBPF_MAP_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
         Opts::new("map_capacity", "Maximum capacity of eBPF maps. For hash maps (FLOW_STATS, LISTENING_PORTS) this is max entries. For ring buffers (FLOW_EVENTS) this is size in bytes.")
             .namespace("mermin")
             .subsystem("ebpf"),
-        &["map", "unit"]
-    ).expect("failed to create ebpf_map_capacity metric");
+        &["map", "unit"],
+    )
+    .expect("failed to create ebpf_map_capacity metric")
+});
 
-    pub static ref EBPF_ATTACHMENT_MODE: IntGaugeVec = IntGaugeVec::new(
+pub static EBPF_ATTACHMENT_MODE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
         Opts::new("method", "Current eBPF attachment method used (tc or tcx)")
             .namespace("mermin")
             .subsystem("ebpf"),
-        &["attachment"]
-    ).expect("failed to create ebpf_method metric");
+        &["attachment"],
+    )
+    .expect("failed to create ebpf_method metric")
+});
 
-    pub static ref BPF_FS_WRITABLE: prometheus::IntGauge = prometheus::IntGauge::with_opts(
-        Opts::new("bpf_fs_writable", "Whether /sys/fs/bpf is writable for TCX link pinning (1 = writable, 0 = not writable)")
-            .namespace("mermin")
-            .subsystem("ebpf")
-    ).expect("failed to create ebpf_bpf_fs_writable metric");
+pub static BPF_FS_WRITABLE: LazyLock<prometheus::IntGauge> = LazyLock::new(|| {
+    prometheus::IntGauge::with_opts(
+        Opts::new(
+            "bpf_fs_writable",
+            "Whether /sys/fs/bpf is writable for TCX link pinning (1 = writable, 0 = not writable)",
+        )
+        .namespace("mermin")
+        .subsystem("ebpf"),
+    )
+    .expect("failed to create ebpf_bpf_fs_writable metric")
+});
 
-    pub static ref EBPF_MAP_OPS_TOTAL: IntCounterVec = IntCounterVec::new(
+pub static EBPF_MAP_OPS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
         Opts::new("map_ops_total", "Total number of eBPF map operations")
             .namespace("mermin")
             .subsystem("ebpf"),
-        &["map", "operation", "status"]
-    ).expect("failed to create ebpf_map_ops_total metric");
+        &["map", "operation", "status"],
+    )
+    .expect("failed to create ebpf_map_ops_total metric")
+});
 
-    pub static ref EBPF_ORPHANS_CLEANED_TOTAL: IntCounter = IntCounter::with_opts(
-        Opts::new("orphans_cleaned_total", "Total number of orphaned eBPF map entries cleaned up")
-            .namespace("mermin")
-            .subsystem("ebpf")
-    ).expect("failed to create ebpf_orphans_cleaned_total metric");
+pub static EBPF_ORPHANS_CLEANED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::with_opts(
+        Opts::new(
+            "orphans_cleaned_total",
+            "Total number of orphaned eBPF map entries cleaned up",
+        )
+        .namespace("mermin")
+        .subsystem("ebpf"),
+    )
+    .expect("failed to create ebpf_orphans_cleaned_total metric")
+});
 
-    pub static ref TC_PROGRAMS_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("tc_programs_total", "Total number of TC programs attached or detached across all interfaces")
-            .namespace("mermin")
-            .subsystem("ebpf"),
-        &["operation"]  // operation: "attached" | "detached"
-    ).expect("failed to create ebpf_tc_programs_total metric");
+pub static TC_PROGRAMS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "tc_programs_total",
+            "Total number of TC programs attached or detached across all interfaces",
+        )
+        .namespace("mermin")
+        .subsystem("ebpf"),
+        &["operation"], // operation: "attached" | "detached"
+    )
+    .expect("failed to create ebpf_tc_programs_total metric")
+});
 
-    pub static ref TC_PROGRAMS_ATTACHED_BY_INTERFACE_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("tc_programs_attached_by_interface_total", "Total number of TC programs attached by interface and direction")
-            .namespace("mermin")
-            .subsystem("ebpf"),
-        &["interface", "direction"]
-    ).expect("failed to create ebpf_tc_programs_attached_by_interface_total metric");
+pub static TC_PROGRAMS_ATTACHED_BY_INTERFACE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "tc_programs_attached_by_interface_total",
+            "Total number of TC programs attached by interface and direction",
+        )
+        .namespace("mermin")
+        .subsystem("ebpf"),
+        &["interface", "direction"],
+    )
+    .expect("failed to create ebpf_tc_programs_attached_by_interface_total metric")
+});
 
-    pub static ref TC_PROGRAMS_DETACHED_BY_INTERFACE_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("tc_programs_detached_by_interface_total", "Total number of TC programs detached by interface and direction")
-            .namespace("mermin")
-            .subsystem("ebpf"),
-        &["interface", "direction"]
-    ).expect("failed to create ebpf_tc_programs_detached_by_interface_total metric");
+pub static TC_PROGRAMS_DETACHED_BY_INTERFACE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "tc_programs_detached_by_interface_total",
+            "Total number of TC programs detached by interface and direction",
+        )
+        .namespace("mermin")
+        .subsystem("ebpf"),
+        &["interface", "direction"],
+    )
+    .expect("failed to create ebpf_tc_programs_detached_by_interface_total metric")
+});
 
-    pub static ref CHANNEL_CAPACITY: IntGaugeVec = IntGaugeVec::new(
+pub static CHANNEL_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
         Opts::new("capacity", "Capacity of internal channels")
             .namespace("mermin")
             .subsystem("channel"),
-        &["channel"]  // packet_worker, exporter
-    ).expect("failed to create capacity metric");
+        &["channel"], // packet_worker, exporter
+    )
+    .expect("failed to create capacity metric")
+});
 
-    pub static ref CHANNEL_ENTRIES: IntGaugeVec = IntGaugeVec::new(
+pub static CHANNEL_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
         Opts::new("entries", "Current number of items in channels")
             .namespace("mermin")
             .subsystem("channel"),
-        &["channel"]  // packet_worker, exporter
-    ).expect("failed to create entries metric");
+        &["channel"], // packet_worker, exporter
+    )
+    .expect("failed to create entries metric")
+});
 
-    pub static ref CHANNEL_SENDS_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("sends_total", "Total number of send operations to internal channels")
-            .namespace("mermin")
-            .subsystem("channel"),
-        &["channel", "status"]  // channel: packet_worker, producer_output, decorator_output; status: success, error, backpressure
-    ).expect("failed to create sends_total metric");
+pub static CHANNEL_SENDS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "sends_total",
+            "Total number of send operations to internal channels",
+        )
+        .namespace("mermin")
+        .subsystem("channel"),
+        &["channel", "status"], // channel: packet_worker, producer_output, decorator_output; status: success, error, backpressure
+    )
+    .expect("failed to create sends_total metric")
+});
 
-    pub static ref FLOW_SPANS_CREATED_TOTAL: IntCounter = IntCounter::with_opts(
-        Opts::new("spans_created_total", "Total number of flow spans created across all interfaces")
-            .namespace("mermin")
-            .subsystem("flow")
-    ).expect("failed to create flow_spans_created_total metric");
+pub static FLOW_SPANS_CREATED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::with_opts(
+        Opts::new(
+            "spans_created_total",
+            "Total number of flow spans created across all interfaces",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+    )
+    .expect("failed to create flow_spans_created_total metric")
+});
 
-    pub static ref FLOW_SPANS_ACTIVE_TOTAL: prometheus::IntGauge = prometheus::IntGauge::with_opts(
-        Opts::new("spans_active_total", "Current number of active flow traces across all interfaces")
-            .namespace("mermin")
-            .subsystem("flow")
-    ).expect("failed to create flow_spans_active_total metric");
+pub static FLOW_SPANS_ACTIVE_TOTAL: LazyLock<prometheus::IntGauge> = LazyLock::new(|| {
+    prometheus::IntGauge::with_opts(
+        Opts::new(
+            "spans_active_total",
+            "Current number of active flow traces across all interfaces",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+    )
+    .expect("failed to create flow_spans_active_total metric")
+});
 
-    pub static ref FLOW_SPAN_STORE_SIZE: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("span_store_size", "Current number of flows in flow_store per poller")
-            .namespace("mermin")
-            .subsystem("flow"),
-        &["poller_id"]
-    ).expect("failed to create flow_span_store_size metric");
+pub static FLOW_SPAN_STORE_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "span_store_size",
+            "Current number of flows in flow_store per poller",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+        &["poller_id"],
+    )
+    .expect("failed to create flow_span_store_size metric")
+});
 
-    pub static ref FLOW_SPANS_PROCESSED_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("spans_processed_total", "Total number of flow spans processed by FlowWorker per poller")
-            .namespace("mermin")
-            .subsystem("flow"),
-        &["poller_id"]
-    ).expect("failed to create flow_spans_processed_total metric");
+pub static FLOW_SPANS_PROCESSED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "spans_processed_total",
+            "Total number of flow spans processed by FlowWorker per poller",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+        &["poller_id"],
+    )
+    .expect("failed to create flow_spans_processed_total metric")
+});
 
-    pub static ref FLOW_EVENTS_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("events_total", "Total number of flow events processed by ring buffer stage")
-            .namespace("mermin")
-            .subsystem("flow"),
-        &["status"] // status: "received" | "filtered" | "dropped_backpressure" | "dropped_error"
-    ).expect("failed to create flow_events_total metric");
+pub static FLOW_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "events_total",
+            "Total number of flow events processed by ring buffer stage",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+        &["status"], // status: "received" | "filtered" | "dropped_backpressure" | "dropped_error"
+    )
+    .expect("failed to create flow_events_total metric")
+});
 
-    pub static ref FLOWS_CREATED_BY_INTERFACE_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("spans_created_by_interface_total", "Total number of flow spans created by interface")
-            .namespace("mermin")
-            .subsystem("flow"),
-        &["interface"]
-    ).expect("failed to create flow_spans_created_by_interface_total metric");
+pub static FLOWS_CREATED_BY_INTERFACE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "spans_created_by_interface_total",
+            "Total number of flow spans created by interface",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+        &["interface"],
+    )
+    .expect("failed to create flow_spans_created_by_interface_total metric")
+});
 
-    pub static ref FLOWS_ACTIVE_BY_INTERFACE_TOTAL: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("spans_active_by_interface_total", "Current number of active flow traces by interface")
-            .namespace("mermin")
-            .subsystem("flow"),
-        &["interface"]
-    ).expect("failed to create flow_spans_active_by_interface_total metric");
+pub static FLOWS_ACTIVE_BY_INTERFACE_TOTAL: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "spans_active_by_interface_total",
+            "Current number of active flow traces by interface",
+        )
+        .namespace("mermin")
+        .subsystem("flow"),
+        &["interface"],
+    )
+    .expect("failed to create flow_spans_active_by_interface_total metric")
+});
 
-    pub static ref PROCESSING_TOTAL: IntCounterVec = IntCounterVec::new(
+pub static PROCESSING_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
         Opts::new("processing_total", "Total number of flow spans processed by Flow Producer stage (aggregated across interfaces)")
             .namespace("mermin")
             .subsystem("flow"),
-        &["status"]
-    ).expect("failed to create processing_total metric");
+        &["status"],
+    )
+    .expect("failed to create processing_total metric")
+});
 
-    pub static ref FLOW_PRODUCER_QUEUE_SIZE: IntGaugeVec = IntGaugeVec::new(
-        Opts::new("queue_size", "Current number of flows queued for processing per poller")
+pub static FLOW_PRODUCER_QUEUE_SIZE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    IntGaugeVec::new(
+        Opts::new(
+            "queue_size",
+            "Current number of flows queued for processing per poller",
+        )
+        .namespace("mermin")
+        .subsystem("producer"),
+        &["poller_id"],
+    )
+    .expect("failed to create flow_producer_queue_size metric")
+});
+
+pub static FLOW_PRODUCER_FLOW_SPANS_BY_INTERFACE_TOTAL: LazyLock<IntCounterVec> =
+    LazyLock::new(|| {
+        IntCounterVec::new(
+            Opts::new(
+                "spans_by_interface_total",
+                "Total number of flow spans processed by producer workers by interface",
+            )
             .namespace("mermin")
             .subsystem("producer"),
-        &["poller_id"]
-    ).expect("failed to create flow_producer_queue_size metric");
+            &["interface", "status"],
+        )
+        .expect("failed to create flow_producer_flow_spans_by_interface_total metric")
+    });
 
-    pub static ref FLOW_PRODUCER_FLOW_SPANS_BY_INTERFACE_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("spans_by_interface_total", "Total number of flow spans processed by producer workers by interface")
-            .namespace("mermin")
-            .subsystem("producer"),
-        &["interface", "status"]
-    ).expect("failed to create flow_producer_flow_spans_by_interface_total metric");
+pub static EXPORT_FLOW_SPANS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "flow_spans_total",
+            "Total number of flow spans exported to external systems",
+        )
+        .namespace("mermin")
+        .subsystem("export"),
+        &["exporter", "status"], // exporter: "otlp" | "stdout", status: "ok" | "attempted" | "error" | "noop"
+    )
+    .expect("failed to create export_flow_spans_total metric")
+});
 
-    pub static ref EXPORT_FLOW_SPANS_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("flow_spans_total", "Total number of flow spans exported to external systems")
-            .namespace("mermin")
-            .subsystem("export"),
-        &["exporter", "status"] // exporter: "otlp" | "stdout", status: "ok" | "attempted" | "error" | "noop"
-    ).expect("failed to create export_flow_spans_total metric");
+pub static EXPORT_TIMEOUTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::with_opts(
+        Opts::new(
+            "timeouts_total",
+            "Total number of export operations that timed out",
+        )
+        .namespace("mermin")
+        .subsystem("export"),
+    )
+    .expect("failed to create export_timeouts_total metric")
+});
 
-    pub static ref EXPORT_TIMEOUTS_TOTAL: IntCounter = IntCounter::with_opts(
-        Opts::new("timeouts_total", "Total number of export operations that timed out")
-            .namespace("mermin")
-            .subsystem("export")
-    ).expect("failed to create export_timeouts_total metric");
+pub static K8S_DECORATOR_FLOW_SPANS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "flow_spans_total",
+            "Total number of flow spans processed by K8s decorator",
+        )
+        .namespace("mermin")
+        .subsystem("k8s_decorator"),
+        &["status"], // status: "dropped" | "ok" | "error" | "undecorated" | "excluded"
+    )
+    .expect("failed to create k8s_decorator_flow_spans_total metric")
+});
 
-    pub static ref K8S_DECORATOR_FLOW_SPANS_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("flow_spans_total", "Total number of flow spans processed by K8s decorator")
-            .namespace("mermin")
-            .subsystem("k8s_decorator"),
-        &["status"] // status: "dropped" | "ok" | "error" | "undecorated" | "excluded"
-    ).expect("failed to create k8s_decorator_flow_spans_total metric");
+pub static K8S_WATCHER_EVENTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "events_total",
+            "Total number of K8s kind watcher events (aggregated across resources)",
+        )
+        .namespace("mermin")
+        .subsystem("k8s_watcher"),
+        &["kind", "event"], // apply, delete, init, init_done, error
+    )
+    .expect("failed to create k8s_watcher_events_total metric")
+});
 
-    pub static ref K8S_WATCHER_EVENTS_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("events_total", "Total number of K8s kind watcher events (aggregated across resources)")
-            .namespace("mermin")
-            .subsystem("k8s_watcher"),
-        &["kind", "event"]  // apply, delete, init, init_done, error
-    ).expect("failed to create k8s_watcher_events_total metric");
+pub static SHUTDOWN_TIMEOUTS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::with_opts(
+        Opts::new(
+            "timeouts_total",
+            "Total number of shutdown operations that timed out",
+        )
+        .namespace("mermin")
+        .subsystem("shutdown"),
+    )
+    .expect("failed to create shutdown_timeouts metric")
+});
 
-    pub static ref SHUTDOWN_TIMEOUTS_TOTAL: IntCounter = IntCounter::with_opts(
-        Opts::new("timeouts_total", "Total number of shutdown operations that timed out")
-            .namespace("mermin")
-            .subsystem("shutdown")
-    ).expect("failed to create shutdown_timeouts metric");
-
-    pub static ref SHUTDOWN_FLOWS_TOTAL: IntCounterVec = IntCounterVec::new(
+pub static SHUTDOWN_FLOWS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
         Opts::new("flows_total", "Total flow spans processed during shutdown")
             .namespace("mermin")
             .subsystem("shutdown"),
-        &["status"]  // preserved, lost
-    ).expect("failed to create shutdown_flows_total metric");
+        &["status"], // preserved, lost
+    )
+    .expect("failed to create shutdown_flows_total metric")
+});
 
-    pub static ref PACKETS_TOTAL: IntCounter = IntCounter::with_opts(
-        Opts::new("packets_total", "Total number of packets processed across all interfaces")
-            .namespace("mermin")
-            .subsystem("interface")
-    ).expect("failed to create packets_total metric");
+pub static PACKETS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::with_opts(
+        Opts::new(
+            "packets_total",
+            "Total number of packets processed across all interfaces",
+        )
+        .namespace("mermin")
+        .subsystem("interface"),
+    )
+    .expect("failed to create packets_total metric")
+});
 
-    pub static ref BYTES_TOTAL: IntCounter = IntCounter::with_opts(
-        Opts::new("bytes_total", "Total number of bytes processed across all interfaces")
-            .namespace("mermin")
-            .subsystem("interface")
-    ).expect("failed to create bytes_total metric");
+pub static BYTES_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    IntCounter::with_opts(
+        Opts::new(
+            "bytes_total",
+            "Total number of bytes processed across all interfaces",
+        )
+        .namespace("mermin")
+        .subsystem("interface"),
+    )
+    .expect("failed to create bytes_total metric")
+});
 
-    pub static ref PACKETS_BY_INTERFACE_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("packets_by_interface_total", "Total number of packets processed by interface and direction")
-            .namespace("mermin")
-            .subsystem("interface"),
-        &["interface", "direction"]  // direction: ingress/egress
-    ).expect("failed to create packets_by_interface_total metric");
+pub static PACKETS_BY_INTERFACE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "packets_by_interface_total",
+            "Total number of packets processed by interface and direction",
+        )
+        .namespace("mermin")
+        .subsystem("interface"),
+        &["interface", "direction"], // direction: ingress/egress
+    )
+    .expect("failed to create packets_by_interface_total metric")
+});
 
-    pub static ref BYTES_BY_INTERFACE_TOTAL: IntCounterVec = IntCounterVec::new(
-        Opts::new("bytes_by_interface_total", "Total number of bytes processed by interface and direction")
-            .namespace("mermin")
-            .subsystem("interface"),
-        &["interface", "direction"]
-    ).expect("failed to create bytes_by_interface_total metric");
-}
+pub static BYTES_BY_INTERFACE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            "bytes_by_interface_total",
+            "Total number of bytes processed by interface and direction",
+        )
+        .namespace("mermin")
+        .subsystem("interface"),
+        &["interface", "direction"],
+    )
+    .expect("failed to create bytes_by_interface_total metric")
+});
 
 #[cfg(test)]
 mod tests {

--- a/mermin/src/metrics/server.rs
+++ b/mermin/src/metrics/server.rs
@@ -25,7 +25,7 @@
 //! metrics::registry::FLOWS_CREATED.with_label_values(&["eth0"]).inc();
 //! ```
 
-use std::io;
+use std::{error::Error, fmt, io};
 
 use axum::{
     Router,
@@ -34,27 +34,51 @@ use axum::{
     routing::get,
 };
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use tokio::net::TcpListener;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info};
 
 use crate::metrics::{self, ebpf::update_ringbuf_size_metric, opts::MetricsOptions};
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum MetricsError {
-    #[error("failed to bind metrics server to {address}: {source}")]
-    BindAddress {
-        address: String,
-        #[source]
-        source: io::Error,
-    },
+    BindAddress { address: String, source: io::Error },
+    ServeError(io::Error),
+    PrometheusError(prometheus::Error),
+}
 
-    #[error("metrics server error: {0}")]
-    ServeError(#[from] io::Error),
+impl fmt::Display for MetricsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BindAddress { address, source } => {
+                write!(f, "failed to bind metrics server to {address}: {source}")
+            }
+            Self::ServeError(e) => write!(f, "metrics server error: {e}"),
+            Self::PrometheusError(e) => write!(f, "prometheus registry error: {e}"),
+        }
+    }
+}
 
-    #[error("prometheus registry error: {0}")]
-    PrometheusError(#[from] prometheus::Error),
+impl Error for MetricsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::BindAddress { source, .. } => Some(source),
+            Self::ServeError(e) => Some(e),
+            Self::PrometheusError(e) => Some(e),
+        }
+    }
+}
+
+impl From<io::Error> for MetricsError {
+    fn from(e: io::Error) -> Self {
+        Self::ServeError(e)
+    }
+}
+
+impl From<prometheus::Error> for MetricsError {
+    fn from(e: prometheus::Error) -> Self {
+        Self::PrometheusError(e)
+    }
 }
 
 impl MetricsError {

--- a/mermin/src/otlp/error.rs
+++ b/mermin/src/otlp/error.rs
@@ -1,18 +1,43 @@
-use thiserror::Error;
+use std::{error::Error, fmt};
 
-#[derive(Debug, Error)]
+#[derive(Debug)]
 pub enum OtlpError {
-    #[error("failed to create OTLP exporter: {0}")]
     ExporterConfiguration(String),
-
-    #[error("invalid exporter endpoint '{endpoint}': {details}")]
     InvalidEndpoint { endpoint: String, details: String },
-
-    #[error("TLS configuration error: {0}")]
     TlsConfiguration(String),
+    TonicTransport(tonic::transport::Error),
+}
 
-    #[error("tonic transport error: {0}")]
-    TonicTransport(#[from] tonic::transport::Error),
+impl fmt::Display for OtlpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExporterConfiguration(msg) => {
+                write!(f, "failed to create OTLP exporter: {msg}")
+            }
+            Self::InvalidEndpoint { endpoint, details } => {
+                write!(f, "invalid exporter endpoint '{endpoint}': {details}")
+            }
+            Self::TlsConfiguration(msg) => write!(f, "TLS configuration error: {msg}"),
+            Self::TonicTransport(e) => write!(f, "tonic transport error: {e}"),
+        }
+    }
+}
+
+impl Error for OtlpError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::TonicTransport(e) => Some(e),
+            Self::ExporterConfiguration(_)
+            | Self::InvalidEndpoint { .. }
+            | Self::TlsConfiguration(_) => None,
+        }
+    }
+}
+
+impl From<tonic::transport::Error> for OtlpError {
+    fn from(e: tonic::transport::Error) -> Self {
+        Self::TonicTransport(e)
+    }
 }
 
 impl OtlpError {

--- a/mermin/src/runtime/reload.rs
+++ b/mermin/src/runtime/reload.rs
@@ -2,24 +2,24 @@
 //!
 //! Supports two trigger sources:
 //! - **SIGHUP** (Unix only) -- `kill -HUP <pid>`
-//! - **File watcher** -- uses the `notify` crate to detect config file modifications
+//! - **File watcher** -- uses Linux inotify via `nix` to detect config file modifications
 
 use std::{
+    ffi::OsStr,
+    os::unix::io::{AsFd, AsRawFd},
     path::{Path, PathBuf},
     sync::{
         Arc,
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use notify::{
-    RecursiveMode, Watcher,
-    event::{DataChange, EventKind, ModifyKind},
-};
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use tokio::{
     signal::unix::{SignalKind, signal},
     sync::mpsc,
+    task::JoinHandle,
 };
 use tracing::{error, info, trace, warn};
 
@@ -38,13 +38,22 @@ pub enum ReloadTrigger {
 
 pub struct ConfigWatcher {
     rx: mpsc::Receiver<ReloadTrigger>,
-    // Hold the watcher so it isn't dropped (which would stop watching)
-    _file_watcher: Option<notify::RecommendedWatcher>,
+    // Held so the JoinHandle isn't dropped (and the task detached) before we signal stop.
+    _file_watcher: Option<JoinHandle<()>>,
+    // Signals the blocking watcher thread to exit; checked every ~200 ms.
+    stop_flag: Arc<AtomicBool>,
+}
+
+impl Drop for ConfigWatcher {
+    fn drop(&mut self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+    }
 }
 
 impl ConfigWatcher {
     pub fn new(config_path: Option<&Path>) -> Result<Self, Box<dyn std::error::Error>> {
         let (tx, rx) = mpsc::channel::<ReloadTrigger>(4);
+        let stop_flag = Arc::new(AtomicBool::new(false));
 
         #[cfg(unix)]
         {
@@ -84,7 +93,7 @@ impl ConfigWatcher {
         }
 
         let file_watcher = if let Some(path) = config_path {
-            Some(Self::start_file_watcher(path, tx)?)
+            Some(Self::start_file_watcher(path, tx, Arc::clone(&stop_flag))?)
         } else {
             None
         };
@@ -92,6 +101,7 @@ impl ConfigWatcher {
         Ok(Self {
             rx,
             _file_watcher: file_watcher,
+            stop_flag,
         })
     }
 
@@ -102,7 +112,8 @@ impl ConfigWatcher {
     fn start_file_watcher(
         config_path: &Path,
         tx: mpsc::Sender<ReloadTrigger>,
-    ) -> Result<notify::RecommendedWatcher, Box<dyn std::error::Error>> {
+        stop: Arc<AtomicBool>,
+    ) -> Result<JoinHandle<()>, Box<dyn std::error::Error>> {
         let config_path = config_path.to_path_buf();
         let config_filename = config_path
             .file_name()
@@ -115,24 +126,79 @@ impl ConfigWatcher {
 
         let last_trigger_ms = Arc::new(AtomicU64::new(0));
 
-        let mut watcher: notify::RecommendedWatcher = notify::recommended_watcher(
-            move |res: Result<notify::Event, notify::Error>| match res {
-                Ok(event) => {
-                    let is_write_event = matches!(
-                        event.kind,
-                        EventKind::Modify(ModifyKind::Data(DataChange::Any | DataChange::Content))
-                            | EventKind::Create(_)
-                    );
-                    if !is_write_event {
-                        return;
-                    }
+        let inotify = Inotify::init(InitFlags::empty())?;
+        inotify.add_watch(
+            &parent_dir,
+            AddWatchFlags::IN_MODIFY
+                | AddWatchFlags::IN_CREATE
+                | AddWatchFlags::IN_CLOSE_WRITE
+                | AddWatchFlags::IN_MOVED_TO,
+        )?;
 
+        info!(
+            event.name = "reload.file_watcher_started",
+            watch_dir = %parent_dir.display(),
+            "config file watcher started"
+        );
+
+        // Capture the raw fd once; it stays valid for the lifetime of `inotify`
+        // (which is moved into the closure below).
+        let raw_fd = inotify.as_fd().as_raw_fd();
+
+        let handle = tokio::task::spawn_blocking(move || {
+            loop {
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                // libc::poll with a 200 ms timeout so the stop flag is checked
+                // regularly without busy-looping.
+                // SAFETY: pollfd is a plain C struct; zeroed is valid initial state.
+                // raw_fd stays valid for the lifetime of `inotify` (owned by this closure).
+                let ret = unsafe {
+                    let mut pfd: libc::pollfd = std::mem::zeroed();
+                    pfd.fd = raw_fd;
+                    pfd.events = libc::POLLIN;
+                    libc::poll(&mut pfd, 1, 200)
+                };
+
+                if ret == 0 {
+                    continue; // timeout — loop back and check stop flag
+                }
+                if ret < 0 {
+                    let os_errno =
+                        std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+                    if os_errno == libc::EINTR {
+                        continue; // interrupted by a signal, retry
+                    }
+                    warn!(
+                        event.name = "reload.watcher_error",
+                        errno = os_errno,
+                        "inotify poll error, file watcher stopping"
+                    );
+                    break;
+                }
+
+                let events = match inotify.read_events() {
+                    Ok(e) => e,
+                    Err(e) => {
+                        warn!(
+                            event.name = "reload.watcher_error",
+                            error.message = %e,
+                            "inotify read error, file watcher stopping"
+                        );
+                        break;
+                    }
+                };
+
+                for event in events {
                     let is_our_file = event
-                        .paths
-                        .iter()
-                        .any(|p| p.file_name().map(|f| f == config_filename).unwrap_or(false));
+                        .name
+                        .as_deref()
+                        .map(|n| n == OsStr::new(&config_filename))
+                        .unwrap_or(false);
                     if !is_our_file {
-                        return;
+                        continue;
                     }
 
                     let now_ms = SystemTime::now()
@@ -141,7 +207,7 @@ impl ConfigWatcher {
                         .as_millis() as u64;
                     let prev_ms = last_trigger_ms.swap(now_ms, Ordering::Relaxed);
                     if now_ms.saturating_sub(prev_ms) < FILE_CHANGE_DEBOUNCE_MS {
-                        return;
+                        continue;
                     }
 
                     info!(
@@ -157,6 +223,7 @@ impl ConfigWatcher {
                                 event.name = "reload.channel_closed",
                                 "reload channel closed, file watcher stopping"
                             );
+                            return;
                         }
                         Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                             trace!(
@@ -166,25 +233,10 @@ impl ConfigWatcher {
                         }
                     }
                 }
-                Err(e) => {
-                    warn!(
-                        event.name = "reload.watcher_error",
-                        error.message = %e,
-                        "file watcher error"
-                    );
-                }
-            },
-        )?;
+            }
+        });
 
-        watcher.watch(&parent_dir, RecursiveMode::NonRecursive)?;
-
-        info!(
-            event.name = "reload.file_watcher_started",
-            watch_dir = %parent_dir.display(),
-            "config file watcher started"
-        );
-
-        Ok(watcher)
+        Ok(handle)
     }
 }
 
@@ -243,5 +295,80 @@ mod tests {
         // Without a config path, only SIGHUP is active
         let watcher = ConfigWatcher::new(None);
         assert!(watcher.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_config_watcher_atomic_rename() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.yaml");
+        std::fs::write(&config_path, "initial: true").unwrap();
+
+        let mut watcher = match ConfigWatcher::new(Some(&config_path)) {
+            Ok(w) => w,
+            Err(e) if e.to_string().contains("Too many open files") => return,
+            Err(e) => panic!("ConfigWatcher::new failed unexpectedly: {e}"),
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Simulate vim/editor-style atomic save: write to sibling temp, then rename over config.
+        // This triggers IN_MOVED_TO on the watched parent directory.
+        let tmp_path = dir.path().join("config.yaml.tmp");
+        std::fs::write(&tmp_path, "updated: true").unwrap();
+        std::fs::rename(&tmp_path, &config_path).unwrap();
+
+        let trigger = tokio::time::timeout(std::time::Duration::from_secs(5), watcher.next()).await;
+        match trigger {
+            Ok(Some(ReloadTrigger::FileChanged(path))) => assert_eq!(path, config_path),
+            Ok(Some(ReloadTrigger::Sighup)) => {} // stray signal, not a failure
+            Ok(None) => panic!("watcher channel closed unexpectedly"),
+            Err(_) => {
+                // Timeout: acceptable in CI environments with unreliable fsevents.
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_config_watcher_debounce() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.yaml");
+        std::fs::write(&config_path, "v: 0").unwrap();
+
+        let mut watcher = match ConfigWatcher::new(Some(&config_path)) {
+            Ok(w) => w,
+            Err(e) if e.to_string().contains("Too many open files") => return,
+            Err(e) => panic!("ConfigWatcher::new failed unexpectedly: {e}"),
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Write 5 times in rapid succession — all within the 1000 ms debounce window.
+        for i in 1..=5u8 {
+            std::fs::write(&config_path, format!("v: {i}")).unwrap();
+        }
+
+        // Collect triggers for 1.5 s (debounce window is 1000 ms).
+        let mut trigger_count = 0usize;
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(1500);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, watcher.next()).await {
+                Ok(Some(ReloadTrigger::FileChanged(_))) => trigger_count += 1,
+                Ok(Some(ReloadTrigger::Sighup)) => {}
+                Ok(None) | Err(_) => break,
+            }
+        }
+
+        // In CI/virtual filesystems events may not fire at all — skip rather than fail.
+        // When they do fire, debounce must coalesce 5 writes into at most 2 triggers.
+        if trigger_count > 0 {
+            assert!(
+                trigger_count <= 2,
+                "expected debounce to coalesce triggers, got {trigger_count}"
+            );
+        }
     }
 }

--- a/mermin/src/runtime/reload.rs
+++ b/mermin/src/runtime/reload.rs
@@ -166,8 +166,7 @@ impl ConfigWatcher {
                     continue; // timeout — loop back and check stop flag
                 }
                 if ret < 0 {
-                    let os_errno =
-                        std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+                    let os_errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
                     if os_errno == libc::EINTR {
                         continue; // interrupted by a signal, retry
                     }

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -976,17 +976,11 @@ impl FlowWorker {
                 flow_reverse_ip_flow_label: is_ipv6.then_some(stats.reverse_ip_flow_label),
 
                 flow_tcp_flags_bits: is_tcp.then_some(stats.tcp_flags),
-                flow_tcp_flags_tags: is_tcp.then(|| {
-                    TcpFlags::flags_from_bits(stats.tcp_flags)
-                        .into_iter()
-                        .collect()
-                }),
+                flow_tcp_flags_tags: is_tcp
+                    .then(|| TcpFlags::flags_from_bits(stats.tcp_flags).collect()),
                 flow_reverse_tcp_flags_bits: is_tcp.then_some(stats.reverse_tcp_flags),
-                flow_reverse_tcp_flags_tags: is_tcp.then(|| {
-                    TcpFlags::flags_from_bits(stats.reverse_tcp_flags)
-                        .into_iter()
-                        .collect()
-                }),
+                flow_reverse_tcp_flags_tags: is_tcp
+                    .then(|| TcpFlags::flags_from_bits(stats.reverse_tcp_flags).collect()),
                 flow_tcp_handshake_latency: (is_tcp
                     && stats.tcp_syn_ns != 0
                     && stats.tcp_syn_ack_ns != 0)

--- a/mermin/src/span/tcp.rs
+++ b/mermin/src/span/tcp.rs
@@ -1,4 +1,3 @@
-use arrayvec::ArrayVec;
 use mermin_common::tcp::{
     TCP_FLAG_ACK, TCP_FLAG_CWR, TCP_FLAG_ECE, TCP_FLAG_FIN, TCP_FLAG_PSH, TCP_FLAG_RST,
     TCP_FLAG_SYN, TCP_FLAG_URG,
@@ -53,13 +52,25 @@ pub struct TcpFlags {
 }
 
 impl TcpFlags {
-    /// Convert a bit-flag byte to a stack-allocated array of active [`TcpFlag`] variants.
+    /// Convert a bit-flag byte into an iterator of active [`TcpFlag`] variants.
     /// Order: [FIN, SYN, RST, PSH, ACK, URG, ECE, CWR]
     ///
-    /// Returns an [`ArrayVec`] with capacity 8 (one per flag bit), avoiding heap allocation
-    /// since the maximum number of active flags is bounded by the bit-width of the input.
-    pub fn flags_from_bits(bits: u8) -> ArrayVec<TcpFlag, 8> {
-        Self::active_flags_from_array(&Self::bits_to_array(bits))
+    /// Returns a lazy iterator with no heap allocation. Callers that need a
+    /// collected value can call `.collect::<Vec<_>>()`.
+    pub fn flags_from_bits(bits: u8) -> impl Iterator<Item = TcpFlag> {
+        const FLAG_MAP: [(u8, TcpFlag); 8] = [
+            (TCP_FLAG_FIN, TcpFlag::Fin),
+            (TCP_FLAG_SYN, TcpFlag::Syn),
+            (TCP_FLAG_RST, TcpFlag::Rst),
+            (TCP_FLAG_PSH, TcpFlag::Psh),
+            (TCP_FLAG_ACK, TcpFlag::Ack),
+            (TCP_FLAG_URG, TcpFlag::Urg),
+            (TCP_FLAG_ECE, TcpFlag::Ece),
+            (TCP_FLAG_CWR, TcpFlag::Cwr),
+        ];
+        FLAG_MAP
+            .into_iter()
+            .filter_map(move |(mask, flag)| (bits & mask != 0).then_some(flag))
     }
 
     /// Latency between SYN and SYN+ACK timestamps (nanoseconds).
@@ -78,40 +89,6 @@ impl TcpFlags {
         }
         (sum / count as u64) as i64
     }
-
-    fn bits_to_array(bits: u8) -> [bool; 8] {
-        [
-            (bits & TCP_FLAG_FIN) != 0, // FIN
-            (bits & TCP_FLAG_SYN) != 0, // SYN
-            (bits & TCP_FLAG_RST) != 0, // RST
-            (bits & TCP_FLAG_PSH) != 0, // PSH
-            (bits & TCP_FLAG_ACK) != 0, // ACK
-            (bits & TCP_FLAG_URG) != 0, // URG
-            (bits & TCP_FLAG_ECE) != 0, // ECE
-            (bits & TCP_FLAG_CWR) != 0, // CWR
-        ]
-    }
-
-    fn active_flags_from_array(flags: &[bool; 8]) -> ArrayVec<TcpFlag, 8> {
-        const FLAG_ENUMS: [TcpFlag; 8] = [
-            TcpFlag::Fin,
-            TcpFlag::Syn,
-            TcpFlag::Rst,
-            TcpFlag::Psh,
-            TcpFlag::Ack,
-            TcpFlag::Urg,
-            TcpFlag::Ece,
-            TcpFlag::Cwr,
-        ];
-
-        let mut result = ArrayVec::new();
-        for (is_set, flag) in flags.iter().zip(FLAG_ENUMS.iter()) {
-            if *is_set {
-                result.push(*flag);
-            }
-        }
-        result
-    }
 }
 
 #[cfg(test)]
@@ -122,70 +99,70 @@ mod tests {
     fn test_tcp_flags_from_struct() {
         let tcp_flags = TCP_FLAG_SYN | TCP_FLAG_ACK;
 
-        let flags = TcpFlags::flags_from_bits(tcp_flags);
-        assert_eq!(flags.as_slice(), &[TcpFlag::Syn, TcpFlag::Ack]);
+        let flags = TcpFlags::flags_from_bits(tcp_flags).collect::<Vec<_>>();
+        assert_eq!(flags, [TcpFlag::Syn, TcpFlag::Ack]);
     }
 
     #[test]
     fn test_flags_from_bits() {
         // Test no flags
         assert_eq!(
-            TcpFlags::flags_from_bits(0x00).as_slice(),
-            &[] as &[TcpFlag]
+            TcpFlags::flags_from_bits(0x00).collect::<Vec<_>>(),
+            [] as [TcpFlag; 0]
         );
 
         // Test individual flags
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_FIN).as_slice(),
-            &[TcpFlag::Fin]
+            TcpFlags::flags_from_bits(TCP_FLAG_FIN).collect::<Vec<_>>(),
+            [TcpFlag::Fin]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_SYN).as_slice(),
-            &[TcpFlag::Syn]
+            TcpFlags::flags_from_bits(TCP_FLAG_SYN).collect::<Vec<_>>(),
+            [TcpFlag::Syn]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_RST).as_slice(),
-            &[TcpFlag::Rst]
+            TcpFlags::flags_from_bits(TCP_FLAG_RST).collect::<Vec<_>>(),
+            [TcpFlag::Rst]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_PSH).as_slice(),
-            &[TcpFlag::Psh]
+            TcpFlags::flags_from_bits(TCP_FLAG_PSH).collect::<Vec<_>>(),
+            [TcpFlag::Psh]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_ACK).as_slice(),
-            &[TcpFlag::Ack]
+            TcpFlags::flags_from_bits(TCP_FLAG_ACK).collect::<Vec<_>>(),
+            [TcpFlag::Ack]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_URG).as_slice(),
-            &[TcpFlag::Urg]
+            TcpFlags::flags_from_bits(TCP_FLAG_URG).collect::<Vec<_>>(),
+            [TcpFlag::Urg]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_ECE).as_slice(),
-            &[TcpFlag::Ece]
+            TcpFlags::flags_from_bits(TCP_FLAG_ECE).collect::<Vec<_>>(),
+            [TcpFlag::Ece]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_CWR).as_slice(),
-            &[TcpFlag::Cwr]
+            TcpFlags::flags_from_bits(TCP_FLAG_CWR).collect::<Vec<_>>(),
+            [TcpFlag::Cwr]
         );
 
         // Test common flag combinations
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_SYN | TCP_FLAG_ACK).as_slice(), // SYN+ACK
-            &[TcpFlag::Syn, TcpFlag::Ack]
+            TcpFlags::flags_from_bits(TCP_FLAG_SYN | TCP_FLAG_ACK).collect::<Vec<_>>(), // SYN+ACK
+            [TcpFlag::Syn, TcpFlag::Ack]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_FIN | TCP_FLAG_ACK).as_slice(), // FIN+ACK
-            &[TcpFlag::Fin, TcpFlag::Ack]
+            TcpFlags::flags_from_bits(TCP_FLAG_FIN | TCP_FLAG_ACK).collect::<Vec<_>>(), // FIN+ACK
+            [TcpFlag::Fin, TcpFlag::Ack]
         );
         assert_eq!(
-            TcpFlags::flags_from_bits(TCP_FLAG_PSH | TCP_FLAG_ACK).as_slice(), // PSH+ACK
-            &[TcpFlag::Psh, TcpFlag::Ack]
+            TcpFlags::flags_from_bits(TCP_FLAG_PSH | TCP_FLAG_ACK).collect::<Vec<_>>(), // PSH+ACK
+            [TcpFlag::Psh, TcpFlag::Ack]
         );
 
         // Test all flags
         assert_eq!(
-            TcpFlags::flags_from_bits(0xFF).as_slice(),
-            &[
+            TcpFlags::flags_from_bits(0xFF).collect::<Vec<_>>(),
+            [
                 TcpFlag::Fin,
                 TcpFlag::Syn,
                 TcpFlag::Rst,

--- a/mermin/tests/integration.rs
+++ b/mermin/tests/integration.rs
@@ -6,8 +6,8 @@ use std::{
     time::Duration,
 };
 
-use log::info;
 use socket2::{Domain, Socket, Type};
+use tracing::info;
 
 const IPV4_HOST: &str = "192.168.100.1";
 const IPV4_NS: &str = "192.168.100.2";


### PR DESCRIPTION
Trying to reduce the footprint of direct and transitive dependencies with little to no additional code maintenance requirements. As an added bonus, I've reorganized the workspace `Cargo.toml` and only left the aya dependencies at that level, while moving all others into their specific workspace crates.