### PR TITLE
feat: Bump the toolchain to `nightly-2026-04-11`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
           dockerfile: Dockerfile
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
-          toolchain: nightly-2025-06-23
+          toolchain: nightly-2026-04-11
           components: clippy, rust-src
       - name: Cache dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
-          toolchain: nightly-2025-06-23
+          toolchain: nightly-2026-04-11
           components: rust-src
       - name: Cache dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/release_mermin-netobserv-os-stack.yaml
+++ b/.github/workflows/release_mermin-netobserv-os-stack.yaml
@@ -32,8 +32,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: set outputs with default values
         id: set_standard_vars
+        env:
+          TAG_PREFIX: ${{ fromJson(env.BRANCH_TAG_PREFIXES)[github.ref_name] }}
         run: |
-          echo "tag_prefix=${{ fromJson(env.BRANCH_TAG_PREFIXES)[github.ref_name] }}" >> $GITHUB_OUTPUT
+          echo "tag_prefix=${TAG_PREFIX}"
+          echo "tag_prefix=${TAG_PREFIX}" >> $GITHUB_OUTPUT
 
   release:
     name: Release mermin-netobserv-os-stack

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN cp mermin/Cargo.toml mermin/Cargo.toml.orig \
     | tr '\r' '\n' > Cargo.lock
 
 # ---- Build Stage ----
-FROM rust:1.88.0-trixie@sha256:9a7159329166b45f453351a077367f501aa3e98378f7e327530e7966a139d05f AS base
+FROM rust:1.96.0-trixie@sha256:fb328f0f58becb23ba1719940a2c94ece8b0b48afa837d05b79ef64bc1e18f6e AS base
 
 # Since Mermin needs root to be ran, switching to non-root in in the base/builder stages does not improve the security.
 # nosemgrep: dockerfile.security.last-user-is-root.last-user-is-root # root is needed due to eBPF
@@ -131,9 +131,10 @@ COPY . .
 RUN cargo build --release
 
 # ---- Runtime Stage ----
-# Use a distroless base image for the final container without shell support
+# Use a distroless base image for the final container without shell support, to get sha run:
+#   skopeo inspect --override-os=linux --override-arch=amd64 --format "Name: {{.Name}} Digest: {{.Digest}}" docker://gcr.io/distroless/cc-debian13:latest
 # hadolint ignore=DL3006 # gcr.io/distroless/cc-debian12 don't have tags
-FROM gcr.io/distroless/cc-debian13@sha256:56aaf20ab2523a346a67c8e8f8e8dabe447447d0788b82284d14ad79cd5f93cc AS runner
+FROM gcr.io/distroless/cc-debian13@sha256:8b5d1db6d2253036a53cb8362d3e3fa82a7caf84c247772c46a023166c64e977 AS runner
 ARG APP_ROOT APP
 
 COPY --from=builder ${APP_ROOT}/target/release/${APP} /usr/bin/${APP}
@@ -141,7 +142,7 @@ ENTRYPOINT ["/usr/bin/mermin"]
 
 # ---- Runtime Stage ----
 # Use a distroless base image for the final container with shell support
-FROM debian:13.4-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS runner-debug
+FROM debian:13.5-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8 AS runner-debug
 ARG APP_ROOT APP
 
 COPY --from=builder ${APP_ROOT}/target/release/${APP} /usr/bin/${APP}

--- a/mermin-common/src/route.rs
+++ b/mermin-common/src/route.rs
@@ -451,7 +451,7 @@ impl RplSourceRouteHeader {
             return 0;
         }
 
