### PR TITLE
fix: Bump OpenSSL to patch CWEs (`0.10.80`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,15 +2082,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2120,9 +2119,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Bump OpenSSL to resolve
- [CWE-20](https://github.com/elastiflow/mermin/security/dependabot/23)
- [CWE-121](https://github.com/elastiflow/mermin/security/dependabot/17)
- [CWE-122](https://github.com/elastiflow/mermin/security/dependabot/24)
- [CWE-126](https://github.com/elastiflow/mermin/security/dependabot/18)
- [CWE-130](https://github.com/elastiflow/mermin/security/dependabot/18)
- [CWE-131](https://github.com/elastiflow/mermin/security/dependabot/21)
- [CWE-787](https://github.com/elastiflow/mermin/security/dependabot/21)
- [CWE-787](https://github.com/elastiflow/mermin/security/dependabot/19)
- [CWE-131](https://github.com/elastiflow/mermin/security/dependabot/25)
- [CWE-787](https://github.com/elastiflow/mermin/security/dependabot/25)
- [CWE-125](https://github.com/elastiflow/mermin/security/dependabot/20)
- [CWE-1284](https://github.com/elastiflow/mermin/security/dependabot/20)

## Testing

Tested local to observe the flow spans

