### PR TITLE
fix(ci): Wrong `REPO_OWNER` in Chart Release

### DIFF
--- a/.github/workflows/reusable_release_chart.yaml
+++ b/.github/workflows/reusable_release_chart.yaml
@@ -164,7 +164,7 @@ jobs:
           files: ".cr-release-packages/${{ inputs.chart_name }}*.tgz"
       - name: Update GH pages index
         env:
-          REPO_OWNER: ${{ inputs.repository_name }}
+          REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ inputs.repository_name }}
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
In the previous [PR](https://github.com/elastiflow/mermin/pull/557/changes#diff-929671f339ea684d38e62c06bddb61696ab46ef7d7912b66de3ed6ecf3f56292R166-R172) the mistake was made for the chart release step, wrong `REPO_OWNER`. 

This PR fixes the error