-        if (addresses_len - size_final) % size_inter != 0 {
+        if !(addresses_len - size_final).is_multiple_of(size_inter) {
             // Malformed header: the total length of intermediate addresses
             // is not a multiple of the intermediate address size.
             return 0;

--- a/mermin/src/metrics/server.rs
+++ b/mermin/src/metrics/server.rs
@@ -301,10 +301,8 @@ async fn metrics_summary_handler(debug_enabled: bool) -> impl IntoResponse {
             }
         }
 
-        let all_metrics: Vec<MetricSummary> = standard_metrics
-            .into_iter()
-            .chain(debug_metrics.into_iter())
-            .collect();
+        let all_metrics: Vec<MetricSummary> =
+            standard_metrics.into_iter().chain(debug_metrics).collect();
 
         MetricsSummaryResponse {
             debug_metrics_enabled: debug_enabled,

--- a/mermin/src/runtime/conf.rs
+++ b/mermin/src/runtime/conf.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 /// TCX ordering strategy for kernel >= 6.6
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum TcxOrderStrategy {
     /// Attach at the tail of the TCX chain (runs after all existing programs)
@@ -33,13 +33,8 @@ pub enum TcxOrderStrategy {
     Last,
     /// Attach at the head of the TCX chain (runs before all existing programs)
     /// Use with caution - may interfere with CNI functionality
+    #[default]
     First,
-}
-
-impl Default for TcxOrderStrategy {
-    fn default() -> Self {
-        Self::First
-    }
 }
 
 impl fmt::Display for TcxOrderStrategy {

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -539,7 +539,7 @@ fn dispatch_flow_event(
         static BACKPRESSURE_DROP_COUNT: std::sync::atomic::AtomicU64 =
             std::sync::atomic::AtomicU64::new(0);
         let drop_count = BACKPRESSURE_DROP_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        if drop_count % 1000 == 0 {
+        if drop_count.is_multiple_of(1000) {
             warn!(
                 event.name = "span.producer.worker.backpressure",
                 worker_count = worker_count,
@@ -2123,9 +2123,7 @@ pub async fn orphan_scanner_task(
 
                 // Check map utilization and warn if approaching capacity
                 let capacity = flow_stats_capacity as u64;
-                if capacity > 0 {
-                    let utilization_pct = (ebpf_map_size * 100) / capacity;
-                    if utilization_pct >= 80 {
+                if let Some(utilization_pct) = (ebpf_map_size * 100).checked_div(capacity) && utilization_pct >= 80 {
                         warn!(
                             event.name = "ebpf_map.high_utilization",
                             map = EbpfMapName::FlowStats.as_str(),
@@ -2135,7 +2133,6 @@ pub async fn orphan_scanner_task(
                             "eBPF map utilization is high, new flow insertions may silently fail in the kernel. \
                              Consider increasing the flow_stats max capacity (flow_stats_capacity) in config."
                         );
-                    }
                 }
 
                 for key in stale_keys {
@@ -2835,18 +2832,18 @@ mod tests {
         let last_recorded_reverse_bytes = 4_000u64;
 
         // Perform the metadata reset exactly as record_flow now does.
-        let mut reset_stats = stats;
-        reset_stats.forward_metadata_seen = 0;
-        reset_stats.reverse_metadata_seen = 0;
-        reset_stats.ip_dscp = 0;
-        reset_stats.ip_ecn = 0;
-        reset_stats.ip_ttl = 0;
-        reset_stats.ip_flow_label = 0;
-        reset_stats.reverse_ip_dscp = 0;
-        reset_stats.reverse_ip_ecn = 0;
-        reset_stats.reverse_ip_ttl = 0;
-        reset_stats.reverse_ip_flow_label = 0;
-        // (reset_stats is written back to the eBPF map here in the real function)
+        let mut _reset_stats = stats;
+        _reset_stats.forward_metadata_seen = 0;
+        _reset_stats.reverse_metadata_seen = 0;
+        _reset_stats.ip_dscp = 0;
+        _reset_stats.ip_ecn = 0;
+        _reset_stats.ip_ttl = 0;
+        _reset_stats.ip_flow_label = 0;
+        _reset_stats.reverse_ip_dscp = 0;
+        _reset_stats.reverse_ip_ecn = 0;
+        _reset_stats.reverse_ip_ttl = 0;
+        _reset_stats.reverse_ip_flow_label = 0;
+        // (_reset_stats is written back to the eBPF map here in the real function)
 
         // Delta computation (after drop(map)) still reads from the original `stats`.
         let delta_packets = stats.packets.saturating_sub(last_recorded_packets);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-# Define build arguments - 2025-05-09 is the last nightly build of rust 1.88.0
-# TODO: Upgprade to rust 1.89 when image is made available with nightly-2025-06-23
-channel = "nightly-2025-06-23"
+# nightly-2026-04-11 is the last nightly with rustc 1.96.0
+channel = "nightly-2026-04-11"
 components = [ "rust-src", "rustfmt", "clippy" ]

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,1 @@
+ignorefile: trivyignore.yaml

--- a/trivyignore.yaml
+++ b/trivyignore.yaml
@@ -1,0 +1,200 @@
+misconfigurations:
+  # Mermin
+  - id: DS-0002
+    statement: Mermin is an eBPF agent, needs root
+    paths:
+      - Dockerfile
+  - id: DS-0026
+    statement: We do not define HEALTHCHECK in the Dockerfile, defined in the Helm chart instead
+    paths:
+      - Dockerfile
+  - id: KSV-0001
+    statement: Mermin is an eBPF agent, needs escalated privileges
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0003
+    statement: Mermin is an eBPF agent, needs elevated caps
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0004
+    statement: Mermin is an eBPF agent, needs elevated caps
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0010
+    statement: Mermin is an eBPF agent, needs hostPID for enrichment
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0011
+    statement: Not setting default cpu/memory requests/limits, up to the user to define reasonable limits.
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0015
+    statement: Not setting default cpu/memory requests/limits, up to the user to define reasonable limits.
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0016
+    statement: Not setting default cpu/memory requests/limits, up to the user to define reasonable limits.
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0017
+    statement: Mermin is an eBPF agent, may be privileged
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0018
+    statement: Not setting default cpu/memory requests/limits, up to the user to define reasonable limits.
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0020
+    statement: Mermin is an eBPF agent, needs root
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0021
+    statement: Mermin is an eBPF agent, needs root
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0023
+    statement: Mermin is an eBPF agent, needs host volume mounts
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0030
+    statement: Mermin is an eBPF agent, up to the user to limit the Seccomp policy
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0104
+    statement: Mermin is an eBPF agent, up to the user to limit the Seccomp policy
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0105
+    statement: Mermin is an eBPF agent, needs root
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0106
+    statement: Mermin is an eBPF agent, needs elevated caps
+    paths:
+      - charts/mermin/**/*
+  - id: KSV-0125
+    statement: ghcr.io/elastiflow/mermin is an official Mermin registry
+    paths:
+      - charts/mermin/**/*
+  # Traffic Generator
+  - id: KSV-0011
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0001
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0003
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0004
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0012
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0013
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0014
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0020
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0021
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0030
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0104
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0105
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0106
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  - id: KSV-0125
+    statement: Chart with a traffic generator, not meant to be compliant
+    paths:
+      - charts/traffic-gen/**/*
+  # Examples
+  - id: KSV-0001
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0003
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0004
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0011
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0012
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0014
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0015
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0016
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0018
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0020
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0021
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0030
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0104
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0106
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0118
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*
+  - id: KSV-0125
+    statement: Examples, not meant to be compliant
+    paths:
+      - docs/deployment/examples/**/*


### PR DESCRIPTION
Several failures were caused by an outdated toolchain - [ref](https://github.com/elastiflow/mermin/actions/runs/26534945918/job/79157245212)

Instead of locking BPF linker the PR upgrades used toolchain to the latest nightly of current stable (1.96 rustc)

- Few fixes to the tests had to be made due to CI failures - [ref](https://github.com/elastiflow/mermin/actions/runs/27133832314/job/80081174588)
- Few clippy suggestions applied - [failures](https://github.com/elastiflow/mermin/actions/runs/27134876219/job/80084713278?pr=584)

Also, necessary Trivy security scan findings were addressed by introducing a structured ignore file and updating Trivy configuration.

## Changes

- fix: Ignore/Fix security findings

## Testing

Locally


