### PR TITLE
feat(mermin): VXLAN and Geneve tunnel flow support

### DIFF
--- a/docs/configuration/default/config.hcl
+++ b/docs/configuration/default/config.hcl
@@ -32,7 +32,7 @@ pipeline {
 parser {
   # Tunnel port detection (IANA defaults shown)
   geneve_port    = 6081  # IANA default for Geneve
-  vxlan_port     = 4789  # IANA default for VXLAN
+  vxlan_port     = 4789  # IANA default for VXLAN; Linux Flannel uses 8472
   wireguard_port = 51820 # IANA default for WireGuard
 }
 

--- a/docs/getting-started/quickstart-guide.md
+++ b/docs/getting-started/quickstart-guide.md
@@ -270,14 +270,13 @@ Default:
 **Use cases**: Fine-tuning for specific CNI setups, reducing monitored interface count
 
 {% hint style="info" %}
-Mermin's goal is to show you pod-to-pod traffic which is exposed by Virtual Ethernet Devices, which match patterns like `"veth*", "gke*", "cali*"`. Currently, bridge interfaces like `"tun*"` or `flannel*` are ignored,
-because Mermin does not support parsing tunneled/encapsulated traffic. This feature will come very soon.
+Mermin's goal is to show you pod-to-pod traffic. Use `veth*` for same-node traffic and tunnel interfaces (`flannel*`, `tunl*`, `vxlan*`) or node uplinks (`eth*`) for inter-node overlay traffic. VXLAN and Geneve encapsulation is parsed automatically; set `parser.vxlan_port` to match your CNI (Linux Flannel uses `8472`, not the IANA default `4789`).
 {% endhint %}
 
 **Physical Interfaces Only:**
 
 {% hint style="warning" %}
-Most of the traffic on the physical interfaces will be ignored, because Mermin currently lacks support for tunneled/encapsulated traffic.
+On node uplinks (`eth*`), only tunneled flows (VXLAN/Geneve UDP ports) are deep-parsed into inner 5-tuples. Plain traffic on those interfaces is still tracked, but avoid monitoring both `veth*` and `eth*` for the same paths unless you need uplink-level tunnel metadata.
 {% endhint %}
 
 Monitor only physical network interfaces for inter-node traffic:

--- a/docs/troubleshooting/interface-visibility-and-traffic-decapsulation.md
+++ b/docs/troubleshooting/interface-visibility-and-traffic-decapsulation.md
@@ -277,7 +277,7 @@ discovery "instrument" {
 
 parser {
   geneve_port = 6081
-  vxlan_port = 4789
+  vxlan_port = 8472  # Linux Flannel; use 4789 for IANA-default VXLAN
   wireguard_port = 51820
 }
 ```

--- a/mermin/src/ip.rs
+++ b/mermin/src/ip.rs
@@ -7,6 +7,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use mermin_common::{FlowKey, IpVersion};
 
+use crate::packet::types::InnerHeaders;
+
 /// Resolve IP addresses from raw byte arrays based on the provided IP address type.
 #[allow(dead_code)]
 pub fn resolve_addrs(
@@ -29,6 +31,33 @@ pub fn resolve_addrs(
             Ok((src, dst))
         }
     }
+}
+
+/// Build a normalized FlowKey from parsed inner tunnel headers.
+pub fn flow_key_from_inner_headers(inner: &InnerHeaders) -> FlowKey {
+    fn field(ip: IpAddr) -> ([u8; 16], IpVersion) {
+        match ip {
+            IpAddr::V4(v4) => {
+                let mut bytes = [0u8; 16];
+                bytes[..4].copy_from_slice(&v4.octets());
+                (bytes, IpVersion::V4)
+            }
+            IpAddr::V6(v6) => (v6.octets(), IpVersion::V6),
+        }
+    }
+
+    let (src_ip, ip_version) = field(inner.src_ip);
+    let (dst_ip, _) = field(inner.dst_ip);
+
+    FlowKey {
+        src_ip,
+        dst_ip,
+        src_port: inner.src_port,
+        dst_port: inner.dst_port,
+        ip_version,
+        protocol: inner.protocol,
+    }
+    .normalize()
 }
 
 /// Convert FlowKey IPs to IpAddr for Community ID generation.
@@ -70,9 +99,12 @@ impl std::error::Error for Error {}
 mod tests {
     use std::net::{IpAddr, Ipv4Addr};
 
-    use mermin_common::IpVersion;
+    use mermin_common::{IpVersion, ip::IpProto};
 
-    use crate::ip::{Error, resolve_addrs};
+    use crate::{
+        ip::{Error, flow_key_from_inner_headers, flow_key_to_ip_addrs, resolve_addrs},
+        packet::types::InnerHeaders,
+    };
 
     #[test]
     fn test_resolve_addrs_ipv4() {
@@ -110,6 +142,25 @@ mod tests {
             IpAddr::V6(addr) => assert!(addr.to_string().starts_with("2001:db8")),
             _ => panic!("Expected IPv6 address"),
         }
+    }
+
+    #[test]
+    fn test_flow_key_from_inner_headers_normalizes() {
+        let inner = InnerHeaders {
+            src_ip: IpAddr::V4(Ipv4Addr::new(10, 244, 2, 2)),
+            dst_ip: IpAddr::V4(Ipv4Addr::new(10, 244, 1, 1)),
+            src_port: (8 << 8) | 0,
+            dst_port: 0,
+            protocol: IpProto::Icmp,
+            src_mac: [0; 6],
+            dst_mac: [0; 6],
+        };
+
+        let key = flow_key_from_inner_headers(&inner);
+        let (src, dst) = flow_key_to_ip_addrs(&key).unwrap();
+        assert_eq!(src, IpAddr::V4(Ipv4Addr::new(10, 244, 1, 1)));
+        assert_eq!(dst, IpAddr::V4(Ipv4Addr::new(10, 244, 2, 2)));
+        assert_eq!(key.protocol, IpProto::Icmp);
     }
 
     #[test]

--- a/mermin/src/packet/parser.rs
+++ b/mermin/src/packet/parser.rs
@@ -9,11 +9,13 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use mermin_common::{FlowKey, TunnelType, eth::EtherType, ip::IpProto};
+use mermin_common::{FlowKey, TunnelType, eth::EtherType, geneve, ip::IpProto, vxlan};
 
-use crate::packet::types::{
-    FiveTuple, InnerHeaders, IpMetadata, L2Metadata, OuterHeaders, ParseError, ParsedPacket,
-    TunnelInfo,
+use crate::{
+    ip,
+    packet::types::{
+        FiveTuple, InnerHeaders, IpMetadata, OuterHeaders, ParseError, ParsedPacket, TunnelInfo,
+    },
 };
 
 /// Returns true if the flow is likely tunneled. Fast check to avoid deep parsing for plain traffic.
@@ -39,121 +41,47 @@ pub fn is_tunnel(
     }
 }
 
-/// Parse packet data where eBPF has already consumed the outer headers.
-/// For tunnels, `data` starts at the inner Ethernet header.
+/// Parse tunnel UDP payload from eBPF `FlowEvent.packet_data` (VXLAN/Geneve + inner frame).
 pub fn parse_packet_from_offset(
     data: &[u8],
-    _parsed_offset: u16,
+    flow_key: &FlowKey,
+    outer_src_mac: [u8; 6],
+    outer_dst_mac: [u8; 6],
+    vxlan_port: u16,
+    geneve_port: u16,
 ) -> Result<ParsedPacket, ParseError> {
-    parse_packet_deep(data)
-}
+    let (outer_src_ip, outer_dst_ip) =
+        ip::flow_key_to_ip_addrs(flow_key).map_err(|_| ParseError::InvalidHeader)?;
+    let outer_src_port = flow_key.src_port;
+    let outer_dst_port = flow_key.dst_port;
 
-/// Parse packet from raw bytes (up to 256 bytes captured)
-pub fn parse_packet_deep(data: &[u8]) -> Result<ParsedPacket, ParseError> {
     let mut offset = 0;
-
-    let (src_mac, dst_mac, ether_type) = parse_ethernet(data, &mut offset)?;
-
-    let l2_meta = L2Metadata {
-        src_mac,
-        dst_mac,
-        ether_type,
-    };
-
-    let (outer_src_ip, outer_dst_ip, outer_protocol, ip_meta) = match ether_type {
-        EtherType::Ipv4 => parse_ipv4(data, &mut offset)?,
-        EtherType::Ipv6 => parse_ipv6(data, &mut offset)?,
-        _ => return Err(ParseError::UnsupportedEtherType),
-    };
-
-    match outer_protocol {
-        IpProto::Udp => {
-            let (outer_src_port, outer_dst_port) = parse_l4_ports(data, offset)?;
-
-            if outer_dst_port == 4789 || outer_src_port == 4789 {
-                return parse_vxlan(
-                    data,
-                    &mut offset,
-                    outer_src_ip,
-                    outer_dst_ip,
-                    outer_src_port,
-                    outer_dst_port,
-                    src_mac,
-                    dst_mac,
-                );
-            } else if outer_dst_port == 6081 || outer_src_port == 6081 {
-                return parse_geneve(
-                    data,
-                    &mut offset,
-                    outer_src_ip,
-                    outer_dst_ip,
-                    outer_src_port,
-                    outer_dst_port,
-                    src_mac,
-                    dst_mac,
-                );
-            }
-
-            Ok(ParsedPacket::Direct {
-                five_tuple: FiveTuple {
-                    src_ip: outer_src_ip,
-                    dst_ip: outer_dst_ip,
-                    src_port: outer_src_port,
-                    dst_port: outer_dst_port,
-                    protocol: IpProto::Udp,
-                    ip_version: if outer_src_ip.is_ipv4() { 4 } else { 6 },
-                },
-                l2_metadata: l2_meta,
-                ip_metadata: ip_meta,
-            })
-        }
-        IpProto::Tcp => {
-            let (src_port, dst_port) = parse_l4_ports(data, offset)?;
-            Ok(ParsedPacket::Direct {
-                five_tuple: FiveTuple {
-                    src_ip: outer_src_ip,
-                    dst_ip: outer_dst_ip,
-                    src_port,
-                    dst_port,
-                    protocol: IpProto::Tcp,
-                    ip_version: if outer_src_ip.is_ipv4() { 4 } else { 6 },
-                },
-                l2_metadata: l2_meta,
-                ip_metadata: ip_meta,
-            })
-        }
-        IpProto::Icmp => {
-            let (type_code, _) = parse_icmp_type_code(data, offset)?;
-            Ok(ParsedPacket::Direct {
-                five_tuple: FiveTuple {
-                    src_ip: outer_src_ip,
-                    dst_ip: outer_dst_ip,
-                    src_port: type_code,
-                    dst_port: 0,
-                    protocol: outer_protocol,
-                    ip_version: if outer_src_ip.is_ipv4() { 4 } else { 6 },
-                },
-                l2_metadata: l2_meta,
-                ip_metadata: ip_meta,
-            })
-        }
-        IpProto::Gre => {
-            // TODO: GRE parsing
-            Err(ParseError::UnsupportedProtocol)
-        }
-        _ => Ok(ParsedPacket::Direct {
-            five_tuple: FiveTuple {
-                src_ip: outer_src_ip,
-                dst_ip: outer_dst_ip,
-                src_port: 0,
-                dst_port: 0,
-                protocol: outer_protocol,
-                ip_version: if outer_src_ip.is_ipv4() { 4 } else { 6 },
-            },
-            l2_metadata: l2_meta,
-            ip_metadata: ip_meta,
-        }),
+    if outer_src_port == vxlan_port || outer_dst_port == vxlan_port {
+        return parse_vxlan_payload(
+            data,
+            &mut offset,
+            outer_src_ip,
+            outer_dst_ip,
+            outer_src_port,
+            outer_dst_port,
+            outer_src_mac,
+            outer_dst_mac,
+        );
     }
+    if outer_src_port == geneve_port || outer_dst_port == geneve_port {
+        return parse_geneve_payload(
+            data,
+            &mut offset,
+            outer_src_ip,
+            outer_dst_ip,
+            outer_src_port,
+            outer_dst_port,
+            outer_src_mac,
+            outer_dst_mac,
+        );
+    }
+
+    Err(ParseError::UnsupportedProtocol)
 }
 
 fn parse_ethernet(
@@ -170,7 +98,8 @@ fn parse_ethernet(
     src_mac.copy_from_slice(&data[*offset + 6..*offset + 12]);
 
     let ether_type_raw = u16::from_be_bytes([data[*offset + 12], data[*offset + 13]]);
-    let ether_type = EtherType::try_from(ether_type_raw).unwrap_or(EtherType::Reserved);
+    // EtherType::try_from expects the same encoding used by the enum repr (see mermin-common eth tests).
+    let ether_type = EtherType::try_from(ether_type_raw.to_be()).unwrap_or(EtherType::Reserved);
 
     *offset += 14;
     Ok((src_mac, dst_mac, ether_type))
@@ -297,7 +226,7 @@ fn parse_icmp_type_code(data: &[u8], offset: usize) -> Result<(u16, u16), ParseE
 }
 
 #[allow(clippy::too_many_arguments)]
-fn parse_vxlan(
+fn parse_vxlan_payload(
     data: &[u8],
     offset: &mut usize,
     outer_src_ip: IpAddr,
@@ -307,15 +236,13 @@ fn parse_vxlan(
     outer_src_mac: [u8; 6],
     outer_dst_mac: [u8; 6],
 ) -> Result<ParsedPacket, ParseError> {
-    *offset += 8; // skip UDP header
-
-    // VXLAN header (8 bytes): flags(1) + reserved(3) + VNI(3) + reserved(1)
-    if data.len() < *offset + 8 {
+    if data.len() < *offset + vxlan::VXLAN_LEN {
         return Err(ParseError::TooShort);
     }
 
-    let vni = u32::from_be_bytes([0, data[*offset + 4], data[*offset + 5], data[*offset + 6]]);
-    *offset += 8;
+    let vni_bytes: vxlan::Vni = [data[*offset + 4], data[*offset + 5], data[*offset + 6]];
+    let vni = vxlan::vni(vni_bytes);
+    *offset += vxlan::VXLAN_LEN;
 
     let (inner_src_mac, inner_dst_mac, inner_ether_type) = parse_ethernet(data, offset)?;
 
@@ -361,7 +288,7 @@ fn parse_vxlan(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn parse_geneve(
+fn parse_geneve_payload(
     data: &[u8],
     offset: &mut usize,
     outer_src_ip: IpAddr,
@@ -371,16 +298,18 @@ fn parse_geneve(
     outer_src_mac: [u8; 6],
     outer_dst_mac: [u8; 6],
 ) -> Result<ParsedPacket, ParseError> {
-    *offset += 8; // skip UDP header
-
-    // Geneve header (8+ bytes): ver/opt_len(1) + flags(1) + protocol(2) + VNI(3) + reserved(1)
-    if data.len() < *offset + 8 {
+    if data.len() <= *offset {
         return Err(ParseError::TooShort);
     }
 
-    let opt_len = (data[*offset] & 0x3F) as usize * 4; // options length in bytes
-    let vni = u32::from_be_bytes([0, data[*offset + 4], data[*offset + 5], data[*offset + 6]]);
-    *offset += 8 + opt_len;
+    let hdr_len = geneve::total_hdr_len(data[*offset]);
+    if data.len() < *offset + hdr_len {
+        return Err(ParseError::TooShort);
+    }
+
+    let vni_bytes: geneve::Vni = [data[*offset + 4], data[*offset + 5], data[*offset + 6]];
+    let vni = geneve::vni(vni_bytes);
+    *offset += hdr_len;
 
     let (inner_src_mac, inner_dst_mac, inner_ether_type) = parse_ethernet(data, offset)?;
 
@@ -423,4 +352,166 @@ fn parse_geneve(
             vni,
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use mermin_common::{FlowKey, IpVersion, ip::IpProto};
+
+    use super::*;
+
+    fn outer_flow_key(src_port: u16, dst_port: u16) -> FlowKey {
+        FlowKey {
+            src_ip: [10, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            dst_ip: [10, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            src_port,
+            dst_port,
+            ip_version: IpVersion::V4,
+            protocol: IpProto::Udp,
+        }
+    }
+
+    fn build_vxlan_icmp_payload(vni: u32) -> Vec<u8> {
+        let mut pkt = Vec::new();
+        // VXLAN header
+        pkt.extend_from_slice(&[0x08, 0x00, 0x00, 0x00]);
+        pkt.push(((vni >> 16) & 0xFF) as u8);
+        pkt.push(((vni >> 8) & 0xFF) as u8);
+        pkt.push((vni & 0xFF) as u8);
+        pkt.push(0x00);
+        // Inner Ethernet
+        pkt.extend_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]); // dst
+        pkt.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]); // src
+        pkt.extend_from_slice(&[0x08, 0x00]); // IPv4
+        // Inner IPv4: 10.244.1.1 -> 10.244.2.2, ICMP
+        pkt.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x40, 0x00, 0x40, 0x01, 0x00, 0x00, 0x0a, 0xf4,
+            0x01, 0x01, 0x0a, 0xf4, 0x02, 0x02,
+        ]);
+        // Inner ICMP echo request (type 8, code 0)
+        pkt.extend_from_slice(&[0x08, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        pkt
+    }
+
+    fn build_geneve_payload(vni: u32, opt_len_quads: u8) -> Vec<u8> {
+        let mut pkt = Vec::new();
+        pkt.push(opt_len_quads);
+        pkt.extend_from_slice(&[0x00, 0x08, 0x00]); // flags + IPv4 ethertype
+        pkt.push(((vni >> 16) & 0xFF) as u8);
+        pkt.push(((vni >> 8) & 0xFF) as u8);
+        pkt.push((vni & 0xFF) as u8);
+        pkt.push(0x00);
+        for i in 0..(opt_len_quads as usize * 4) {
+            pkt.push(i as u8);
+        }
+        // Inner Ethernet + IPv4 UDP
+        pkt.extend_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        pkt.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]);
+        pkt.extend_from_slice(&[0x08, 0x00]);
+        pkt.extend_from_slice(&[
+            0x45, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x40, 0x00, 0x40, 0x11, 0x00, 0x00, 0x0a, 0xf4,
+            0x01, 0x01, 0x0a, 0xf4, 0x02, 0x02,
+        ]);
+        pkt.extend_from_slice(&[0x30, 0x39, 0x00, 0x50, 0x00, 0x08, 0x00, 0x00]); // UDP 12345->80
+        pkt
+    }
+
+    #[test]
+    fn test_parse_vxlan_icmp_from_udp_payload() {
+        let payload = build_vxlan_icmp_payload(0x123456);
+        let flow_key = outer_flow_key(54321, 4789);
+        let parsed = parse_packet_from_offset(&payload, &flow_key, [0; 6], [0; 6], 4789, 6081)
+            .expect("parse vxlan");
+
+        match parsed {
+            ParsedPacket::Tunneled {
+                inner, tunnel_info, ..
+            } => {
+                assert_eq!(tunnel_info.tunnel_type, TunnelType::Vxlan);
+                assert_eq!(tunnel_info.vni, 0x123456);
+                assert_eq!(inner.src_ip, IpAddr::V4(Ipv4Addr::new(10, 244, 1, 1)));
+                assert_eq!(inner.dst_ip, IpAddr::V4(Ipv4Addr::new(10, 244, 2, 2)));
+                assert_eq!(inner.protocol, IpProto::Icmp);
+                assert_eq!(inner.src_port, (8 << 8) | 0);
+            }
+            ParsedPacket::Direct { .. } => panic!("expected tunneled packet"),
+        }
+    }
+
+    #[test]
+    fn test_parse_vxlan_non_default_port() {
+        let payload = build_vxlan_icmp_payload(42);
+        let flow_key = outer_flow_key(12345, 8472);
+        let parsed = parse_packet_from_offset(&payload, &flow_key, [0; 6], [0; 6], 8472, 6081)
+            .expect("parse flannel vxlan");
+
+        match parsed {
+            ParsedPacket::Tunneled { tunnel_info, .. } => {
+                assert_eq!(tunnel_info.tunnel_type, TunnelType::Vxlan);
+                assert_eq!(tunnel_info.vni, 42);
+            }
+            ParsedPacket::Direct { .. } => panic!("expected tunneled packet"),
+        }
+    }
+
+    #[test]
+    fn test_parse_geneve_default_options() {
+        let payload = build_geneve_payload(0x00ABCD, 0);
+        let flow_key = outer_flow_key(54321, 6081);
+        let parsed = parse_packet_from_offset(&payload, &flow_key, [0; 6], [0; 6], 4789, 6081)
+            .expect("parse geneve");
+
+        match parsed {
+            ParsedPacket::Tunneled {
+                inner, tunnel_info, ..
+            } => {
+                assert_eq!(tunnel_info.tunnel_type, TunnelType::Geneve);
+                assert_eq!(tunnel_info.vni, 0x00ABCD);
+                assert_eq!(inner.protocol, IpProto::Udp);
+                assert_eq!(inner.src_port, 12345);
+                assert_eq!(inner.dst_port, 80);
+            }
+            ParsedPacket::Direct { .. } => panic!("expected tunneled packet"),
+        }
+    }
+
+    #[test]
+    fn test_parse_geneve_with_options() {
+        let payload = build_geneve_payload(99, 1);
+        let flow_key = outer_flow_key(6081, 54321);
+        let parsed = parse_packet_from_offset(&payload, &flow_key, [0; 6], [0; 6], 4789, 6081)
+            .expect("parse geneve with options");
+
+        match parsed {
+            ParsedPacket::Tunneled { tunnel_info, .. } => {
+                assert_eq!(tunnel_info.tunnel_type, TunnelType::Geneve);
+                assert_eq!(tunnel_info.vni, 99);
+            }
+            ParsedPacket::Direct { .. } => panic!("expected tunneled packet"),
+        }
+    }
+
+    #[test]
+    fn test_parse_truncated_payload() {
+        let payload = vec![0x08, 0x00, 0x00, 0x00];
+        let flow_key = outer_flow_key(54321, 4789);
+        let err =
+            parse_packet_from_offset(&payload, &flow_key, [0; 6], [0; 6], 4789, 6081).unwrap_err();
+        assert_eq!(err, ParseError::TooShort);
+    }
+
+    #[test]
+    fn test_is_tunnel_port_match() {
+        let flow_key = outer_flow_key(8472, 54321);
+        assert!(is_tunnel(&flow_key, 8472, 6081, 51820));
+        let direct = FlowKey {
+            src_port: 12345,
+            dst_port: 80,
+            protocol: IpProto::Udp,
+            ..outer_flow_key(0, 0)
+        };
+        assert!(!is_tunnel(&direct, 4789, 6081, 51820));
+    }
 }

--- a/mermin/src/span/producer.rs
+++ b/mermin/src/span/producer.rs
@@ -10,7 +10,7 @@ use aya::maps::{HashMap as EbpfHashMap, RingBuf};
 use dashmap::DashMap;
 use fxhash::FxBuildHasher;
 use mermin_common::{
-    FlowEvent, FlowKey, FlowStats, ListeningPortKey, MapUnit,
+    FlowEvent, FlowKey, FlowStats, IpVersion, ListeningPortKey, MapUnit, TunnelType,
     eth::EtherType,
     ip::{IpDscp, IpEcn, IpProto},
     tcp::{TCP_FLAG_FIN, TCP_FLAG_RST},
@@ -27,7 +27,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     filter::source::PacketFilter,
-    ip::{Error, flow_key_to_ip_addrs},
+    ip::{Error, flow_key_from_inner_headers, flow_key_to_ip_addrs},
     metrics::{
         self,
         ebpf::{EbpfMapName, EbpfMapOperation, EbpfMapStatus, map_entry_not_found},
@@ -76,6 +76,30 @@ pub type FlowStore = Arc<DashMap<Arc<str>, FlowEntry, FxBuildHasher>>;
 /// Entry in the flow map containing the flow span.
 pub struct FlowEntry {
     pub flow_span: FlowSpan,
+}
+
+/// Outer tunnel transport metadata for encapsulated flows.
+struct OuterTunnel {
+    key: FlowKey,
+    tunnel_type: TunnelType,
+    vni: u32,
+}
+
+/// Returns the UDP payload copied into `FlowEvent.packet_data` for userspace tunnel parsing.
+fn tunnel_payload_from_event(event: &FlowEvent) -> &[u8] {
+    let offset = event.parsed_offset as usize;
+    let snaplen = event.snaplen as usize;
+    let len = if snaplen > offset {
+        snaplen - offset
+    } else {
+        event
+            .packet_data
+            .iter()
+            .rposition(|&b| b != 0)
+            .map(|i| i + 1)
+            .unwrap_or(0)
+    };
+    &event.packet_data[..len.min(event.packet_data.len())]
 }
 
 /// Shared components that need to be accessed by multiple tasks and the shutdown manager
@@ -707,20 +731,7 @@ impl FlowWorker {
             return self.create_direct_flow(event).await;
         }
 
-        // TODO: Skip tunneled flow processing for now - untested and needs refactoring
-        debug!(
-            event.name = "tunneled_flow.skipped",
-            worker.id = self.worker_id,
-            protocol = ?event.flow_key.protocol,
-            src_ip = ?event.flow_key.src_ip,
-            dst_ip = ?event.flow_key.dst_ip,
-            "skipping tunneled flow processing - not yet implemented"
-        );
-
-        self.remove_ebpf_map_entry(&self.flow_stats_map, &event.flow_key)
-            .await;
-
-        Ok(())
+        self.create_tunneled_flow(event).await
     }
 
     async fn remove_ebpf_map_entry(
@@ -799,7 +810,18 @@ impl FlowWorker {
             )
             .into();
 
-        self.create_flow_span(community_id, &event.flow_key, &stats)
+        if self
+            .flow_store
+            .get(&community_id)
+            .is_some_and(|e| e.flow_span.attributes.tunnel_type.is_some())
+        {
+            self.remove_ebpf_map_entry(&self.flow_stats_map, &event.flow_key)
+                .await;
+            guard.keep();
+            return Ok(());
+        }
+
+        self.create_flow_span(community_id, &event.flow_key, &stats, None)
             .await?;
 
         guard.keep();
@@ -840,32 +862,90 @@ impl FlowWorker {
 
     /// Slow path for tunneled traffic.
     /// Parses packet_data to extract innermost 5-tuple and tunnel metadata.
-    #[allow(dead_code)]
     async fn create_tunneled_flow(&self, event: FlowEvent) -> Result<(), Error> {
-        // Parse only the UNPARSED portion (inner headers for tunnels)
-        let unparsed_data = &event.packet_data[..];
-        let parsed = parse_packet_from_offset(unparsed_data, event.parsed_offset)
-            .map_err(|_| Error::UnknownIpAddrType)?;
+        let guard = EbpfFlowGuard::new(event.flow_key, Arc::clone(&self.flow_stats_map));
 
-        // Extract innermost 5-tuple for Community ID
-        match parsed {
-            ParsedPacket::Tunneled { inner, .. } => {
-                // TODO: Generate Community ID from innermost 5-tuple
-                // TODO: Map eBPF FlowKey → Community ID
-                // TODO: Create FlowSpan with tunnel metadata
+        let stats = self
+            .get_ebpf_map_entry(&self.flow_stats_map, &event.flow_key)
+            .await
+            .map_err(|_| Error::FlowNotFound)?;
 
-                warn!(
-                    event.name = "tunneled_flow.not_implemented",
+        if !self.should_process_flow(&event.flow_key, &stats) {
+            self.remove_ebpf_map_entry(&self.flow_stats_map, &event.flow_key)
+                .await;
+            guard.keep();
+            return Ok(());
+        }
+
+        let unparsed_data = tunnel_payload_from_event(&event);
+
+        let parsed = match parse_packet_from_offset(
+            unparsed_data,
+            &event.flow_key,
+            stats.src_mac,
+            [0; 6],
+            self.vxlan_port,
+            self.geneve_port,
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                debug!(
+                    event.name = "tunneled_flow.parse_failed",
                     worker.id = self.worker_id,
-                    inner.src_ip = %inner.src_ip,
-                    inner.dst_ip = %inner.dst_ip,
-                    "tunneled flow processing not yet fully implemented"
+                    payload.len = unparsed_data.len(),
+                    error.message = %e,
+                    "failed to parse tunneled flow payload"
                 );
+                self.remove_ebpf_map_entry(&self.flow_stats_map, &event.flow_key)
+                    .await;
+                guard.keep();
+                return Ok(());
             }
-            ParsedPacket::Direct { .. } => {
-                // This shouldn't happen - we already checked is_likely_tunnel
-                warn!("expected tunneled packet but got plain, treating as error");
-            }
+        };
+
+        let ParsedPacket::Tunneled {
+            inner, tunnel_info, ..
+        } = parsed
+        else {
+            debug!(
+                event.name = "tunneled_flow.unexpected_direct",
+                worker.id = self.worker_id,
+                "expected tunneled packet but parser returned direct"
+            );
+            self.remove_ebpf_map_entry(&self.flow_stats_map, &event.flow_key)
+                .await;
+            guard.keep();
+            return Ok(());
+        };
+
+        let inner_key = flow_key_from_inner_headers(&inner);
+        let (src_addr, dst_addr) = flow_key_to_ip_addrs(&inner_key)?;
+        let community_id: Arc<str> = self
+            .community_id_generator
+            .generate(
+                src_addr,
+                dst_addr,
+                inner_key.src_port,
+                inner_key.dst_port,
+                inner_key.protocol,
+            )
+            .into();
+
+        let outer_tunnel = Some(OuterTunnel {
+            key: event.flow_key,
+            tunnel_type: tunnel_info.tunnel_type,
+            vni: tunnel_info.vni,
+        });
+
+        self.create_flow_span(community_id, &inner_key, &stats, outer_tunnel)
+            .await?;
+
+        guard.keep();
+
+        if metrics::registry::debug_enabled() {
+            metrics::registry::FLOW_SPANS_PROCESSED_TOTAL
+                .with_label_values(&[&self.worker_id.to_string()])
+                .inc();
         }
 
         Ok(())
@@ -897,12 +977,17 @@ impl FlowWorker {
         community_id: Arc<str>,
         flow_key: &FlowKey,
         stats: &FlowStats,
+        outer_tunnel: Option<OuterTunnel>,
     ) -> Result<(), Error> {
-        let is_ip_flow = stats.ether_type == EtherType::Ipv4 || stats.ether_type == EtherType::Ipv6;
-        let is_ipv6 = stats.ether_type == EtherType::Ipv6;
-        let is_tcp = stats.protocol == IpProto::Tcp;
-        let is_icmp = stats.protocol == IpProto::Icmp;
-        let is_icmpv6 = stats.protocol == IpProto::Ipv6Icmp;
+        // flow_key carries the application 5-tuple (inner headers when tunneled).
+        // stats.protocol is the eBPF-tracked outer transport (UDP for VXLAN/Geneve).
+        let transport = flow_key.protocol;
+        let is_ip_flow =
+            flow_key.ip_version == IpVersion::V4 || flow_key.ip_version == IpVersion::V6;
+        let is_ipv6 = flow_key.ip_version == IpVersion::V6;
+        let is_tcp = transport == IpProto::Tcp;
+        let is_icmp = transport == IpProto::Icmp;
+        let is_icmpv6 = transport == IpProto::Ipv6Icmp;
         let start_time_nanos = stats.first_seen_ns + self.boot_time_offset_nanos;
         let end_time_nanos = stats.last_seen_ns + self.boot_time_offset_nanos;
         let iface_name: Option<Arc<str>> = self
@@ -911,10 +996,32 @@ impl FlowWorker {
             .get(&stats.ifindex)
             .map(|s| Arc::from(s.as_str()));
         let (src_addr, dst_addr) = flow_key_to_ip_addrs(flow_key)?;
-        let timeout = self.calculate_timeout(stats);
+        let (icmp_type, icmp_code) = if outer_tunnel.is_some() && (is_icmp || is_icmpv6) {
+            (
+                (flow_key.src_port >> 8) as u8,
+                (flow_key.src_port & 0xff) as u8,
+            )
+        } else {
+            (stats.icmp_type, stats.icmp_code)
+        };
+        let (reverse_icmp_type, reverse_icmp_code) = if outer_tunnel.is_some() {
+            (0, 0)
+        } else {
+            (stats.reverse_icmp_type, stats.reverse_icmp_code)
+        };
+
+        let outer_tunnel_addrs = match &outer_tunnel {
+            Some(tunnel) => Some(flow_key_to_ip_addrs(&tunnel.key)?),
+            None => None,
+        };
+        let infer_key = outer_tunnel
+            .as_ref()
+            .map(|tunnel| tunnel.key)
+            .unwrap_or(*flow_key);
+        let timeout = self.calculate_timeout(stats, transport);
         let span_kind = self
             .direction_inferrer
-            .infer_from_stats(flow_key, stats)
+            .infer_from_stats(&infer_key, stats)
             .await;
         let is_server = span_kind == SpanKind::Server;
         let is_client = span_kind == SpanKind::Client;
@@ -1015,29 +1122,18 @@ impl FlowWorker {
                     Arc::from(lossy.trim_end_matches('\0'))
                 }),
 
-                flow_icmp_type_id: (is_icmp || is_icmpv6).then_some(stats.icmp_type),
-                flow_icmp_type_name: icmp_type_name(is_icmp, is_icmpv6, stats.icmp_type),
-                flow_icmp_code_id: (is_icmp || is_icmpv6).then_some(stats.icmp_code),
-                flow_icmp_code_name: icmp_code_name(
-                    is_icmp,
-                    is_icmpv6,
-                    stats.icmp_type,
-                    stats.icmp_code,
-                ),
-                flow_reverse_icmp_type_id: (is_icmp || is_icmpv6)
-                    .then_some(stats.reverse_icmp_type),
-                flow_reverse_icmp_type_name: icmp_type_name(
-                    is_icmp,
-                    is_icmpv6,
-                    stats.reverse_icmp_type,
-                ),
-                flow_reverse_icmp_code_id: (is_icmp || is_icmpv6)
-                    .then_some(stats.reverse_icmp_code),
+                flow_icmp_type_id: (is_icmp || is_icmpv6).then_some(icmp_type),
+                flow_icmp_type_name: icmp_type_name(is_icmp, is_icmpv6, icmp_type),
+                flow_icmp_code_id: (is_icmp || is_icmpv6).then_some(icmp_code),
+                flow_icmp_code_name: icmp_code_name(is_icmp, is_icmpv6, icmp_type, icmp_code),
+                flow_reverse_icmp_type_id: (is_icmp || is_icmpv6).then_some(reverse_icmp_type),
+                flow_reverse_icmp_type_name: icmp_type_name(is_icmp, is_icmpv6, reverse_icmp_type),
+                flow_reverse_icmp_code_id: (is_icmp || is_icmpv6).then_some(reverse_icmp_code),
                 flow_reverse_icmp_code_name: icmp_code_name(
                     is_icmp,
                     is_icmpv6,
-                    stats.reverse_icmp_type,
-                    stats.reverse_icmp_code,
+                    reverse_icmp_type,
+                    reverse_icmp_code,
                 ),
 
                 flow_bytes_delta: 0,
@@ -1049,9 +1145,30 @@ impl FlowWorker {
                 flow_reverse_packets_delta: 0,
                 flow_reverse_packets_total: 0,
 
+                tunnel_type: outer_tunnel.as_ref().map(|t| t.tunnel_type),
+                tunnel_id: outer_tunnel.as_ref().map(|t| t.vni),
+                tunnel_network_type: outer_tunnel.as_ref().map(|_| stats.ether_type),
+                tunnel_network_transport: outer_tunnel.as_ref().map(|_| IpProto::Udp),
+                tunnel_source_address: outer_tunnel_addrs
+                    .as_ref()
+                    .map(|(src, _)| Arc::from(src.to_string())),
+                tunnel_destination_address: outer_tunnel_addrs
+                    .as_ref()
+                    .map(|(_, dst)| Arc::from(dst.to_string())),
+                tunnel_source_port: outer_tunnel.as_ref().map(|t| t.key.src_port),
+                tunnel_destination_port: outer_tunnel.as_ref().map(|t| t.key.dst_port),
+                tunnel_network_interface_mac: outer_tunnel
+                    .as_ref()
+                    .map(|_| Arc::from(MacAddr::from(stats.src_mac).to_string())),
+
                 ..Default::default()
             }),
-            flow_key: Some(*flow_key),
+            flow_key: Some(
+                outer_tunnel
+                    .as_ref()
+                    .map(|tunnel| tunnel.key)
+                    .unwrap_or(*flow_key),
+            ),
             last_recorded_packets: 0,
             last_recorded_bytes: 0,
             last_recorded_reverse_packets: 0,
@@ -1112,9 +1229,9 @@ impl FlowWorker {
         Ok(())
     }
 
-    /// Calculate timeout duration based on protocol and flow stats
-    fn calculate_timeout(&self, stats: &FlowStats) -> Duration {
-        match stats.protocol {
+    /// Calculate timeout duration based on application protocol and flow stats.
+    fn calculate_timeout(&self, stats: &FlowStats, transport: IpProto) -> Duration {
+        match transport {
             IpProto::Icmp | IpProto::Ipv6Icmp => self.icmp_timeout,
             IpProto::Tcp => {
                 if stats.tcp_flags & TCP_FLAG_FIN != 0 {
@@ -2401,7 +2518,7 @@ mod tests {
         let worker = create_test_worker_for_timeout();
         let stats = create_test_stats(IpProto::Icmp);
 
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.icmp_timeout);
 
         // Prevent drop to avoid IO Safety violation from zeroed eBPF map
@@ -2413,7 +2530,7 @@ mod tests {
         let worker = create_test_worker_for_timeout();
         let stats = create_test_stats(IpProto::Ipv6Icmp);
 
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.icmp_timeout);
 
         std::mem::forget(worker);
@@ -2426,7 +2543,7 @@ mod tests {
         stats.tcp_flags = 0x10; // ACK only
         stats.forward_tcp_flags = 0x10;
 
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.tcp_timeout);
 
         std::mem::forget(worker);
@@ -2439,7 +2556,7 @@ mod tests {
         stats.tcp_flags = TCP_FLAG_FIN;
         stats.forward_tcp_flags = TCP_FLAG_FIN;
 
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.tcp_fin_timeout);
 
         std::mem::forget(worker);
@@ -2452,7 +2569,7 @@ mod tests {
         stats.tcp_flags = TCP_FLAG_RST;
         stats.forward_tcp_flags = TCP_FLAG_RST;
 
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.tcp_rst_timeout);
 
         std::mem::forget(worker);
@@ -2462,7 +2579,7 @@ mod tests {
     fn test_calculate_timeout_udp() {
         let worker = create_test_worker_for_timeout();
         let stats = create_test_stats(IpProto::Udp);
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.udp_timeout);
 
         std::mem::forget(worker);
@@ -2472,10 +2589,39 @@ mod tests {
     fn test_calculate_timeout_generic() {
         let worker = create_test_worker_for_timeout();
         let stats = create_test_stats(IpProto::Gre);
-        let timeout = worker.calculate_timeout(&stats);
+        let timeout = worker.calculate_timeout(&stats, stats.protocol);
         assert_eq!(timeout, worker.generic_timeout);
 
         std::mem::forget(worker);
+    }
+
+    #[test]
+    fn test_calculate_timeout_uses_application_protocol_for_tunneled_flows() {
+        let worker = create_test_worker_for_timeout();
+        let stats = create_test_stats(IpProto::Udp);
+        let timeout = worker.calculate_timeout(&stats, IpProto::Icmp);
+        assert_eq!(timeout, worker.icmp_timeout);
+
+        std::mem::forget(worker);
+    }
+
+    #[test]
+    fn test_tunneled_span_uses_outer_ebpf_key() {
+        let inner = FlowKey {
+            src_port: (8 << 8) | 0,
+            dst_port: 0,
+            protocol: IpProto::Icmp,
+            ..FlowKey::default()
+        };
+        let outer = FlowKey {
+            src_port: 40000,
+            dst_port: 8472,
+            protocol: IpProto::Udp,
+            ..FlowKey::default()
+        };
+        let ebpf_key = Some(outer).unwrap_or(inner);
+        assert_eq!(ebpf_key.protocol, IpProto::Udp);
+        assert_eq!(ebpf_key.dst_port, 8472);
     }
 
     #[test]
@@ -3064,4 +3210,18 @@ mod tests {
             "future last_seen must not be classified as stale"
         );
     }
+}
+
+#[cfg(test)]
+#[test]
+fn tunnel_payload_uses_snaplen_when_available() {
+    let mut event = FlowEvent {
+        flow_key: FlowKey::default(),
+        snaplen: 20,
+        parsed_offset: 8,
+        packet_data: [0; 192],
+    };
+    event.packet_data[..12].copy_from_slice(&[0x08; 12]);
+    let payload = tunnel_payload_from_event(&event);
+    assert_eq!(payload.len(), 12);
 }

--- a/mermin/tests/e2e/common/setup.sh
+++ b/mermin/tests/e2e/common/setup.sh
@@ -39,7 +39,11 @@ install_cilium() {
     sudo tar -C /usr/local/bin -xzvf "cilium-${OS}-${ARCH}.tar.gz"
     rm "cilium-${OS}-${ARCH}.tar.gz"{,.sha256sum}
   fi
-  cilium install --wait
+  cilium install --wait \
+    --set image.pullPolicy=IfNotPresent \
+    --set ipam.mode=kubernetes
+  kubectl rollout status daemonset/cilium -n kube-system --timeout=5m
+  kubectl rollout status daemonset/cilium-envoy -n kube-system --timeout=5m
 }
 
 


### PR DESCRIPTION
This pr adds the ability for mermin to parse VXLAN and Geneve encapsulated traffic. Mermin should now be able to  export spans with the inner flow plus tunnel metadata.

## Changes

- Parse tunnel UDP payload from eBPF (VXLAN/Geneve header + inner frame) on new flows only
- Use the inner 5-tuple for flow addresses and community ID
- Populate `tunnel.*` span attributes from the outer encapsulation. Reference used: https://docs.mermin.dev/getting-started/attribute-reference#tunnel-and-ip-in-ip-and-ipsec-attributes
- Derive ICMP fields, flow timeouts, and direction from inner headers when tunneled
- Fix Ethernet EtherType parsing for inner frames
- Fix Cilium Kind install (`pullPolicy`, `ipam.mode`, rollout waits) in e2e setup

## Testing

- `cargo nextest run -r --workspace --exclude mermin-ebpf` (parser unit tests, Linux CI job)
- `CNI=<calico|cilium|flannel|kindnetd> DOCKER_IMAGE_TAG=<tag> bash ./mermin/tests/e2e/cni/test.sh`

## Proof it works

Parser unit tests (6 passed, Linux Docker):

- VXLAN ICMP inner frame
- VXLAN on non-default port (8472)
- Geneve default and with options
- Truncated payload error handling
- Tunnel port detection

CNI e2e (all passed locally with `mermin:vxlan-verify`):

- calico
- cilium
- flannel
- kindnetd

Each e2e run deploys mermin on Kind, generates cross-pod ICMP, and checks agent logs for Kubernetes pod enrichment.